### PR TITLE
TRIVIAL: dual sonar setup

### DIFF
--- a/.sonar.settings
+++ b/.sonar.settings
@@ -1,4 +1,4 @@
-# (C) 2022 GoodData Corporation
+# (C) 2021 GoodData Corporation
 sonar.sources=gooddata-sdk,gooddata-fdw,gooddata-pandas
 sonar.exclusions=gooddata-afm-client/**/*,gooddata-metadata-client/**/*,gooddata-scan-client/**/*
 sonar.python.version=3.7, 3.8, 3.9, 3.10


### PR DESCRIPTION
- Retrun back custom setup for sonarqube. It is hopefully just temporary action.
- Tune setup for both sonarqube and sonarcloud - specify supported
  python versions