### PR TITLE
XSH-835: Pass traceId to pythonSDK

### DIFF
--- a/gooddata-pandas/gooddata_pandas/utils.py
+++ b/gooddata-pandas/gooddata_pandas/utils.py
@@ -1,7 +1,11 @@
 # (C) 2021 GoodData Corporation
 from __future__ import annotations
 
+import datetime
 import hashlib
+import json
+import logging
+import os
 import uuid
 from typing import Any, Dict, Optional, Union
 
@@ -124,3 +128,19 @@ class DefaultInsightColumnNaming:
         id_to_use = measure.item_id or measure.alias or measure.title or measure.local_id
 
         return self._ensure_unique(id_to_use)
+
+
+def log_info(trace_ids: list, message: str) -> None:
+    logger = logging.getLogger(__name__)
+    logger.info(
+        json.dumps(
+            {
+                "ts": datetime.datetime.now().astimezone().isoformat(),
+                "level": "INFO",
+                "app": "gooddata-python-sdk",
+                "pid": str(os.getpid()),
+                "trace_id": ", ".join(map(lambda x: x if x is not None else "N/A", trace_ids)),
+                "msg": message,
+            }
+        )
+    )

--- a/gooddata-sdk/gooddata_sdk/__init__.py
+++ b/gooddata-sdk/gooddata_sdk/__init__.py
@@ -84,6 +84,7 @@ from gooddata_sdk.compute.model.execution import (
     ExecutionDefinition,
     ExecutionResponse,
     ExecutionResult,
+    ExecutionResultWithHttpHeaders,
     ResultCacheMetadata,
     ResultSizeBytesLimitExceeded,
     ResultSizeDimensions,

--- a/gooddata-sdk/gooddata_sdk/client.py
+++ b/gooddata-sdk/gooddata_sdk/client.py
@@ -96,6 +96,10 @@ class GoodDataApiClient:
         headers["X-GDC-VALIDATE-RELATIONS"] = "true"
 
     @property
+    def get_headers(self) -> dict[str, str]:
+        return self._custom_headers
+
+    @property
     def afm_client(self) -> afm_client.ApiClient:
         warn(
             "This property is deprecated and it will be removed in PythonSDK 2.0. "

--- a/gooddata-sdk/gooddata_sdk/compute/service.py
+++ b/gooddata-sdk/gooddata_sdk/compute/service.py
@@ -42,6 +42,6 @@ class ComputeService:
         """
         return ResultCacheMetadata(
             result_cache_metadata=self._actions_api.retrieve_execution_metadata(
-                workspace_id, result_id, _check_return_type=False
+                workspace_id, result_id, _check_return_type=False, _return_http_data_only=False
             )
         )

--- a/gooddata-sdk/gooddata_sdk/utils.py
+++ b/gooddata-sdk/gooddata_sdk/utils.py
@@ -2,9 +2,15 @@
 from __future__ import annotations
 
 import functools
-import os
 import re
 import typing
+import datetime
+import json
+import logging
+import os
+import sys
+import traceback
+
 from pathlib import Path
 from shutil import rmtree
 from typing import Any, Callable, Dict, NamedTuple, Union, cast
@@ -16,7 +22,7 @@ from gooddata_sdk.compute.model.base import ObjId
 
 # Use typing collection types to support python < py3.9
 IdObjType = Union[str, ObjId, Dict[str, Dict[str, str]], Dict[str, str]]
-
+LOG_LEVELS_WITH_TRACEBACK = ["DEBUG", "ERROR", "CRITICAL"]
 
 def id_obj_to_key(id_obj: IdObjType) -> str:
     """
@@ -195,3 +201,58 @@ def change_case(dictionary: dict, case: Callable[[str], str]) -> dict:
     for k, v in dictionary.items():
         temp[case(k)] = change_case_helper(v, case)
     return temp
+
+
+class Logger:
+    """
+    Wrapper around native logging to provide structured logs
+    """
+
+    def __init__(self, app: str, level: str, format: str = "JSON"):
+        self.app = app
+        self.format = format.upper()
+        if self.format not in ["PLAIN", "JSON"]:
+            raise Exception("invalid logformat")
+        logging.basicConfig(level=level.upper(), format="%(message)s")
+
+    def compose(self, loglevel: str, message: str, **kwargs: str) -> str:
+        include_exc = loglevel in LOG_LEVELS_WITH_TRACEBACK
+        base = {}
+        base["ts"] = datetime.datetime.now().astimezone().isoformat()
+        base["level"] = loglevel
+        base["app"] = self.app
+        base["pid"] = str(os.getpid())
+        base["msg"] = message
+        if include_exc:
+            exception_tb = sys.exc_info()[2]
+            base["exc"] = "N/A" if exception_tb is None else "".join(traceback.format_tb(exception_tb))
+        if self.format == "PLAIN":
+            composed_msg = "[%s] [%s:%s] [%s] %s %s" % (
+                base["ts"],
+                base["app"],
+                base["pid"],
+                base["level"],
+                base["msg"],
+                json.dumps(kwargs, ensure_ascii=False),
+            )
+            if include_exc:
+                composed_msg += f" {base['exc']}"
+            return composed_msg
+        elif self.format == "JSON":
+            return json.dumps(kwargs | base, ensure_ascii=False)
+        return ""
+
+    def debug(self, message: str, **kwargs: str) -> None:
+        logging.debug(self.compose("DEBUG", message, **kwargs))
+
+    def info(self, message: str, **kwargs: str) -> None:
+        logging.info(self.compose("INFO", message, **kwargs))
+
+    def warn(self, message: str, **kwargs: str) -> None:
+        logging.warn(self.compose("WARNING", message, **kwargs))
+
+    def error(self, message: str, **kwargs: str) -> None:
+        logging.error(self.compose("ERROR", message, **kwargs))
+
+    def critical(self, message: str, **kwargs: str) -> None:
+        logging.critical(self.compose("CRITICAL", message, **kwargs))


### PR DESCRIPTION
Log traceIds passed using additional headers from client application and add traceIds passed from afm_exec_api