### PR TITLE
XSH-867: Use None in DataFrame index/column names for missing headers

### DIFF
--- a/gooddata-pandas/gooddata_pandas/result_convertor.py
+++ b/gooddata-pandas/gooddata_pandas/result_convertor.py
@@ -232,7 +232,7 @@ def _create_header_mapper(
     dim: int,
     label_overrides: Optional[LabelOverrides] = None,
     use_local_ids_in_headers: bool = False,
-) -> Callable[[Any, Optional[int]], str]:
+) -> Callable[[Any, Optional[int]], Optional[str]]:
     """
     Prepares header mapper function which is doing header structures translations into appropriate label used
     in a dataframe
@@ -250,8 +250,8 @@ def _create_header_mapper(
     attribute_labels = label_overrides.get("labels", {})
     measure_labels = label_overrides.get("metrics", {})
 
-    def _mapper(header: Any, header_idx: Optional[int]) -> str:
-        label = ""
+    def _mapper(header: Any, header_idx: Optional[int]) -> Optional[str]:
+        label = None
         if header is None:
             pass
         elif "attributeHeader" in header:


### PR DESCRIPTION
* because pandas.io.formats.style.Styler.to_excel expects empty headers with None otherwise it takes the value and prints it which is not expected for empty string in this case