### PR TITLE
Fix docstring annotations for better rendering online

### DIFF
--- a/gooddata-fdw/gooddata_fdw/column_utils.py
+++ b/gooddata-fdw/gooddata_fdw/column_utils.py
@@ -28,6 +28,7 @@ def table_col_as_computable(col: ColumnDefinition) -> Union[Attribute, Metric]:
 def column_data_type_for(attribute: Optional[CatalogAttribute]) -> str:
     """
     Determine what postgres type should be used for `attribute`.
+
     :param attribute: catalog attribute instance
     """
     if not attribute:

--- a/gooddata-pandas/gooddata_pandas/dataframe.py
+++ b/gooddata-pandas/gooddata_pandas/dataframe.py
@@ -23,14 +23,14 @@ class DataFrameFactory:
 
     There are several methods in place that should provide for convenient construction of data frames:
 
-        - indexed() - calculate measure values sliced by one or more labels, indexed by those labels
-        - not_indexed() - calculate measure values sliced by one or more labels, but not indexed by those labels,
-            label values will be part of the DataFrame and will be in the same row as the measure values calculated
-            for them
-        - for_items() - calculate measure values for a one or more items which may be labels or measures. Depending
-            what items you specify, this method will create DataFrame with or without index
-        - for_insight() - calculate DataFrame for insight created by GoodData.CN Analytical Designer. Depending
-            on what items are in the insight, this method will create DataFrame with or without index.
+    - ``indexed()`` - calculate measure values sliced by one or more labels, indexed by those labels
+    - ``not_indexed()`` - calculate measure values sliced by one or more labels, but not indexed by those labels,
+      label values will be part of the DataFrame and will be in the same row as the measure values calculated
+      for them
+    - ``for_items()`` - calculate measure values for a one or more items which may be labels or measures. Depending
+      what items you specify, this method will create DataFrame with or without index
+    - ``for_insight()`` - calculate DataFrame for insight created by GoodData.CN Analytical Designer. Depending
+      on what items are in the insight, this method will create DataFrame with or without index.
 
     Note that all of these methods have additional levels of convenience and flexibility so their purpose is not
     limited to just what is listed above.
@@ -53,26 +53,31 @@ class DataFrameFactory:
         Note that depending on composition of the labels, the DataFrame's index may or may not be unique.
 
         :param index_by: one or more labels to index by; specify either:
+
          - string with reference to columns key - only attribute can be referenced
-         - string with id: 'some_label_id',
-         - string representation of object identifier: 'label/some_label_id'
-         - object identifier: ObjId(id='some_label_id', type='label'),
-         - or an Attribute object used in the compute model: Attribute(local_id=..., label='some_label_id'),
+         - string with id: ``some_label_id``,
+         - string representation of object identifier: ``label/some_label_id``
+         - object identifier: ``ObjId(id='some_label_id', type='label')``,
+         - or an Attribute object used in the compute model: ``Attribute(local_id=..., label='some_label_id')``,
          - dict containing mapping of index name to label to use for indexing - specified in one of the ways list above
 
         :param columns: dict mapping column name to its definition; column may be specified as:
-         - object identifier: ObjId(id='some_id', type='<type>') - where type is either 'label', 'fact' or 'metric'
-         - string representation of object identifier: '<type>/some_id' - where type is either 'label', 'fact' or
-         'metric'
-         - Attribute object used in the compute model: Attribute(local_id=..., label='some_label_id')
+
+         - object identifier: ``ObjId(id='some_id', type='<type>')`` - where type is either ``label``, ``fact``
+           or ``metric``
+         - string representation of object identifier: ``<type>/some_id`` - where type is either ``label``, ``fact`` or
+           ``metric``
+         - Attribute object used in the compute model: ``Attribute(local_id=..., label='some_label_id')``
          - subclass of Measure object used in the compute model: SimpleMeasure, PopDateMeasure, PopDatasetMeasure,
-         ArithmeticMeasure
+           ArithmeticMeasure
+
         :param filter_by: optional filters to apply during computation on the server, reference to filtering column
