### PR TITLE
NAS3355 - CatalogDataSourceService extension 

### DIFF
--- a/gooddata-sdk/gooddata_sdk/__init__.py
+++ b/gooddata-sdk/gooddata_sdk/__init__.py
@@ -5,6 +5,7 @@ At the moment the SDK provides services to inspect and interact with the Semanti
 """
 
 from gooddata_sdk._version import __version__
+from gooddata_sdk.catalog.data_source.action_requests.ldm_request import CatalogGenerateLdmRequest
 from gooddata_sdk.catalog.data_source.model.content_objects.table import CatalogDataSourceTable
 from gooddata_sdk.catalog.data_source.model.data_source import (
     BigQueryAttributes,

--- a/gooddata-sdk/gooddata_sdk/catalog/data_source/action_requests/__init__.py
+++ b/gooddata-sdk/gooddata_sdk/catalog/data_source/action_requests/__init__.py
@@ -1,0 +1,1 @@
+# (C) 2022 GoodData Corporation

--- a/gooddata-sdk/gooddata_sdk/catalog/data_source/action_requests/ldm_request.py
+++ b/gooddata-sdk/gooddata_sdk/catalog/data_source/action_requests/ldm_request.py
@@ -1,0 +1,66 @@
+# (C) 2022 GoodData Corporation
+from __future__ import annotations
+
+from typing import Any
+
+from gooddata_metadata_client.model.generate_ldm_request import GenerateLdmRequest
+
+
+class CatalogGenerateLdmRequest:
+    def __init__(
+        self,
+        separator: str,
+        generate_long_ids: bool = None,
+        table_prefix: str = None,
+        view_prefix: str = None,
+        primary_label_prefix: str = None,
+        secondary_label_prefix: str = None,
+        fact_prefix: str = None,
+        date_granularities: str = None,
+        grain_prefix: str = None,
+        reference_prefix: str = None,
+        grain_reference_prefix: str = None,
+        denorm_prefix: str = None,
+        wdf_prefix: str = None,
+    ):
+        self.separator = separator
+        self.generate_long_ids = generate_long_ids
+        self.table_prefix = table_prefix
+        self.view_prefix = view_prefix
+        self.primary_label_prefix = primary_label_prefix
+        self.secondary_label_prefix = secondary_label_prefix
+        self.fact_prefix = fact_prefix
+        self.date_granularities = date_granularities
+        self.grain_prefix = grain_prefix
+        self.reference_prefix = reference_prefix
+        self.grain_reference_prefix = grain_reference_prefix
+        self.denorm_prefix = denorm_prefix
+        self.wdf_prefix = wdf_prefix
+
+    def to_api(self) -> GenerateLdmRequest:
+        kwargs: dict[str, Any] = dict()
+        if self.generate_long_ids:
+            kwargs["generate_long_ids"] = self.generate_long_ids
+        if self.table_prefix:
+            kwargs["table_prefix"] = self.table_prefix
+        if self.view_prefix:
+            kwargs["view_prefix"] = self.view_prefix
+        if self.primary_label_prefix:
+            kwargs["primary_label_prefix"] = self.primary_label_prefix
+        if self.secondary_label_prefix:
+            kwargs["secondary_label_prefix"] = self.secondary_label_prefix
+        if self.fact_prefix:
+            kwargs["fact_prefix"] = self.fact_prefix
+        if self.date_granularities:
+            kwargs["date_granularities"] = self.date_granularities
+        if self.grain_prefix:
+            kwargs["grain_prefix"] = self.grain_prefix
+        if self.reference_prefix:
+            kwargs["reference_prefix"] = self.reference_prefix
+        if self.grain_reference_prefix:
+            kwargs["grain_reference_prefix"] = self.grain_reference_prefix
+        if self.denorm_prefix:
+            kwargs["denorm_prefix"] = self.denorm_prefix
+        if self.wdf_prefix:
+            kwargs["wdf_prefix"] = self.wdf_prefix
+        return GenerateLdmRequest(self.separator, **kwargs)

--- a/gooddata-sdk/gooddata_sdk/catalog/data_source/service.py
+++ b/gooddata-sdk/gooddata_sdk/catalog/data_source/service.py
@@ -6,8 +6,10 @@ from typing import List
 
 import gooddata_metadata_client.apis as metadata_apis
 from gooddata_metadata_client.exceptions import NotFoundException
+from gooddata_sdk.catalog.data_source.action_requests.ldm_request import CatalogGenerateLdmRequest
 from gooddata_sdk.catalog.data_source.model.content_objects.table import CatalogDataSourceTable
 from gooddata_sdk.catalog.data_source.model.data_source import CatalogDataSource
+from gooddata_sdk.catalog.workspace.declarative_model.workspace.logical_model.ldm import CatalogDeclarativeModel
 from gooddata_sdk.client import GoodDataApiClient
 from gooddata_sdk.utils import load_all_entities
 
@@ -16,6 +18,7 @@ class CatalogDataSourceService:
     def __init__(self, api_client: GoodDataApiClient) -> None:
         self._client = api_client
         self._entities_api = metadata_apis.EntitiesApi(api_client.metadata_client)
+        self._actions_api = metadata_apis.ActionsApi(api_client.metadata_client)
 
     def list_data_sources(self) -> List[CatalogDataSource]:
         get_data_sources = functools.partial(
@@ -62,3 +65,13 @@ class CatalogDataSourceService:
         self._entities_api.patch_entity_data_sources(
             data_source_id, CatalogDataSource.to_api_patch(data_source_id, attributes)
         )
+
+    def generate_logical_model(
+        self, data_source_id: str, generate_ldm_request: CatalogGenerateLdmRequest
+    ) -> CatalogDeclarativeModel:
+        return CatalogDeclarativeModel.from_api(
+            self._actions_api.generate_logical_model(data_source_id, generate_ldm_request.to_api())
+        )
+
+    def register_upload_notification(self, data_source_id: str) -> None:
+        self._actions_api.register_upload_notification(data_source_id)

--- a/gooddata-sdk/gooddata_sdk/catalog/workspace/service.py
+++ b/gooddata-sdk/gooddata_sdk/catalog/workspace/service.py
@@ -142,38 +142,6 @@ class CatalogWorkspaceService:
             )
         )
 
-    def get_declarative_ldm(self, workspace_id: str) -> CatalogDeclarativeModel:
-        return CatalogDeclarativeModel.from_api(self._layout_api.get_logical_model(workspace_id))
-
-    def store_declarative_ldm(self, workspace_id: str, path: Path) -> None:
-        declarative_ldm = self._layout_api.get_logical_model(workspace_id)
-        with open(path / f"declarative_ldm_{workspace_id}.yaml", "w+") as fp:
-            yaml.safe_dump(declarative_ldm.to_dict(), fp, indent=2, sort_keys=True)
-
-    def load_and_put_declarative_ldm(self, workspace_id: str, path: Path) -> None:
-        with open(path / f"declarative_ldm_{workspace_id}.yaml", "r") as f:
-            declarative_ldm = CatalogDeclarativeModel.from_api(yaml.safe_load(f))
-        self.put_declarative_ldm(workspace_id, declarative_ldm)
-
-    def put_declarative_ldm(self, workspace_id: str, ldm: CatalogDeclarativeModel) -> None:
-        self._layout_api.set_logical_model(workspace_id, ldm.to_api())
-
-    def get_declarative_analytics_model(self, workspace_id: str) -> CatalogDeclarativeAnalytics:
-        return CatalogDeclarativeAnalytics.from_api(self._layout_api.get_analytics_model(workspace_id))
-
-    def put_declarative_analytics_model(self, workspace_id: str, analytics_model: CatalogDeclarativeAnalytics) -> None:
-        self._layout_api.set_analytics_model(workspace_id, analytics_model.to_api())
-
-    def store_declarative_analytics_model(self, workspace_id: str, path: Path) -> None:
-        declarative_analytics_model = self._layout_api.get_analytics_model(workspace_id)
-        with open(path / f"declarative_analytics_model_{workspace_id}.yaml", "w+") as fp:
-            yaml.safe_dump(declarative_analytics_model.to_dict(), fp, indent=2, sort_keys=True)
-
-    def load_and_put_declarative_analytics_model(self, workspace_id: str, path: Path) -> None:
-        with open(path / f"declarative_analytics_model_{workspace_id}.yaml", "r") as f:
-            declarative_analytics_model = CatalogDeclarativeAnalytics.from_api(yaml.safe_load(f))
-        self.put_declarative_analytics_model(workspace_id, declarative_analytics_model)
-
 
 class CatalogWorkspaceContentService:
     # Note on the disabled checking:
@@ -186,6 +154,7 @@ class CatalogWorkspaceContentService:
         self._client = api_client
         self._entities_api = metadata_apis.EntitiesApi(api_client.metadata_client)
         self._afm_actions_api = afm_apis.ActionsApi(api_client.afm_client)
+        self._layout_api = metadata_apis.LayoutApi(api_client.metadata_client)
 
     def get_attributes_catalog(self, workspace_id: str) -> list[CatalogAttribute]:
         get_attributes = functools.partial(
@@ -314,3 +283,35 @@ class CatalogWorkspaceContentService:
             items_of_type.add(available["id"])
 
         return by_type
+
+    def get_declarative_ldm(self, workspace_id: str) -> CatalogDeclarativeModel:
+        return CatalogDeclarativeModel.from_api(self._layout_api.get_logical_model(workspace_id))
+
+    def store_declarative_ldm(self, workspace_id: str, path: Path) -> None:
+        declarative_ldm = self._layout_api.get_logical_model(workspace_id)
+        with open(path / f"declarative_ldm_{workspace_id}.yaml", "w+") as fp:
+            yaml.safe_dump(declarative_ldm.to_dict(), fp, indent=2, sort_keys=True)
+
+    def load_and_put_declarative_ldm(self, workspace_id: str, path: Path) -> None:
+        with open(path / f"declarative_ldm_{workspace_id}.yaml", "r") as f:
+            declarative_ldm = CatalogDeclarativeModel.from_api(yaml.safe_load(f))
+        self.put_declarative_ldm(workspace_id, declarative_ldm)
+
+    def put_declarative_ldm(self, workspace_id: str, ldm: CatalogDeclarativeModel) -> None:
+        self._layout_api.set_logical_model(workspace_id, ldm.to_api())
+
+    def get_declarative_analytics_model(self, workspace_id: str) -> CatalogDeclarativeAnalytics:
+        return CatalogDeclarativeAnalytics.from_api(self._layout_api.get_analytics_model(workspace_id))
+
+    def put_declarative_analytics_model(self, workspace_id: str, analytics_model: CatalogDeclarativeAnalytics) -> None:
+        self._layout_api.set_analytics_model(workspace_id, analytics_model.to_api())
+
+    def store_declarative_analytics_model(self, workspace_id: str, path: Path) -> None:
+        declarative_analytics_model = self._layout_api.get_analytics_model(workspace_id)
+        with open(path / f"declarative_analytics_model_{workspace_id}.yaml", "w+") as fp:
+            yaml.safe_dump(declarative_analytics_model.to_dict(), fp, indent=2, sort_keys=True)
+
+    def load_and_put_declarative_analytics_model(self, workspace_id: str, path: Path) -> None:
+        with open(path / f"declarative_analytics_model_{workspace_id}.yaml", "r") as f:
+            declarative_analytics_model = CatalogDeclarativeAnalytics.from_api(yaml.safe_load(f))
+        self.put_declarative_analytics_model(workspace_id, declarative_analytics_model)

--- a/gooddata-sdk/tests/catalog/fixtures/data_sources/demo_generate_logical_model.json
+++ b/gooddata-sdk/tests/catalog/fixtures/data_sources/demo_generate_logical_model.json
@@ -1,0 +1,184 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "http://localhost:3000/api/layout/workspaces/demo/logicalModel",
+                "body": null,
+                "headers": {
+                    "Accept": [
+                        "application/json"
+                    ],
+                    "X-Requested-With": [
+                        "XMLHttpRequest"
+                    ],
+                    "X-GDC-VALIDATE-RELATIONS": [
+                        "true"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": ""
+                },
+                "headers": {
+                    "X-XSS-Protection": [
+                        "1; mode=block"
+                    ],
+                    "Expires": [
+                        "0"
+                    ],
+                    "Content-Security-Policy": [
+                        "default-src 'self' *.wistia.com *.wistia.net; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.wistia.com *.wistia.net src.litix.io matomo.anywhere.gooddata.com code.jquery.com unpkg.com cdn.jsdelivr.net cdnjs.cloudflare.com; img-src 'self' data: blob: *.wistia.com *.wistia.net embedwistia-a.akamaihd.net www.gooddata.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com cdn.jsdelivr.net; font-src 'self' data: fonts.gstatic.com *.alicdn.com *.wistia.com cdn.jsdelivr.net info.gooddata.com; frame-src 'self'; object-src 'none'; worker-src 'self' blob:; child-src blob:; connect-src 'self' *.tiles.mapbox.com *.mapbox.com *.litix.io *.wistia.com embedwistia-a.akamaihd.net matomo.anywhere.gooddata.com; media-src 'self' blob: data: *.wistia.com *.wistia.net embedwistia-a.akamaihd.net"
+                    ],
+                    "X-Content-Type-Options": [
+                        "nosniff"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "Vary": [
+                        "Origin",
+                        "Access-Control-Request-Method",
+                        "Access-Control-Request-Headers"
+                    ],
+                    "X-GDC-TRACE-ID": [
+                        "64bc57f076d10834"
+                    ],
+                    "Access-Control-Allow-Credentials": [
+                        "true"
+                    ],
+                    "Pragma": [
+                        "no-cache"
+                    ],
+                    "Date": [
+                        "Fri, 18 Mar 2022 10:47:28 GMT"
+                    ],
+                    "Server": [
+                        "nginx"
+                    ],
+                    "Cache-Control": [
+                        "no-cache, no-store, max-age=0, must-revalidate"
+                    ],
+                    "Set-Cookie": [
+                        "SPRING_SEC_SECURITY_CONTEXT=; Max-Age=0; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; HttpOnly"
+                    ],
+                    "Permission-Policy": [
+                        "geolocation 'none'; midi 'none'; sync-xhr 'none'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none'; fullscreen 'none'; payment 'none';"
+                    ],
+                    "Content-Type": [
+                        "application/json"
+                    ],
+                    "GoodData-Deployment": [
+                        "aio"
+                    ],
+                    "X-Frame-Options": [
+                        "DENY"
+                    ],
+                    "Access-Control-Expose-Headers": [
+                        "Content-Disposition, Content-Length, Content-Range, Set-Cookie"
+                    ],
+                    "Transfer-Encoding": [
+                        "chunked"
+                    ]
+                },
+                "body": {
+                    "string": "{\"ldm\":{\"datasets\":[{\"attributes\":[{\"description\":\"Campaign channel id\",\"id\":\"campaign_channels.campaign_channel_id\",\"labels\":[{\"description\":\"Campaign channel id\",\"id\":\"campaign_channels.campaign_channel_id\",\"primary\":true,\"sourceColumn\":\"campaign_channel_id\",\"tags\":[\"Campaign channels\"],\"title\":\"Campaign channel id\"}],\"tags\":[\"Campaign channels\"],\"title\":\"Campaign channel id\"},{\"description\":\"Category\",\"id\":\"campaign_channels.category\",\"labels\":[{\"description\":\"Category\",\"id\":\"campaign_channels.category\",\"primary\":true,\"sourceColumn\":\"category\",\"tags\":[\"Campaign channels\"],\"title\":\"Category\"}],\"tags\":[\"Campaign channels\"],\"title\":\"Category\"},{\"description\":\"Type\",\"id\":\"campaign_channels.type\",\"labels\":[{\"description\":\"Type\",\"id\":\"campaign_channels.type\",\"primary\":true,\"sourceColumn\":\"type\",\"tags\":[\"Campaign channels\"],\"title\":\"Type\"}],\"tags\":[\"Campaign channels\"],\"title\":\"Type\"}],\"dataSourceTableId\":{\"dataSourceId\":\"demo-test-ds\",\"id\":\"campaign_channels\",\"type\":\"dataSource\"},\"description\":\"Campaign channels\",\"facts\":[{\"description\":\"Budget\",\"id\":\"campaign_channels.budget\",\"sourceColumn\":\"budget\",\"tags\":[\"Campaign channels\"],\"title\":\"Budget\"},{\"description\":\"Spend\",\"id\":\"campaign_channels.spend\",\"sourceColumn\":\"spend\",\"tags\":[\"Campaign channels\"],\"title\":\"Spend\"}],\"grain\":[{\"id\":\"campaign_channels.campaign_channel_id\",\"type\":\"attribute\"}],\"id\":\"campaign_channels\",\"references\":[{\"identifier\":{\"id\":\"campaigns\",\"type\":\"dataset\"},\"multivalue\":false,\"sourceColumns\":[\"campaign_id\"]}],\"tags\":[\"Campaign channels\"],\"title\":\"Campaign channels\"},{\"attributes\":[{\"description\":\"Campaign id\",\"id\":\"campaigns.campaign_id\",\"labels\":[{\"description\":\"Campaign id\",\"id\":\"campaigns.campaign_id\",\"primary\":true,\"sourceColumn\":\"campaign_id\",\"tags\":[\"Campaigns\"],\"title\":\"Campaign id\"}],\"tags\":[\"Campaigns\"],\"title\":\"Campaign id\"},{\"description\":\"Campaign name\",\"id\":\"campaigns.campaign_name\",\"labels\":[{\"description\":\"Campaign name\",\"id\":\"campaigns.campaign_name\",\"primary\":true,\"sourceColumn\":\"campaign_name\",\"tags\":[\"Campaigns\"],\"title\":\"Campaign name\"}],\"tags\":[\"Campaigns\"],\"title\":\"Campaign name\"}],\"dataSourceTableId\":{\"dataSourceId\":\"demo-test-ds\",\"id\":\"campaigns\",\"type\":\"dataSource\"},\"description\":\"Campaigns\",\"facts\":[],\"grain\":[{\"id\":\"campaigns.campaign_id\",\"type\":\"attribute\"}],\"id\":\"campaigns\",\"references\":[],\"tags\":[\"Campaigns\"],\"title\":\"Campaigns\"},{\"attributes\":[{\"description\":\"Customer id\",\"id\":\"customers.customer_id\",\"labels\":[{\"description\":\"Customer id\",\"id\":\"customers.customer_id\",\"primary\":true,\"sourceColumn\":\"customer_id\",\"tags\":[\"Customers\"],\"title\":\"Customer id\"}],\"tags\":[\"Customers\"],\"title\":\"Customer id\"},{\"description\":\"Customer name\",\"id\":\"customers.customer_name\",\"labels\":[{\"description\":\"Customer name\",\"id\":\"customers.customer_name\",\"primary\":true,\"sourceColumn\":\"customer_name\",\"tags\":[\"Customers\"],\"title\":\"Customer name\"}],\"tags\":[\"Customers\"],\"title\":\"Customer name\"},{\"description\":\"Region\",\"id\":\"customers.region\",\"labels\":[{\"description\":\"Region\",\"id\":\"customers.region\",\"primary\":true,\"sourceColumn\":\"region\",\"tags\":[\"Customers\"],\"title\":\"Region\"}],\"tags\":[\"Customers\"],\"title\":\"Region\"},{\"description\":\"State\",\"id\":\"customers.state\",\"labels\":[{\"description\":\"Location\",\"id\":\"customers.geo__state__location\",\"primary\":false,\"sourceColumn\":\"geo__state__location\",\"tags\":[\"Customers\"],\"title\":\"Location\"},{\"description\":\"State\",\"id\":\"customers.state\",\"primary\":true,\"sourceColumn\":\"state\",\"tags\":[\"Customers\"],\"title\":\"State\"}],\"tags\":[\"Customers\"],\"title\":\"State\"}],\"dataSourceTableId\":{\"dataSourceId\":\"demo-test-ds\",\"id\":\"customers\",\"type\":\"dataSource\"},\"description\":\"Customers\",\"facts\":[],\"grain\":[{\"id\":\"customers.customer_id\",\"type\":\"attribute\"}],\"id\":\"customers\",\"references\":[],\"tags\":[\"Customers\"],\"title\":\"Customers\"},{\"attributes\":[{\"description\":\"Order id\",\"id\":\"order_lines.order_id\",\"labels\":[{\"description\":\"Order id\",\"id\":\"order_lines.order_id\",\"primary\":true,\"sourceColumn\":\"order_id\",\"tags\":[\"Order lines\"],\"title\":\"Order id\"}],\"tags\":[\"Order lines\"],\"title\":\"Order id\"},{\"description\":\"Order line id\",\"id\":\"order_lines.order_line_id\",\"labels\":[{\"description\":\"Order line id\",\"id\":\"order_lines.order_line_id\",\"primary\":true,\"sourceColumn\":\"order_line_id\",\"tags\":[\"Order lines\"],\"title\":\"Order line id\"}],\"tags\":[\"Order lines\"],\"title\":\"Order line id\"},{\"description\":\"Order status\",\"id\":\"order_lines.order_status\",\"labels\":[{\"description\":\"Order status\",\"id\":\"order_lines.order_status\",\"primary\":true,\"sourceColumn\":\"order_status\",\"tags\":[\"Order lines\"],\"title\":\"Order status\"}],\"tags\":[\"Order lines\"],\"title\":\"Order status\"}],\"dataSourceTableId\":{\"dataSourceId\":\"demo-test-ds\",\"id\":\"order_lines\",\"type\":\"dataSource\"},\"description\":\"Order lines\",\"facts\":[{\"description\":\"Price\",\"id\":\"order_lines.price\",\"sourceColumn\":\"price\",\"tags\":[\"Order lines\"],\"title\":\"Price\"},{\"description\":\"Quantity\",\"id\":\"order_lines.quantity\",\"sourceColumn\":\"quantity\",\"tags\":[\"Order lines\"],\"title\":\"Quantity\"}],\"grain\":[{\"id\":\"order_lines.order_line_id\",\"type\":\"attribute\"}],\"id\":\"order_lines\",\"references\":[{\"identifier\":{\"id\":\"campaigns\",\"type\":\"dataset\"},\"multivalue\":false,\"sourceColumns\":[\"campaign_id\"]},{\"identifier\":{\"id\":\"customers\",\"type\":\"dataset\"},\"multivalue\":false,\"sourceColumns\":[\"customer_id\"]},{\"identifier\":{\"id\":\"date\",\"type\":\"dataset\"},\"multivalue\":false,\"sourceColumns\":[\"date\"]},{\"identifier\":{\"id\":\"products\",\"type\":\"dataset\"},\"multivalue\":false,\"sourceColumns\":[\"product_id\"]}],\"tags\":[\"Order lines\"],\"title\":\"Order lines\"},{\"attributes\":[{\"description\":\"Category\",\"id\":\"products.category\",\"labels\":[{\"description\":\"Category\",\"id\":\"products.category\",\"primary\":true,\"sourceColumn\":\"category\",\"tags\":[\"Products\"],\"title\":\"Category\"}],\"tags\":[\"Products\"],\"title\":\"Category\"},{\"description\":\"Product id\",\"id\":\"products.product_id\",\"labels\":[{\"description\":\"Product id\",\"id\":\"products.product_id\",\"primary\":true,\"sourceColumn\":\"product_id\",\"tags\":[\"Products\"],\"title\":\"Product id\"}],\"tags\":[\"Products\"],\"title\":\"Product id\"},{\"description\":\"Product name\",\"id\":\"products.product_name\",\"labels\":[{\"description\":\"Product name\",\"id\":\"products.product_name\",\"primary\":true,\"sourceColumn\":\"product_name\",\"tags\":[\"Products\"],\"title\":\"Product name\"}],\"tags\":[\"Products\"],\"title\":\"Product name\"}],\"dataSourceTableId\":{\"dataSourceId\":\"demo-test-ds\",\"id\":\"products\",\"type\":\"dataSource\"},\"description\":\"Products\",\"facts\":[],\"grain\":[{\"id\":\"products.product_id\",\"type\":\"attribute\"}],\"id\":\"products\",\"references\":[],\"tags\":[\"Products\"],\"title\":\"Products\"}],\"dateInstances\":[{\"description\":\"\",\"granularities\":[\"DAY\",\"WEEK\",\"MONTH\",\"QUARTER\",\"YEAR\"],\"granularitiesFormatting\":{\"titleBase\":\"\",\"titlePattern\":\"%titleBase - %granularityTitle\"},\"id\":\"date\",\"tags\":[\"Date\"],\"title\":\"Date\"}]}}"
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "POST",
+                "uri": "http://localhost:3000/api/actions/dataSources/demo-test-ds/generateLogicalModel",
+                "body": "{\"separator\": \"__\", \"generateLongIds\": true, \"dateGranularities\": \"basic\", \"wdfPrefix\": \"wdf\"}",
+                "headers": {
+                    "Accept": [
+                        "application/json"
+                    ],
+                    "Content-Type": [
+                        "application/json"
+                    ],
+                    "X-Requested-With": [
+                        "XMLHttpRequest"
+                    ],
+                    "X-GDC-VALIDATE-RELATIONS": [
+                        "true"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": ""
+                },
+                "headers": {
+                    "X-XSS-Protection": [
+                        "1; mode=block"
+                    ],
+                    "Expires": [
+                        "0"
+                    ],
+                    "Content-Security-Policy": [
+                        "default-src 'self' *.wistia.com *.wistia.net; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.wistia.com *.wistia.net src.litix.io matomo.anywhere.gooddata.com code.jquery.com unpkg.com cdn.jsdelivr.net cdnjs.cloudflare.com; img-src 'self' data: blob: *.wistia.com *.wistia.net embedwistia-a.akamaihd.net www.gooddata.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com cdn.jsdelivr.net; font-src 'self' data: fonts.gstatic.com *.alicdn.com *.wistia.com cdn.jsdelivr.net info.gooddata.com; frame-src 'self'; object-src 'none'; worker-src 'self' blob:; child-src blob:; connect-src 'self' *.tiles.mapbox.com *.mapbox.com *.litix.io *.wistia.com embedwistia-a.akamaihd.net matomo.anywhere.gooddata.com; media-src 'self' blob: data: *.wistia.com *.wistia.net embedwistia-a.akamaihd.net"
+                    ],
+                    "X-Content-Type-Options": [
+                        "nosniff"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "Vary": [
+                        "Origin",
+                        "Access-Control-Request-Method",
+                        "Access-Control-Request-Headers"
+                    ],
+                    "X-GDC-TRACE-ID": [
+                        "ef1c43489f844828"
+                    ],
+                    "Access-Control-Allow-Credentials": [
+                        "true"
+                    ],
+                    "Pragma": [
+                        "no-cache"
+                    ],
+                    "Date": [
+                        "Fri, 18 Mar 2022 10:47:28 GMT"
+                    ],
+                    "Server": [
+                        "nginx"
+                    ],
+                    "Cache-Control": [
+                        "no-cache, no-store, max-age=0, must-revalidate"
+                    ],
+                    "Set-Cookie": [
+                        "SPRING_SEC_SECURITY_CONTEXT=; Max-Age=0; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; HttpOnly"
+                    ],
+                    "Permission-Policy": [
+                        "geolocation 'none'; midi 'none'; sync-xhr 'none'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none'; fullscreen 'none'; payment 'none';"
+                    ],
+                    "Content-Type": [
+                        "application/json"
+                    ],
+                    "GoodData-Deployment": [
+                        "aio"
+                    ],
+                    "X-Frame-Options": [
+                        "DENY"
+                    ],
+                    "Access-Control-Expose-Headers": [
+                        "Content-Disposition, Content-Length, Content-Range, Set-Cookie"
+                    ],
+                    "Transfer-Encoding": [
+                        "chunked"
+                    ]
+                },
+                "body": {
+                    "string": "{\"ldm\":{\"datasets\":[{\"attributes\":[{\"description\":\"Campaign channel id\",\"id\":\"campaign_channels.campaign_channel_id\",\"labels\":[{\"description\":\"Campaign channel id\",\"id\":\"campaign_channels.campaign_channel_id\",\"primary\":true,\"sourceColumn\":\"campaign_channel_id\",\"tags\":[\"Campaign channels\"],\"title\":\"Campaign channel id\"}],\"tags\":[\"Campaign channels\"],\"title\":\"Campaign channel id\"},{\"description\":\"Category\",\"id\":\"campaign_channels.category\",\"labels\":[{\"description\":\"Category\",\"id\":\"campaign_channels.category\",\"primary\":true,\"sourceColumn\":\"category\",\"tags\":[\"Campaign channels\"],\"title\":\"Category\"}],\"tags\":[\"Campaign channels\"],\"title\":\"Category\"},{\"description\":\"Type\",\"id\":\"campaign_channels.type\",\"labels\":[{\"description\":\"Type\",\"id\":\"campaign_channels.type\",\"primary\":true,\"sourceColumn\":\"type\",\"tags\":[\"Campaign channels\"],\"title\":\"Type\"}],\"tags\":[\"Campaign channels\"],\"title\":\"Type\"}],\"dataSourceTableId\":{\"dataSourceId\":\"demo-test-ds\",\"id\":\"campaign_channels\",\"type\":\"dataSource\"},\"description\":\"Campaign channels\",\"facts\":[{\"description\":\"Budget\",\"id\":\"campaign_channels.budget\",\"sourceColumn\":\"budget\",\"tags\":[\"Campaign channels\"],\"title\":\"Budget\"},{\"description\":\"Spend\",\"id\":\"campaign_channels.spend\",\"sourceColumn\":\"spend\",\"tags\":[\"Campaign channels\"],\"title\":\"Spend\"}],\"grain\":[{\"id\":\"campaign_channels.campaign_channel_id\",\"type\":\"attribute\"}],\"id\":\"campaign_channels\",\"references\":[{\"identifier\":{\"id\":\"campaigns\",\"type\":\"dataset\"},\"multivalue\":false,\"sourceColumns\":[\"campaign_id\"]}],\"tags\":[\"Campaign channels\"],\"title\":\"Campaign channels\"},{\"attributes\":[{\"description\":\"Campaign id\",\"id\":\"campaigns.campaign_id\",\"labels\":[{\"description\":\"Campaign id\",\"id\":\"campaigns.campaign_id\",\"primary\":true,\"sourceColumn\":\"campaign_id\",\"tags\":[\"Campaigns\"],\"title\":\"Campaign id\"}],\"tags\":[\"Campaigns\"],\"title\":\"Campaign id\"},{\"description\":\"Campaign name\",\"id\":\"campaigns.campaign_name\",\"labels\":[{\"description\":\"Campaign name\",\"id\":\"campaigns.campaign_name\",\"primary\":true,\"sourceColumn\":\"campaign_name\",\"tags\":[\"Campaigns\"],\"title\":\"Campaign name\"}],\"tags\":[\"Campaigns\"],\"title\":\"Campaign name\"}],\"dataSourceTableId\":{\"dataSourceId\":\"demo-test-ds\",\"id\":\"campaigns\",\"type\":\"dataSource\"},\"description\":\"Campaigns\",\"facts\":[],\"grain\":[{\"id\":\"campaigns.campaign_id\",\"type\":\"attribute\"}],\"id\":\"campaigns\",\"references\":[],\"tags\":[\"Campaigns\"],\"title\":\"Campaigns\"},{\"attributes\":[{\"description\":\"Customer id\",\"id\":\"customers.customer_id\",\"labels\":[{\"description\":\"Customer id\",\"id\":\"customers.customer_id\",\"primary\":true,\"sourceColumn\":\"customer_id\",\"tags\":[\"Customers\"],\"title\":\"Customer id\"}],\"tags\":[\"Customers\"],\"title\":\"Customer id\"},{\"description\":\"Customer name\",\"id\":\"customers.customer_name\",\"labels\":[{\"description\":\"Customer name\",\"id\":\"customers.customer_name\",\"primary\":true,\"sourceColumn\":\"customer_name\",\"tags\":[\"Customers\"],\"title\":\"Customer name\"}],\"tags\":[\"Customers\"],\"title\":\"Customer name\"},{\"description\":\"Region\",\"id\":\"customers.region\",\"labels\":[{\"description\":\"Region\",\"id\":\"customers.region\",\"primary\":true,\"sourceColumn\":\"region\",\"tags\":[\"Customers\"],\"title\":\"Region\"}],\"tags\":[\"Customers\"],\"title\":\"Region\"},{\"description\":\"State\",\"id\":\"customers.state\",\"labels\":[{\"description\":\"Location\",\"id\":\"customers.geo__state__location\",\"primary\":false,\"sourceColumn\":\"geo__state__location\",\"tags\":[\"Customers\"],\"title\":\"Location\"},{\"description\":\"State\",\"id\":\"customers.state\",\"primary\":true,\"sourceColumn\":\"state\",\"tags\":[\"Customers\"],\"title\":\"State\"}],\"tags\":[\"Customers\"],\"title\":\"State\"}],\"dataSourceTableId\":{\"dataSourceId\":\"demo-test-ds\",\"id\":\"customers\",\"type\":\"dataSource\"},\"description\":\"Customers\",\"facts\":[],\"grain\":[{\"id\":\"customers.customer_id\",\"type\":\"attribute\"}],\"id\":\"customers\",\"references\":[],\"tags\":[\"Customers\"],\"title\":\"Customers\"},{\"attributes\":[{\"description\":\"Order id\",\"id\":\"order_lines.order_id\",\"labels\":[{\"description\":\"Order id\",\"id\":\"order_lines.order_id\",\"primary\":true,\"sourceColumn\":\"order_id\",\"tags\":[\"Order lines\"],\"title\":\"Order id\"}],\"tags\":[\"Order lines\"],\"title\":\"Order id\"},{\"description\":\"Order line id\",\"id\":\"order_lines.order_line_id\",\"labels\":[{\"description\":\"Order line id\",\"id\":\"order_lines.order_line_id\",\"primary\":true,\"sourceColumn\":\"order_line_id\",\"tags\":[\"Order lines\"],\"title\":\"Order line id\"}],\"tags\":[\"Order lines\"],\"title\":\"Order line id\"},{\"description\":\"Order status\",\"id\":\"order_lines.order_status\",\"labels\":[{\"description\":\"Order status\",\"id\":\"order_lines.order_status\",\"primary\":true,\"sourceColumn\":\"order_status\",\"tags\":[\"Order lines\"],\"title\":\"Order status\"}],\"tags\":[\"Order lines\"],\"title\":\"Order status\"}],\"dataSourceTableId\":{\"dataSourceId\":\"demo-test-ds\",\"id\":\"order_lines\",\"type\":\"dataSource\"},\"description\":\"Order lines\",\"facts\":[{\"description\":\"Price\",\"id\":\"order_lines.price\",\"sourceColumn\":\"price\",\"tags\":[\"Order lines\"],\"title\":\"Price\"},{\"description\":\"Quantity\",\"id\":\"order_lines.quantity\",\"sourceColumn\":\"quantity\",\"tags\":[\"Order lines\"],\"title\":\"Quantity\"}],\"grain\":[{\"id\":\"order_lines.order_line_id\",\"type\":\"attribute\"}],\"id\":\"order_lines\",\"references\":[{\"identifier\":{\"id\":\"campaigns\",\"type\":\"dataset\"},\"multivalue\":false,\"sourceColumns\":[\"campaign_id\"]},{\"identifier\":{\"id\":\"customers\",\"type\":\"dataset\"},\"multivalue\":false,\"sourceColumns\":[\"customer_id\"]},{\"identifier\":{\"id\":\"date\",\"type\":\"dataset\"},\"multivalue\":false,\"sourceColumns\":[\"date\"]},{\"identifier\":{\"id\":\"products\",\"type\":\"dataset\"},\"multivalue\":false,\"sourceColumns\":[\"product_id\"]}],\"tags\":[\"Order lines\"],\"title\":\"Order lines\"},{\"attributes\":[{\"description\":\"Category\",\"id\":\"products.category\",\"labels\":[{\"description\":\"Category\",\"id\":\"products.category\",\"primary\":true,\"sourceColumn\":\"category\",\"tags\":[\"Products\"],\"title\":\"Category\"}],\"tags\":[\"Products\"],\"title\":\"Category\"},{\"description\":\"Product id\",\"id\":\"products.product_id\",\"labels\":[{\"description\":\"Product id\",\"id\":\"products.product_id\",\"primary\":true,\"sourceColumn\":\"product_id\",\"tags\":[\"Products\"],\"title\":\"Product id\"}],\"tags\":[\"Products\"],\"title\":\"Product id\"},{\"description\":\"Product name\",\"id\":\"products.product_name\",\"labels\":[{\"description\":\"Product name\",\"id\":\"products.product_name\",\"primary\":true,\"sourceColumn\":\"product_name\",\"tags\":[\"Products\"],\"title\":\"Product name\"}],\"tags\":[\"Products\"],\"title\":\"Product name\"}],\"dataSourceTableId\":{\"dataSourceId\":\"demo-test-ds\",\"id\":\"products\",\"type\":\"dataSource\"},\"description\":\"Products\",\"facts\":[],\"grain\":[{\"id\":\"products.product_id\",\"type\":\"attribute\"}],\"id\":\"products\",\"references\":[],\"tags\":[\"Products\"],\"title\":\"Products\"}],\"dateInstances\":[{\"granularities\":[\"DAY\",\"MONTH\",\"QUARTER\",\"WEEK\",\"YEAR\"],\"granularitiesFormatting\":{\"titleBase\":\"\",\"titlePattern\":\"%titleBase - %granularityTitle\"},\"id\":\"date\",\"tags\":[\"Date\"],\"title\":\"Date\"}]}}"
+                }
+            }
+        }
+    ]
+}

--- a/gooddata-sdk/tests/catalog/fixtures/data_sources/demo_register_upload_notification.json
+++ b/gooddata-sdk/tests/catalog/fixtures/data_sources/demo_register_upload_notification.json
@@ -1,0 +1,357 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "http://localhost:3000/api/entities/workspaces/demo/metrics?page=0&size=500",
+                "body": null,
+                "headers": {
+                    "Accept": [
+                        "application/vnd.gooddata.api+json"
+                    ],
+                    "X-Requested-With": [
+                        "XMLHttpRequest"
+                    ],
+                    "X-GDC-VALIDATE-RELATIONS": [
+                        "true"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": ""
+                },
+                "headers": {
+                    "X-Content-Type-Options": [
+                        "nosniff"
+                    ],
+                    "Content-Type": [
+                        "application/vnd.gooddata.api+json"
+                    ],
+                    "Cache-Control": [
+                        "no-cache, no-store, max-age=0, must-revalidate"
+                    ],
+                    "Access-Control-Allow-Credentials": [
+                        "true"
+                    ],
+                    "Date": [
+                        "Fri, 18 Mar 2022 10:46:28 GMT"
+                    ],
+                    "X-GDC-TRACE-ID": [
+                        "de1d0084572dec73"
+                    ],
+                    "X-XSS-Protection": [
+                        "1; mode=block"
+                    ],
+                    "Set-Cookie": [
+                        "SPRING_SEC_SECURITY_CONTEXT=; Max-Age=0; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; HttpOnly"
+                    ],
+                    "Expires": [
+                        "0"
+                    ],
+                    "Access-Control-Expose-Headers": [
+                        "Content-Disposition, Content-Length, Content-Range, Set-Cookie"
+                    ],
+                    "Permission-Policy": [
+                        "geolocation 'none'; midi 'none'; sync-xhr 'none'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none'; fullscreen 'none'; payment 'none';"
+                    ],
+                    "X-Frame-Options": [
+                        "DENY"
+                    ],
+                    "GoodData-Deployment": [
+                        "aio"
+                    ],
+                    "Pragma": [
+                        "no-cache"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "Vary": [
+                        "Origin",
+                        "Access-Control-Request-Method",
+                        "Access-Control-Request-Headers"
+                    ],
+                    "Transfer-Encoding": [
+                        "chunked"
+                    ],
+                    "Server": [
+                        "nginx"
+                    ],
+                    "Content-Security-Policy": [
+                        "default-src 'self' *.wistia.com *.wistia.net; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.wistia.com *.wistia.net src.litix.io matomo.anywhere.gooddata.com code.jquery.com unpkg.com cdn.jsdelivr.net cdnjs.cloudflare.com; img-src 'self' data: blob: *.wistia.com *.wistia.net embedwistia-a.akamaihd.net www.gooddata.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com cdn.jsdelivr.net; font-src 'self' data: fonts.gstatic.com *.alicdn.com *.wistia.com cdn.jsdelivr.net info.gooddata.com; frame-src 'self'; object-src 'none'; worker-src 'self' blob:; child-src blob:; connect-src 'self' *.tiles.mapbox.com *.mapbox.com *.litix.io *.wistia.com embedwistia-a.akamaihd.net matomo.anywhere.gooddata.com; media-src 'self' blob: data: *.wistia.com *.wistia.net embedwistia-a.akamaihd.net"
+                    ]
+                },
+                "body": {
+                    "string": "{\"data\":[{\"attributes\":{\"title\":\"Order Amount\",\"areRelationsValid\":true,\"content\":{\"format\":\"$#,##0\",\"maql\":\"SELECT SUM({fact/order_lines.price}*{fact/order_lines.quantity})\"}},\"id\":\"order_amount\",\"links\":{\"self\":\"http://localhost:3000/api/entities/workspaces/demo/metrics/order_amount\"},\"type\":\"metric\"},{\"attributes\":{\"title\":\"# of Orders\",\"areRelationsValid\":true,\"content\":{\"format\":\"#,##0\",\"maql\":\"SELECT COUNT({attribute/order_lines.order_id})\"}},\"id\":\"amount_of_orders\",\"links\":{\"self\":\"http://localhost:3000/api/entities/workspaces/demo/metrics/amount_of_orders\"},\"type\":\"metric\"},{\"attributes\":{\"title\":\"Revenue\",\"areRelationsValid\":true,\"content\":{\"format\":\"$#,##0\",\"maql\":\"SELECT {metric/order_amount} WHERE NOT ({label/order_lines.order_status} IN (\\\"null\\\", \\\"Returned\\\", \\\"Canceled\\\"))\"}},\"id\":\"revenue\",\"links\":{\"self\":\"http://localhost:3000/api/entities/workspaces/demo/metrics/revenue\"},\"type\":\"metric\"},{\"attributes\":{\"title\":\"# of Valid Orders\",\"areRelationsValid\":true,\"content\":{\"format\":\"#,##0.00\",\"maql\":\"SELECT {metric/amount_of_orders} WHERE NOT ({label/order_lines.order_status} IN (\\\"null\\\", \\\"Returned\\\", \\\"Canceled\\\"))\"}},\"id\":\"amount_of_valid_orders\",\"links\":{\"self\":\"http://localhost:3000/api/entities/workspaces/demo/metrics/amount_of_valid_orders\"},\"type\":\"metric\"},{\"attributes\":{\"title\":\"Revenue per Customer\",\"areRelationsValid\":true,\"content\":{\"format\":\"$#,##0.0\",\"maql\":\"SELECT AVG(SELECT {metric/revenue} BY {attribute/customers.customer_id})\"}},\"id\":\"revenue_per_customer\",\"links\":{\"self\":\"http://localhost:3000/api/entities/workspaces/demo/metrics/revenue_per_customer\"},\"type\":\"metric\"},{\"attributes\":{\"title\":\"# of Active Customers\",\"areRelationsValid\":true,\"content\":{\"format\":\"#,##0\",\"maql\":\"SELECT COUNT({attribute/customers.customer_id},{attribute/order_lines.order_line_id})\"}},\"id\":\"amount_of_active_customers\",\"links\":{\"self\":\"http://localhost:3000/api/entities/workspaces/demo/metrics/amount_of_active_customers\"},\"type\":\"metric\"},{\"attributes\":{\"title\":\"# of Top Customers\",\"areRelationsValid\":true,\"content\":{\"format\":\"#,##0\",\"maql\":\"SELECT {metric/amount_of_active_customers} WHERE (SELECT {metric/revenue} BY {attribute/customers.customer_id}) >  10000 \"}},\"id\":\"amount_of_top_customers\",\"links\":{\"self\":\"http://localhost:3000/api/entities/workspaces/demo/metrics/amount_of_top_customers\"},\"type\":\"metric\"},{\"attributes\":{\"title\":\"Total Revenue\",\"areRelationsValid\":true,\"content\":{\"format\":\"$#,##0\",\"maql\":\"SELECT {metric/revenue} BY ALL OTHER\"}},\"id\":\"total_revenue\",\"links\":{\"self\":\"http://localhost:3000/api/entities/workspaces/demo/metrics/total_revenue\"},\"type\":\"metric\"},{\"attributes\":{\"title\":\"Total Revenue (No Filters)\",\"areRelationsValid\":true,\"content\":{\"format\":\"$#,##0\",\"maql\":\"SELECT {metric/total_revenue} WITHOUT PARENT FILTER\"}},\"id\":\"total_revenue-no_filters\",\"links\":{\"self\":\"http://localhost:3000/api/entities/workspaces/demo/metrics/total_revenue-no_filters\"},\"type\":\"metric\"},{\"attributes\":{\"title\":\"% Revenue\",\"areRelationsValid\":true,\"content\":{\"format\":\"#,##0.0%\",\"maql\":\"SELECT {metric/revenue} / {metric/total_revenue}\"}},\"id\":\"percent_revenue\",\"links\":{\"self\":\"http://localhost:3000/api/entities/workspaces/demo/metrics/percent_revenue\"},\"type\":\"metric\"},{\"attributes\":{\"title\":\"% Revenue per Product\",\"areRelationsValid\":true,\"content\":{\"format\":\"#,##0.0%\",\"maql\":\"SELECT {metric/revenue} / (SELECT {metric/revenue} BY ALL {attribute/products.product_id})\"}},\"id\":\"percent_revenue_per_product\",\"links\":{\"self\":\"http://localhost:3000/api/entities/workspaces/demo/metrics/percent_revenue_per_product\"},\"type\":\"metric\"},{\"attributes\":{\"title\":\"% Revenue in Category\",\"areRelationsValid\":true,\"content\":{\"format\":\"#,##0.0%\",\"maql\":\"SELECT {metric/revenue} / (SELECT {metric/revenue} BY {attribute/products.category}, ALL OTHER)\"}},\"id\":\"percent_revenue_in_category\",\"links\":{\"self\":\"http://localhost:3000/api/entities/workspaces/demo/metrics/percent_revenue_in_category\"},\"type\":\"metric\"},{\"attributes\":{\"title\":\"Revenue / Top 10\",\"areRelationsValid\":true,\"content\":{\"format\":\"$#,##0\",\"maql\":\"SELECT {metric/revenue} WHERE TOP(10) OF ({metric/revenue})\"}},\"id\":\"revenue_top_10\",\"links\":{\"self\":\"http://localhost:3000/api/entities/workspaces/demo/metrics/revenue_top_10\"},\"type\":\"metric\"},{\"attributes\":{\"title\":\"% Revenue from Top 10 Products\",\"areRelationsValid\":true,\"content\":{\"format\":\"#,##0.0%\",\"maql\":\"SELECT\\n (SELECT {metric/revenue} WHERE (SELECT {metric/revenue_top_10} BY {attribute/products.product_id}) > 0)\\n  /\\n {metric/revenue}\"}},\"id\":\"percent_revenue_from_top_10_products\",\"links\":{\"self\":\"http://localhost:3000/api/entities/workspaces/demo/metrics/percent_revenue_from_top_10_products\"},\"type\":\"metric\"},{\"attributes\":{\"title\":\"% Revenue from Top 10 Customers\",\"areRelationsValid\":true,\"content\":{\"format\":\"#,##0.0%\",\"maql\":\"SELECT\\n (SELECT {metric/revenue} WHERE (SELECT {metric/revenue_top_10} BY {attribute/customers.customer_id}) > 0)\\n  /\\n {metric/revenue}\"}},\"id\":\"percent_revenue_from_top_10_customers\",\"links\":{\"self\":\"http://localhost:3000/api/entities/workspaces/demo/metrics/percent_revenue_from_top_10_customers\"},\"type\":\"metric\"},{\"attributes\":{\"title\":\"Revenue / Top 10%\",\"areRelationsValid\":true,\"content\":{\"format\":\"$#,##0\",\"maql\":\"SELECT {metric/revenue} WHERE TOP(10%) OF ({metric/revenue})\"}},\"id\":\"revenue_top_10_percent\",\"links\":{\"self\":\"http://localhost:3000/api/entities/workspaces/demo/metrics/revenue_top_10_percent\"},\"type\":\"metric\"},{\"attributes\":{\"title\":\"% Revenue from Top 10% Customers\",\"areRelationsValid\":true,\"content\":{\"format\":\"#,##0.0%\",\"maql\":\"SELECT\\n (SELECT {metric/revenue} WHERE (SELECT {metric/revenue_top_10_percent} BY {attribute/customers.customer_id}) > 0)\\n  /\\n {metric/revenue}\"}},\"id\":\"percent_revenue_from_top_10_percent_customers\",\"links\":{\"self\":\"http://localhost:3000/api/entities/workspaces/demo/metrics/percent_revenue_from_top_10_percent_customers\"},\"type\":\"metric\"},{\"attributes\":{\"title\":\"% Revenue from Top 10% Products\",\"areRelationsValid\":true,\"content\":{\"format\":\"#,##0.0%\",\"maql\":\"SELECT\\n (SELECT {metric/revenue} WHERE (SELECT {metric/revenue_top_10_percent} BY {attribute/products.product_id}) > 0)\\n  /\\n {metric/revenue}\"}},\"id\":\"percent_revenue_from_top_10_percent_products\",\"links\":{\"self\":\"http://localhost:3000/api/entities/workspaces/demo/metrics/percent_revenue_from_top_10_percent_products\"},\"type\":\"metric\"},{\"attributes\":{\"title\":\"Revenue per Dollar Spent\",\"areRelationsValid\":true,\"content\":{\"format\":\"$#,##0.0\",\"maql\":\"SELECT {metric/revenue} / {metric/campaign_spend}\"}},\"id\":\"revenue_per_dollar_spent\",\"links\":{\"self\":\"http://localhost:3000/api/entities/workspaces/demo/metrics/revenue_per_dollar_spent\"},\"type\":\"metric\"},{\"attributes\":{\"title\":\"Campaign Spend\",\"areRelationsValid\":true,\"content\":{\"format\":\"$#,##0\",\"maql\":\"SELECT SUM({fact/campaign_channels.spend})\"}},\"id\":\"campaign_spend\",\"links\":{\"self\":\"http://localhost:3000/api/entities/workspaces/demo/metrics/campaign_spend\"},\"type\":\"metric\"},{\"attributes\":{\"title\":\"Revenue (Outdoor)\",\"areRelationsValid\":true,\"content\":{\"format\":\"$#,##0\",\"maql\":\"SELECT {metric/revenue} WHERE {label/products.category} IN (\\\"Outdoor\\\")\"}},\"id\":\"revenue-outdoor\",\"links\":{\"self\":\"http://localhost:3000/api/entities/workspaces/demo/metrics/revenue-outdoor\"},\"type\":\"metric\"},{\"attributes\":{\"title\":\"Revenue (Clothing)\",\"areRelationsValid\":true,\"content\":{\"format\":\"$#,##0\",\"maql\":\"SELECT {metric/revenue} WHERE {label/products.category} IN (\\\"Clothing\\\")\"}},\"id\":\"revenue-clothing\",\"links\":{\"self\":\"http://localhost:3000/api/entities/workspaces/demo/metrics/revenue-clothing\"},\"type\":\"metric\"},{\"attributes\":{\"title\":\"Revenue (Home)\",\"areRelationsValid\":true,\"content\":{\"format\":\"$#,##0\",\"maql\":\"SELECT {metric/revenue} WHERE {label/products.category} IN (\\\"Home\\\")\"}},\"id\":\"revenue-home\",\"links\":{\"self\":\"http://localhost:3000/api/entities/workspaces/demo/metrics/revenue-home\"},\"type\":\"metric\"},{\"attributes\":{\"title\":\"Revenue (Electronic)\",\"areRelationsValid\":true,\"content\":{\"format\":\"$#,##0\",\"maql\":\"SELECT {metric/revenue} WHERE {label/products.category} IN ( \\\"Electronics\\\")\"}},\"id\":\"revenue-electronic\",\"links\":{\"self\":\"http://localhost:3000/api/entities/workspaces/demo/metrics/revenue-electronic\"},\"type\":\"metric\"}],\"links\":{\"self\":\"http://localhost:3000/api/entities/workspaces/demo/metrics?page=0&size=500\",\"next\":\"http://localhost:3000/api/entities/workspaces/demo/metrics?page=1&size=500\"}}"
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "POST",
+                "uri": "http://localhost:3000/api/actions/workspaces/demo/execution/afm/execute",
+                "body": "{\"execution\": {\"attributes\": [], \"filters\": [], \"measures\": [{\"localIdentifier\": \"order_amount\", \"definition\": {\"measure\": {\"item\": {\"identifier\": {\"id\": \"order_amount\", \"type\": \"metric\"}}, \"computeRatio\": false, \"filters\": []}}}]}, \"resultSpec\": {\"dimensions\": [{\"itemIdentifiers\": [\"measureGroup\"], \"localIdentifier\": \"dim_0\"}]}}",
+                "headers": {
+                    "Accept": [
+                        "application/json"
+                    ],
+                    "Content-Type": [
+                        "application/json"
+                    ],
+                    "X-Requested-With": [
+                        "XMLHttpRequest"
+                    ],
+                    "X-GDC-VALIDATE-RELATIONS": [
+                        "true"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "X-Content-Type-Options": [
+                        "nosniff"
+                    ],
+                    "Content-Type": [
+                        "application/json"
+                    ],
+                    "Cache-Control": [
+                        "no-cache, no-store, max-age=0, must-revalidate"
+                    ],
+                    "Access-Control-Allow-Credentials": [
+                        "true"
+                    ],
+                    "Date": [
+                        "Fri, 18 Mar 2022 10:46:29 GMT"
+                    ],
+                    "X-GDC-TRACE-ID": [
+                        "493744915124100b"
+                    ],
+                    "X-XSS-Protection": [
+                        "1 ; mode=block"
+                    ],
+                    "Set-Cookie": [
+                        "SPRING_REDIRECT_URI=; Path=/; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=Lax"
+                    ],
+                    "Expires": [
+                        "0"
+                    ],
+                    "Access-Control-Expose-Headers": [
+                        "Content-Disposition, Content-Length, Content-Range, Set-Cookie"
+                    ],
+                    "Permission-Policy": [
+                        "geolocation 'none'; midi 'none'; sync-xhr 'none'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none'; fullscreen 'none'; payment 'none';"
+                    ],
+                    "GoodData-Deployment": [
+                        "aio"
+                    ],
+                    "Pragma": [
+                        "no-cache"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "Vary": [
+                        "Origin",
+                        "Access-Control-Request-Method",
+                        "Access-Control-Request-Headers"
+                    ],
+                    "Content-Length": [
+                        "224"
+                    ],
+                    "Server": [
+                        "nginx"
+                    ],
+                    "Content-Security-Policy": [
+                        "default-src 'self' *.wistia.com *.wistia.net; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.wistia.com *.wistia.net src.litix.io matomo.anywhere.gooddata.com code.jquery.com unpkg.com cdn.jsdelivr.net cdnjs.cloudflare.com; img-src 'self' data: blob: *.wistia.com *.wistia.net embedwistia-a.akamaihd.net www.gooddata.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com cdn.jsdelivr.net; font-src 'self' data: fonts.gstatic.com *.alicdn.com *.wistia.com cdn.jsdelivr.net info.gooddata.com; frame-src 'self'; object-src 'none'; worker-src 'self' blob:; child-src blob:; connect-src 'self' *.tiles.mapbox.com *.mapbox.com *.litix.io *.wistia.com embedwistia-a.akamaihd.net matomo.anywhere.gooddata.com; media-src 'self' blob: data: *.wistia.com *.wistia.net embedwistia-a.akamaihd.net"
+                    ],
+                    "Referrer-Policy": [
+                        "no-referrer"
+                    ]
+                },
+                "body": {
+                    "string": "{\"executionResponse\":{\"dimensions\":[{\"headers\":[{\"measureGroupHeaders\":[{\"localIdentifier\":\"order_amount\",\"format\":\"$#,##0\",\"name\":\"Order Amount\"}]}]}],\"links\":{\"executionResult\":\"38498afeb70df7bfd49f6854753b3e8c5376f337\"}}}"
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "POST",
+                "uri": "http://localhost:3000/api/actions/dataSources/demo-test-ds/uploadNotification",
+                "body": null,
+                "headers": {
+                    "X-Requested-With": [
+                        "XMLHttpRequest"
+                    ],
+                    "X-GDC-VALIDATE-RELATIONS": [
+                        "true"
+                    ],
+                    "Content-Type": [
+                        "application/json"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 204,
+                    "message": ""
+                },
+                "headers": {
+                    "Set-Cookie": [
+                        "SPRING_SEC_SECURITY_CONTEXT=; Max-Age=0; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; HttpOnly"
+                    ],
+                    "Pragma": [
+                        "no-cache"
+                    ],
+                    "Cache-Control": [
+                        "no-cache, no-store, max-age=0, must-revalidate"
+                    ],
+                    "Access-Control-Allow-Credentials": [
+                        "true"
+                    ],
+                    "Expires": [
+                        "0"
+                    ],
+                    "Date": [
+                        "Fri, 18 Mar 2022 10:46:29 GMT"
+                    ],
+                    "X-Content-Type-Options": [
+                        "nosniff"
+                    ],
+                    "X-GDC-TRACE-ID": [
+                        "d76632890c6bf5bf"
+                    ],
+                    "X-XSS-Protection": [
+                        "1; mode=block"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "Vary": [
+                        "Origin",
+                        "Access-Control-Request-Method",
+                        "Access-Control-Request-Headers"
+                    ],
+                    "Access-Control-Expose-Headers": [
+                        "Content-Disposition, Content-Length, Content-Range, Set-Cookie"
+                    ],
+                    "Permission-Policy": [
+                        "geolocation 'none'; midi 'none'; sync-xhr 'none'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none'; fullscreen 'none'; payment 'none';"
+                    ],
+                    "X-Frame-Options": [
+                        "DENY"
+                    ],
+                    "GoodData-Deployment": [
+                        "aio"
+                    ],
+                    "Server": [
+                        "nginx"
+                    ],
+                    "Content-Security-Policy": [
+                        "default-src 'self' *.wistia.com *.wistia.net; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.wistia.com *.wistia.net src.litix.io matomo.anywhere.gooddata.com code.jquery.com unpkg.com cdn.jsdelivr.net cdnjs.cloudflare.com; img-src 'self' data: blob: *.wistia.com *.wistia.net embedwistia-a.akamaihd.net www.gooddata.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com cdn.jsdelivr.net; font-src 'self' data: fonts.gstatic.com *.alicdn.com *.wistia.com cdn.jsdelivr.net info.gooddata.com; frame-src 'self'; object-src 'none'; worker-src 'self' blob:; child-src blob:; connect-src 'self' *.tiles.mapbox.com *.mapbox.com *.litix.io *.wistia.com embedwistia-a.akamaihd.net matomo.anywhere.gooddata.com; media-src 'self' blob: data: *.wistia.com *.wistia.net embedwistia-a.akamaihd.net"
+                    ]
+                },
+                "body": {
+                    "string": ""
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "POST",
+                "uri": "http://localhost:3000/api/actions/workspaces/demo/execution/afm/execute",
+                "body": "{\"execution\": {\"attributes\": [], \"filters\": [], \"measures\": [{\"localIdentifier\": \"order_amount\", \"definition\": {\"measure\": {\"item\": {\"identifier\": {\"id\": \"order_amount\", \"type\": \"metric\"}}, \"computeRatio\": false, \"filters\": []}}}]}, \"resultSpec\": {\"dimensions\": [{\"itemIdentifiers\": [\"measureGroup\"], \"localIdentifier\": \"dim_0\"}]}}",
+                "headers": {
+                    "Accept": [
+                        "application/json"
+                    ],
+                    "Content-Type": [
+                        "application/json"
+                    ],
+                    "X-Requested-With": [
+                        "XMLHttpRequest"
+                    ],
+                    "X-GDC-VALIDATE-RELATIONS": [
+                        "true"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "X-Content-Type-Options": [
+                        "nosniff"
+                    ],
+                    "Content-Type": [
+                        "application/json"
+                    ],
+                    "Cache-Control": [
+                        "no-cache, no-store, max-age=0, must-revalidate"
+                    ],
+                    "Access-Control-Allow-Credentials": [
+                        "true"
+                    ],
+                    "Date": [
+                        "Fri, 18 Mar 2022 10:46:31 GMT"
+                    ],
+                    "X-GDC-TRACE-ID": [
+                        "283ae2b29d9c7564"
+                    ],
+                    "X-XSS-Protection": [
+                        "1 ; mode=block"
+                    ],
+                    "Set-Cookie": [
+                        "SPRING_REDIRECT_URI=; Path=/; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=Lax"
+                    ],
+                    "Expires": [
+                        "0"
+                    ],
+                    "Access-Control-Expose-Headers": [
+                        "Content-Disposition, Content-Length, Content-Range, Set-Cookie"
+                    ],
+                    "Permission-Policy": [
+                        "geolocation 'none'; midi 'none'; sync-xhr 'none'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none'; fullscreen 'none'; payment 'none';"
+                    ],
+                    "GoodData-Deployment": [
+                        "aio"
+                    ],
+                    "Pragma": [
+                        "no-cache"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "Vary": [
+                        "Origin",
+                        "Access-Control-Request-Method",
+                        "Access-Control-Request-Headers"
+                    ],
+                    "Content-Length": [
+                        "224"
+                    ],
+                    "Server": [
+                        "nginx"
+                    ],
+                    "Content-Security-Policy": [
+                        "default-src 'self' *.wistia.com *.wistia.net; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.wistia.com *.wistia.net src.litix.io matomo.anywhere.gooddata.com code.jquery.com unpkg.com cdn.jsdelivr.net cdnjs.cloudflare.com; img-src 'self' data: blob: *.wistia.com *.wistia.net embedwistia-a.akamaihd.net www.gooddata.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com cdn.jsdelivr.net; font-src 'self' data: fonts.gstatic.com *.alicdn.com *.wistia.com cdn.jsdelivr.net info.gooddata.com; frame-src 'self'; object-src 'none'; worker-src 'self' blob:; child-src blob:; connect-src 'self' *.tiles.mapbox.com *.mapbox.com *.litix.io *.wistia.com embedwistia-a.akamaihd.net matomo.anywhere.gooddata.com; media-src 'self' blob: data: *.wistia.com *.wistia.net embedwistia-a.akamaihd.net"
+                    ],
+                    "Referrer-Policy": [
+                        "no-referrer"
+                    ]
+                },
+                "body": {
+                    "string": "{\"executionResponse\":{\"dimensions\":[{\"headers\":[{\"measureGroupHeaders\":[{\"localIdentifier\":\"order_amount\",\"format\":\"$#,##0\",\"name\":\"Order Amount\"}]}]}],\"links\":{\"executionResult\":\"ea511030af8a74508c6d2953c7b95496eccbb76f\"}}}"
+                }
+            }
+        }
+    ]
+}

--- a/gooddata-sdk/tests/gd_test_config.yaml
+++ b/gooddata-sdk/tests/gd_test_config.yaml
@@ -6,3 +6,4 @@ workspace_name: "Demo"
 workspace_with_parent: "demo_west"
 workspace_with_parent_name: "Demo West"
 header_host: localhost
+data_source: "demo-test-ds"


### PR DESCRIPTION
get_declarative_ldm, store_declarative_ldm, load_and_put_declarative_ldm, put_declarative_ldm, get_declarative_analytics_model, put_declarative_analytics_model, store_declarative_analytics_model, load_and_put_declarative_analytics_model moved to CatalogWorkspaceContentService

Created 2 new methods in CatalogDataSourceService - generate_logical_model, register_upload_notification.