### PR TITLE
NAS-2640 fix PG docker image for gooddata-fdw

### DIFF
--- a/gooddata-fdw/Dockerfile
+++ b/gooddata-fdw/Dockerfile
@@ -28,11 +28,13 @@ RUN apk add --no-cache --update wget make musl-dev llvm11 gcc clang python3 pyth
 #
 ADD gooddata-afm-client /gd/gooddata-afm-client
 ADD gooddata-metadata-client /gd/gooddata-metadata-client
+ADD gooddata-scan-client /gd/gooddata-scan-client
 ADD gooddata-sdk /gd/gooddata-sdk
 ADD gooddata-fdw /gd/gooddata-fdw
 
 RUN cd /gd/gooddata-afm-client && python3 setup.py install \
      && cd /gd/gooddata-metadata-client && python3 setup.py install \
+     && cd /gd/gooddata-scan-client && python3 setup.py install \
      && cd /gd/gooddata-sdk && python3 setup.py install \
      && cd /gd/gooddata-fdw && python3 setup.py install \
      && echo "CREATE EXTENSION multicorn; CREATE EXTENSION foreign_table_exposer; " > /docker-entrypoint-initdb.d/create_extensions.sql

--- a/gooddata-fdw/setup.py
+++ b/gooddata-fdw/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-REQUIRES = ["gooddata-sdk==0.1"]
+REQUIRES = ["gooddata-sdk==0.2"]
 
 
 def _read_version():

--- a/gooddata-fdw/tox.ini
+++ b/gooddata-fdw/tox.ini
@@ -6,6 +6,7 @@ deps =
     -r{toxinidir}/test-requirements.txt
     ../gooddata-metadata-client
     ../gooddata-afm-client
+    ../gooddata-scan-client
     ../gooddata-sdk
 
 commands =

--- a/gooddata-pandas/setup.py
+++ b/gooddata-pandas/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-REQUIRES = ["gooddata-sdk==0.1", "pandas"]
+REQUIRES = ["gooddata-sdk==0.2", "pandas"]
 
 
 def _read_version():

--- a/gooddata-pandas/tox.ini
+++ b/gooddata-pandas/tox.ini
@@ -6,6 +6,7 @@ deps =
     -r{toxinidir}/test-requirements.txt
     ../gooddata-metadata-client
     ../gooddata-afm-client
+    ../gooddata-scan-client
     ../gooddata-sdk
 
 commands =


### PR DESCRIPTION
PG docker image build was broken by introduction of gooddata-scan-client
project. The project is not installable from PyPI now. It has to be
installed explicitly.