-            can be one of:
-            - string reference to column key or index key
-            - object identifier in string form
-            - object identifier: ObjId(id='some_label_id', type='<type>')
-            - Attribute or Metric depending on type of filter
+         can be one of:
+
+         - string reference to column key or index key
+         - object identifier in string form
+         - object identifier: ``ObjId(id='some_label_id', type='<type>')``
+         - Attribute or Metric depending on type of filter
 
         :return: pandas dataframe instance
         """
@@ -98,18 +103,22 @@ class DataFrameFactory:
         to aggregate values of metric columns.
 
         :param columns: dict mapping column name to its definition; column may be specified as:
-         - object identifier: ObjId(id='some_id', type='<type>') - where type is either 'label', 'fact' or 'metric'
-         - string representation of object identifier: '<type>/some_id' - where type is either 'label',
-         'fact' or 'metric'
-         - Attribute object used in the compute model: Attribute(local_id=..., label='some_label_id')
+
+         - object identifier: ``ObjId(id='some_id', type='<type>')`` - where type is either ``label``, ``fact``
+           or ``metric``
+         - string representation of object identifier: ``<type>/some_id`` - where type is either ``label``,
+           ``fact`` or ``metric``
+         - Attribute object used in the compute model: ``Attribute(local_id=..., label='some_label_id')``
          - subclass of Measure object used in the compute model: SimpleMeasure, PopDateMeasure, PopDatasetMeasure,
-         ArithmeticMeasure
+           ArithmeticMeasure
+
         :param filter_by: optionally specify filters to apply during computation on the server, reference to filtering
-            column can be one of:
-            - string reference to column key
-            - object identifier in string form
-            - object identifier: ObjId(id='some_label_id', type='<type>')
-            - Attribute or Metric depending on type of filter
+         column can be one of:
+
+         - string reference to column key
+         - object identifier in string form
+         - object identifier: ``ObjId(id='some_label_id', type='<type>')``
+         - Attribute or Metric depending on type of filter
 
         :return: pandas dataframe instance
         """
@@ -125,30 +134,33 @@ class DataFrameFactory:
         Creates a data frame for a named items. This is a convenience method that will create DataFrame with or
         without index based on the context of the items that you pass.
 
-            - If items contain labels and measures, then DataFrame with index will be created. If there is more than
-               one label among the items, then hierarchical index will be created.
+        - If items contain labels and measures, then DataFrame with index will be created. If there is more than
+          one label among the items, then hierarchical index will be created.
 
-               You can turn this behavior using 'auto_index' parameter.
+          You can turn this behavior using 'auto_index' parameter.
 
-            - Otherwise DataFrame without index will be created and will contain column per item.
+        - Otherwise DataFrame without index will be created and will contain column per item.
 
         You may also optionally specify filters to apply during the computation on the server.
 
         :param items: dict mapping item name to its definition; item may be specified as:
-             - object identifier: ObjId(id='some_id', type='<type>') - where type is either 'label', 'fact' or 'metric'
-             - string representation of object identifier: '<type>/some_id' - where type is either 'label',
-             'fact' or 'metric'
-             - Attribute object used in the compute model: Attribute(local_id=..., label='some_label_id')
-             - subclass of Measure object used in the compute model: SimpleMeasure, PopDateMeasure, PopDatasetMeasure,
-             ArithmeticMeasure
+
+         - object identifier: ``ObjId(id='some_id', type='<type>')`` - where type is either ``label``, ``fact``
+           or ``metric``
+         - string representation of object identifier: ``<type>/some_id`` - where type is either ``label``,
+           ``fact`` or ``metric``
+         - Attribute object used in the compute model: ``Attribute(local_id=..., label='some_label_id')``
+         - subclass of Measure object used in the compute model: SimpleMeasure, PopDateMeasure, PopDatasetMeasure,
+           ArithmeticMeasure
+
         :param filter_by: optionally specify filters to apply during computation on the server, reference to filtering
