### PR TITLE
PSDK-152: fix paths in .readthedocs.yaml

### DIFF
--- a/gooddata-fdw/.readthedocs.yaml
+++ b/gooddata-fdw/.readthedocs.yaml
@@ -12,8 +12,8 @@ build:
     python: "3.11"
 
 sphinx:
-  configuration: docs/conf.py
+  configuration: gooddata-fdw/docs/conf.py
 
 python:
   install:
-    - requirements: docs/requirements.txt
+    - requirements: gooddata-fdw/docs/requirements.txt

--- a/gooddata-pandas/.readthedocs.yaml
+++ b/gooddata-pandas/.readthedocs.yaml
@@ -12,8 +12,8 @@ build:
     python: "3.11"
 
 sphinx:
-  configuration: docs/conf.py
+  configuration: gooddata-pandas/docs/conf.py
 
 python:
   install:
-    - requirements: docs/requirements.txt
+    - requirements: gooddata-pandas/docs/requirements.txt


### PR DESCRIPTION
Documentation is not very clear. It turned out, paths are relative to the root of repository.