### PR TITLE
TRIVIAL: Add github action to trigger sonarcloud scan

### DIFF
--- a/.github/workflows/sonarcloud.yaml
+++ b/.github/workflows/sonarcloud.yaml
@@ -1,0 +1,29 @@
+name: sonarcloud
+on: 
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  sonarcloud:
+    name: SonarCloud
+    strategy:
+      matrix:
+        component:
+          - gooddata-pandas
+          - gooddata-fdw
+          - gooddata-sdk
+          - tests-support
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          projectBaseDir: ${{ matrix.component }}

--- a/.github/workflows/sonarcloud.yaml
+++ b/.github/workflows/sonarcloud.yaml
@@ -1,5 +1,6 @@
 name: sonarcloud
 on: 
+  workflow_dispatch:
   push:
     branches:
       - master

--- a/gooddata-fdw/sonar-project.properties
+++ b/gooddata-fdw/sonar-project.properties
@@ -1,0 +1,6 @@
+sonar.projectKey=gooddata_python-sdk_gooddata-fdw
+sonar.organization=gooddata-github
+sonar.projectName=GoddData Foreign Data Wrapper
+sonar.python.version=3.7, 3.8, 3.9, 3.10
+sonar.sources=gooddata_fdw
+sonar.tests=tests

--- a/gooddata-pandas/sonar-project.properties
+++ b/gooddata-pandas/sonar-project.properties
@@ -1,0 +1,6 @@
+sonar.projectKey=gooddata_python-sdk_gooddata-pandas
+sonar.organization=gooddata-github
+sonar.projectName=GoodData Pandas
+sonar.python.version=3.7, 3.8, 3.9, 3.10
+sonar.sources=gooddata_pandas
+sonar.tests=tests

--- a/gooddata-sdk/sonar-project.properties
+++ b/gooddata-sdk/sonar-project.properties
@@ -1,0 +1,6 @@
+sonar.projectKey=gooddata_python-sdk_gooddata-sdk
+sonar.organization=gooddata-github
+sonar.projectName=GoddData Python SDK
+sonar.python.version=3.7, 3.8, 3.9, 3.10
+sonar.sources=gooddata_sdk
+sonar.tests=tests

--- a/tests-support/sonar-project.properties
+++ b/tests-support/sonar-project.properties
@@ -1,0 +1,5 @@
+sonar.projectKey=gooddata_python-sdk_tests-support
+sonar.organization=gooddata-github
+sonar.projectName=GoddData Tests support for Python SDK
+sonar.python.version=3.7, 3.8, 3.9, 3.10
+sonar.tests=.


### PR DESCRIPTION
The action runs for each component separately => updates
four sonarcloud projects.