-            column can be one of:
-            - string reference to item key
-            - object identifier in string form
-            - object identifier: ObjId(id='some_label_id', type='<type>')
-            - Attribute or Metric depending on type of filter
-        :param auto_index: optionally force creation of DataFrame without index even if the contents of items make it
-            eligible for indexing
+         column can be one of:
+
+         - string reference to item key
+         - object identifier in string form
+         - object identifier: ``ObjId(id='some_label_id', type='<type>')``
+         - Attribute or Metric depending on type of filter
+
         :return: pandas dataframe instance
         """
         resolved_attr_cols: dict[str, LabelItemDef] = dict()
@@ -186,20 +198,21 @@ class DataFrameFactory:
         This method will create DataFrame with or without index - depending on the contents of the insight. The
         rules are as follows:
 
-            - if the insight contains both attributes and measures, it will be mapped to a DataFrame with index
-               - if there are multiple attributes, hieararchical index (pandas.MultiIndex) will be used
-               - otherwise a normal index will be used (pandas.Index)
-               - you can use the option 'auto_index' argument to disable this logic and force no indexing
+        - if the insight contains both attributes and measures, it will be mapped to a DataFrame with index
 
-            - if the insight contains either only attributes or only measures, then DataFrame will not be indexed
-              and all attribute or measures values will be used as data.
+          - if there are multiple attributes, hieararchical index (pandas.MultiIndex) will be used
+          - otherwise a normal index will be used (pandas.Index)
+          - you can use the option 'auto_index' argument to disable this logic and force no indexing
 
-           Note that if the insight consists of single measure only, the resulting data frame is guaranteed to have
-           single 'row' of data with one column per measure.
+        - if the insight contains either only attributes or only measures, then DataFrame will not be indexed
+          and all attribute or measures values will be used as data.
+
+        Note that if the insight consists of single measure only, the resulting data frame is guaranteed to have
+        single 'row' of data with one column per measure.
 
         :param insight_id: insight identifier
         :param auto_index: optionally force creation of DataFrame without index even if the data in the insight is
-            eligible for indexing
+         eligible for indexing
 
         :return: pandas dataframe instance
         """

--- a/gooddata-pandas/gooddata_pandas/series.py
+++ b/gooddata-pandas/gooddata_pandas/series.py
@@ -27,29 +27,32 @@ class SeriesFactory:
 
         :param index_by: label to index by; specify either:
 
-         - string with id: 'some_label_id',
-         - object identifier: ObjId(id='some_label_id', type='label'),
-         - string representation of object identifier: 'label/some_label_id'
-         - or an Attribute object used in the compute model: Attribute(local_id=..., label='some_label_id')
+         - string with id: ``some_label_id``,
+         - object identifier: ``ObjId(id='some_label_id', type='label')``,
+         - string representation of object identifier: ``label/some_label_id``
+         - or an Attribute object used in the compute model: ``Attribute(local_id=..., label='some_label_id')``
          - dict containing mapping of index name to label to use for indexing - specified in one of the ways list above
 
         :param data_by: label, fact or metric to that will provide data (metric values or label elements); specify
          either:
 
-         - object identifier: ObjId(id='some_id', type='<type>') - where type is either 'label', 'fact' or 'metric'
-         - string representation of object identifier: '<type>/some_id' - where type is either 'label', 'fact' or
-           'metric'
-         - Attribute object used in the compute model: Attribute(local_id=..., label='some_label_id')
-         - SimpleMetric object used in the compute model: SimpleMetric(local_id=..., item=..., aggregation=...)
+         - object identifier: ``ObjId(id='some_id', type='<type>')`` - where type is either ``label``, ``fact``
+           or ``metric``
+         - string representation of object identifier: ``<type>/some_id`` - where type is either ``label``, ``fact`` or
+           ``metric``
+         - Attribute object used in the compute model: ``Attribute(local_id=..., label='some_label_id')``
+         - SimpleMetric object used in the compute model: ``SimpleMetric(local_id=..., item=..., aggregation=...)``
 
         :param filter_by: optionally specify filter to apply during computation on the server, reference to filtering
-            column can be one of:
-            - string reference to index key
-            - object identifier in string form
-            - object identifier: ObjId(id='some_label_id', type='<type>')
-            - Attribute or Metric depending on type of filter
+         column can be one of:
 
