### PR TITLE
BUGFIX: Get only docs/content/en from a PR

### DIFF
--- a/.github/workflows/netlify-deploy-preview.yaml
+++ b/.github/workflows/netlify-deploy-preview.yaml
@@ -16,10 +16,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
         with:
           submodules: recursive
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
+          path: 'PR-tmp'
+      - name: Get only changed docs
+        run: |
+          rsync --delete -av PR-tmp/docs/content/en/ docs/content/en/
+          rm -rf PR-tmp
       - name: Generate Versioned Docs
         uses: gooddata/gooddata-python-sdk/.github/actions/hugo-build-versioned-action@master
         with:


### PR DESCRIPTION
When we build the preview in pull_request_target action we want to get only docs/content/en (the actual documentation files) from the PR.
The rest of the repository can be used from master branch (and fork). This is more secure as we don't allow users to inject malicious commands in the building process (e.g. scripts in package.json files).