### PR TITLE
Fix dev bootstrap and extend documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,8 @@
     git clone git@github.com:gooddata/gooddata-python-sdk.git
     cd gooddata-python-sdk
     make dev
+    # activate venv
+    source .venv/bin/activate
     ```
 
    The `make dev` command will create a new Python 3.9 virtual environment in the `.venv` directory, install all

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,7 +4,6 @@ pre-commit~=2.14.0
 
 -r ./fmt-requirements.txt
 -r ./lint-requirements.txt
--r ./docs-requirements.txt
 
 -r ./gooddata-afm-client/requirements.txt
 -r ./gooddata-metadata-client/requirements.txt


### PR DESCRIPTION
- Development bootstrap requirements contained invalid reference.
- Added how to activate virtualenv to getting started section of docs