### PR TITLE
RELATED: PSDK-149 fix failed fdw docker image build with postgres:12.15

### DIFF
--- a/gooddata-fdw/Dockerfile
+++ b/gooddata-fdw/Dockerfile
@@ -1,5 +1,5 @@
 # (C) 2021 GoodData Corporation
-FROM postgres:12-alpine
+FROM postgres:12.14-alpine
 
 #
 # Docker image that adds multicorn & gooddata-fdw on top of official PostgreSQL image.


### PR DESCRIPTION
There were several issues with the latest postgres:12.15. First, docker-compose build gooddata-fdw stopped working out of the box with the missing pg_config. I tried to fix it by adding libpq-dev, but it failed with an incompatible version of clang. The expected version is 15, but the installed is 16. Therefore, I decided to lock the base image to postgres:12.14-alpine which works.