### PR TITLE
PSDK-122: Update docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,8 +34,6 @@ services:
     build:
       context: .
       dockerfile: tests-support/Dockerfile
-    volumes:
-      - ./tests-support/fixtures:/app/fixtures
     environment:
       FIXTURES_DIR: /app/fixtures
       HOST: "http://gooddata-cn-ce:3000"

--- a/tests-support/Dockerfile
+++ b/tests-support/Dockerfile
@@ -13,6 +13,7 @@ RUN set -x \
 USER ${USER_NAME}
 WORKDIR /app
 COPY ./tests-support/requirements.txt /app/requirements.txt
+COPY ./tests-support/fixtures /app/fixtures
 
 RUN set -x \
   && pip3 install --no-cache-dir --user -r requirements.txt \


### PR DESCRIPTION
Update test-support/Dockerfile, so docker-compose.yaml can be reused in the demos/workshops by changing context to Python SDK repo without need to clone the whole repo.