-        :return pandas series instance
+         - string reference to index key
+         - object identifier in string form
+         - object identifier: ``ObjId(id='some_label_id', type='<type>')``
+         - Attribute or Metric depending on type of filter
+
+        :return: pandas series instance
+
         """
         data, index = compute_and_extract(
             self._sdk,
@@ -77,29 +80,31 @@ class SeriesFactory:
 
         :param data_by: label, fact or metric to get data from; specify either:
 
-         - object identifier: ObjId(id='some_id', type='<type>') - where type is either 'label', 'fact' or 'metric'
-         - string representation of object identifier: '<type>/some_id' - where type is either 'label', 'fact' or
-           'metric'
-         - Attribute object used in the compute model: Attribute(local_id=..., label='some_label_id')
-         - SimpleMetric object used in the compute model: SimpleMetric(local_id=..., item=..., aggregation=...)
+         - object identifier: ``ObjId(id='some_id', type='<type>')`` - where type is either ``label``, ``fact``
+           or ``metric``
+         - string representation of object identifier: ``<type>/some_id`` - where type is either ``label``, ``fact`` or
+           ``metric``
+         - Attribute object used in the compute model: ``Attribute(local_id=..., label='some_label_id')``
+         - SimpleMetric object used in the compute model: ``SimpleMetric(local_id=..., item=..., aggregation=...)``
 
         :param granularity: optionally specify label to slice the metric by; specify either:
 
-         - string with id: 'some_label_id',
-         - object identifier: ObjId(id='some_label_id', type='label'),
-         - string representation of object identifier: 'label/some_label_id'
-         - or an Attribute object used in the compute model: Attribute(local_id=..., label='some_label_id')
+         - string with id: ``some_label_id``,
+         - object identifier: ``ObjId(id='some_label_id', type='label')``,
+         - string representation of object identifier: ``label/some_label_id``
+         - or an Attribute object used in the compute model: ``Attribute(local_id=..., label='some_label_id')``
          - list containing multiple labels to slice the metric by - specified in one of the ways list above
          - dict containing mapping of index name to label to use for indexing - specified in one of the ways list above;
            this option is available so that you can easily switch from indexed factory method to this one if needed
 
         :param filter_by: optionally specify filter to apply during computation on the server, reference to filtering
-            column can be one of:
-            - object identifier in string form
-            - object identifier: ObjId(id='some_label_id', type='<type>')
-            - Attribute or Metric depending on type of filter
+         column can be one of:
 
-        :return pandas series instance
+         - object identifier in string form
+         - object identifier: ``ObjId(id='some_label_id', type='<type>')``
+         - Attribute or Metric depending on type of filter
+
+        :return: pandas series instance
         """
 
         if isinstance(granularity, list):

--- a/gooddata-sdk/gooddata_sdk/catalog/workspace/model_container.py
+++ b/gooddata-sdk/gooddata_sdk/catalog/workspace/model_container.py
@@ -55,7 +55,7 @@ class CatalogWorkspaceContent:
 
         :return: instance of CatalogMetric or None if no such metric in catalog
 
-        :rtype CatalogMetric
+        :rtype: CatalogMetric
         """
         if isinstance(metric_id, ObjId):
             obj_id_str = str(metric_id)
@@ -68,14 +68,14 @@ class CatalogWorkspaceContent:
 
     def get_dataset(self, dataset_id: Union[str, ObjId]) -> Union[CatalogDataset, None]:
         """
-        Gets dataset by id. The id can be either an instance of ObjId or string containing serialized ObjId
-        ('dataset/some.dataset.id') or contain just the id part ('some.dataset.id').
+        Gets dataset by id. The id can be either an instance of ObjId or string containing serialized ``ObjId
+        ('dataset/some.dataset.id')`` or contain just the id part (``some.dataset.id``).
 
         :param dataset_id: fully qualified dataset entity id (type/id) or just the identifier of dataset entity
 
         :return: instance of CatalogDataset or None if no such dataset in catalog
 
-        :rtype CatalogDataset
+        :rtype: CatalogDataset
         """
         if isinstance(dataset_id, ObjId):
             obj_id_str = str(dataset_id)
@@ -106,11 +106,11 @@ class CatalogWorkspaceContent:
         the filtered catalog will contain only those entities that can be safely added on top of that existing context.
 
         :param ctx: existing context. you can specify context in one of the following ways:
-            - single item or list of items from the execution model
-            - single item or list of items from catalog model; catalog fact, label or metric may be added
-            - the entire execution definition that is used to compute analytics
 
-        :return:
+         - single item or list of items from the execution model
+         - single item or list of items from catalog model; catalog fact, label or metric may be added
+         - the entire execution definition that is used to compute analytics
+
         """
         valid_objects = self._valid_objects(ctx)
 

