### PR TITLE
NAS-2723: FDW - enclose object names in import_gooddata procedure

### DIFF
--- a/gooddata-fdw/sql/import_gooddata.sql
+++ b/gooddata-fdw/sql/import_gooddata.sql
@@ -21,15 +21,15 @@ DECLARE
   server VARCHAR := 'multicorn_gooddata';
 BEGIN
   -- Recreate schema, where foreign tables will be imported
-  sql_statement := format('DROP SCHEMA IF EXISTS %s', foreign_schema);
+  sql_statement := format('DROP SCHEMA IF EXISTS "%s"', foreign_schema);
   CALL execute_sql(sql_statement, debug);
 
-  sql_statement := format('CREATE SCHEMA %s', foreign_schema);
+  sql_statement := format('CREATE SCHEMA "%s"', foreign_schema);
   CALL execute_sql(sql_statement, debug);
 
   -- Import GoodData objects as foreign tables into the schema created above
   sql_statement := format(
-    'IMPORT FOREIGN SCHEMA %s FROM SERVER %s INTO %s OPTIONS (object_type ''%s'')',
+    'IMPORT FOREIGN SCHEMA "%s" FROM SERVER "%s" INTO "%s" OPTIONS (object_type ''%s'')',
     workspace, server, foreign_schema, object_type
   );
   CALL execute_sql(sql_statement, debug);


### PR DESCRIPTION
Enable importing workspaces into schemata with names, which must be enclosed in SQL