--- a/gooddata-sdk/gooddata_sdk/catalog/workspace/service.py
+++ b/gooddata-sdk/gooddata_sdk/catalog/workspace/service.py
@@ -75,6 +75,7 @@ class CatalogWorkspaceService(CatalogServiceBase):
     def get_workspace(self, workspace_id: str) -> CatalogWorkspace:
         """
         Gets workspace content and returns it as CatalogWorkspace object.
+
         :param workspace_id: An input string parameter of workspace id.
         :return: CatalogWorkspace object containing structure of workspace.
         """
@@ -196,7 +197,6 @@ class CatalogWorkspaceContentService(CatalogServiceBase):
         Retrieves catalog for a workspace. Catalog contains all data sets and metrics defined in that workspace.
 
         :param workspace_id: workspace identifier
-        :return:
         """
         get_datasets = functools.partial(
             self._entities_api.get_all_entities_datasets,
@@ -253,12 +253,13 @@ class CatalogWorkspaceContentService(CatalogServiceBase):
 
         :param workspace_id: workspace identifier
         :param ctx: items already in context. you can specify context in one of the following ways:
-            - single item or list of items from the execution model
-            - single item or list of items from catalog model; catalog fact, label or metric may be added
-            - the entire execution definition that is used to compute analytics
+
+         - single item or list of items from the execution model
+         - single item or list of items from catalog model; catalog fact, label or metric may be added
+         - the entire execution definition that is used to compute analytics
 
         :return: a dict of sets; type of available object is used as key in the dict,
-            the value is a set containing id's of available items
+         the value is a set containing id's of available items
         """
         if isinstance(ctx, ExecutionDefinition):
             afm = compute_model_to_api_model(attributes=ctx.attributes, metrics=ctx.metrics, filters=ctx.filters)

--- a/gooddata-sdk/gooddata_sdk/compute/model/execution.py
+++ b/gooddata-sdk/gooddata_sdk/compute/model/execution.py
@@ -151,9 +151,6 @@ class ExecutionResponse:
     def read_result(self, limit: Union[int, list[int]], offset: Union[None, int, list[int]] = None) -> ExecutionResult:
         """
         Reads from the execution result.
-        :param offset:
-        :param limit:
-        :return:
         """
 
         _offset = offset if isinstance(offset, list) else [offset] if offset is not None else None
@@ -192,7 +189,6 @@ def compute_model_to_api_model(
     :param attributes: optionally specify list of attributes
     :param metrics: optionally specify list of metrics
     :param filters: optionally specify list of filters
-    :return:
     """
     return models.AFM(
         attributes=[a.as_api_model() for a in attributes] if attributes is not None else [],

--- a/gooddata-sdk/gooddata_sdk/compute/service.py
+++ b/gooddata-sdk/gooddata_sdk/compute/service.py
@@ -22,9 +22,7 @@ class ComputeService:
 
         :param workspace_id: workspace identifier
         :param exec_def: execution definition - this prescribes what to calculate, how to place labels and metric values
-            into dimensions
-
-        :return:
+         into dimensions
         """
         response = self._actions_api.compute_report(workspace_id, exec_def.as_api_model(), _check_return_type=False)
 

--- a/gooddata-sdk/gooddata_sdk/insight.py
+++ b/gooddata-sdk/gooddata_sdk/insight.py
@@ -280,6 +280,7 @@ class InsightMetric:
         """
         If this is a time comparison metric, return local_id of the master metric from which it is
         derived.
+
         :return: local_id of master metric, None if not a time comparison metric
         """
         if "popMeasureDefinition" in self._d:

--- a/gooddata-sdk/gooddata_sdk/support.py
+++ b/gooddata-sdk/gooddata_sdk/support.py
@@ -19,6 +19,7 @@ class SupportService:
         """
         Checks if GD.CN is available.
         Can raise exceptions in case of authentication or authorization failure.
+
         :return: True - available, False - not available
         """
         try:
@@ -37,11 +38,13 @@ class SupportService:
     def wait_till_available(self, timeout: int, sleep_time: float = 2.0) -> None:
         """
         Wait till GD.CN service is available. When timeout is:
+
           - > 0 exception is raised after given number of seconds.
           - = 0 exception is raised whe service is not available immediately
           - < 0 no timeout
 
         Method propagates is_available exceptions.
+
         :param timeout: seconds to wait to service to be available (see method description for details)
         :param sleep_time: seconds to wait between GD.CN availability tests
         """

--- a/gooddata-sdk/gooddata_sdk/table.py
+++ b/gooddata-sdk/gooddata_sdk/table.py
@@ -60,8 +60,6 @@ class ExecutionTable:
     def column_ids(self) -> list[str]:
         """
         Returns column identifiers. Each row will be a mapping of column identifier to column data.
-
-        :return:
         """
         return [a.local_id for a in self.attributes] + [m.local_id for m in self.metrics]
 
@@ -70,7 +68,6 @@ class ExecutionTable:
         """
         Returns mapping of column identifier to definition of either attribute whose elements will be in that column
         or metric whose value will be calculated in that column.
-        :return:
         """
         return {**{a.local_id: a for a in self.attributes}, **{m.local_id: m for m in self.metrics}}
 

--- a/gooddata-sdk/gooddata_sdk/type_converter.py
+++ b/gooddata-sdk/gooddata_sdk/type_converter.py
@@ -121,6 +121,7 @@ class TypeConverterRegistry:
     def __init__(self, type_name: str):
         """
         Initialize instance with type for which instance is going to be responsible
+
         :param type_name: type name
         """
         self._type_name = type_name
@@ -131,6 +132,7 @@ class TypeConverterRegistry:
         """
         Register converter instance for given sub-type (granularity). If sub-type is not specified, converter is
         registered as the default one for the whole type. Default converter can be registered only once.
+
         :param converter: converter instance
         :param sub_type: sub-type name
         """
@@ -142,6 +144,7 @@ class TypeConverterRegistry:
     def _register_with_sub_type(self, converter: Converter, sub_type: str) -> None:
         """
         Register converter instance for given sub-type granularity.
+
         :param converter: converter instance
         :param sub_type: sub-type name
         """
@@ -157,6 +160,7 @@ class TypeConverterRegistry:
     def _register_default(self, converter: Converter) -> None:
         """
         Register default converter instance for the type. Default type can be registered only once.
+
         :param converter: converter instance
         """
         if self._default_converter:
@@ -173,6 +177,7 @@ class TypeConverterRegistry:
         Find and return converter instance for a given sub-type. Default converter instance is returned
         if the sub-type is not found or not provided. When a default converter is not registered, ValueError
         exception is raised.
+
         :param sub_type: sub-type name
         :return: Converter instance
         """
@@ -187,6 +192,7 @@ class TypeConverterRegistry:
     def _get_default_converter(self) -> Converter:
         """
         Check if default converter is registered. If yes, return it. Otherwise raise ValueError exception.
+
         :return: default Converter instance
         """
         if not self._default_converter:
@@ -208,6 +214,7 @@ class ConverterRegistryStore:
     def _get_registry(cls, type_name: str) -> TypeConverterRegistry:
         """
         Return TypeConverterRegistry instance registered for given type. If no such instance exists, it is created.
+
         :param type_name: type name
         :return: TypeConverterRegistry instance for given type name
         """
@@ -222,6 +229,7 @@ class ConverterRegistryStore:
         """
         Register Converter instance created from provided Converter class to given type and list of sub types.
         When sub types are not provided, converter is registered as the default one for given type.
+
         :param type_name: type name
         :param class_converter: Converter class
         :param sub_types: list of sub types or None (default type Converter)
@@ -237,6 +245,7 @@ class ConverterRegistryStore:
     def find_converter(cls, type_name: str, sub_type: Optional[str] = None) -> Converter:
         """
         Find Converter for given type and sub type.
+
         :param type_name: type name
         :param sub_type: sub type name
         """

--- a/gooddata-sdk/gooddata_sdk/utils.py
+++ b/gooddata-sdk/gooddata_sdk/utils.py
@@ -79,7 +79,6 @@ def load_all_entities(get_page_func: functools.partial[Any], page_size: int = 50
 
     :param get_page_func: an API controller from the metadata client
     :param page_size: optionally specify page length, default is 500
-    :return:
     """
     all_paged_entities = AllPagedEntities(data=[], included=[])
     current_page = 0


### PR DESCRIPTION
It seems that docstring annotations are quite fragile and have to follow very strict indentation rules to be parsed correctly by Sphinx autodoc. We should investigate if it's possible to automate this with some linters.