### PR TITLE
Add missing url param to ds patch attributes

### DIFF
--- a/gooddata-sdk/gooddata_sdk/catalog/data_source/service.py
+++ b/gooddata-sdk/gooddata_sdk/catalog/data_source/service.py
@@ -105,7 +105,10 @@ class CatalogDataSourceService(CatalogServiceBase):
         # TODO - workaround solution getting data source type from backend
         #      - once backend accepts empty value in this field (enum), remove this code
         current_ds = self.get_data_source(data_source_id)
+
+        # Both or neither of the two (type, url) have to be defined in single patch call
         attributes["type"] = attributes.get("type", current_ds.type)
+        attributes["url"] = attributes.get("url", current_ds.url)
 
         self._entities_api.patch_entity_data_sources(
             data_source_id, CatalogDataSource.to_api_patch(data_source_id, attributes)

--- a/gooddata-sdk/tests/catalog/fixtures/data_sources/patch.yaml
+++ b/gooddata-sdk/tests/catalog/fixtures/data_sources/patch.yaml
@@ -82,9 +82,9 @@ interactions:
                 url: jdbc:postgresql://localhost:5432/demo
                 username: demouser
                 enableCaching: false
+                name: demo-test-ds
                 type: POSTGRESQL
                 schema: demo
-                name: demo-test-ds
               links:
                 self: http://localhost:3000/api/v1/entities/dataSources/demo-test-ds
           links:
@@ -167,7 +167,7 @@ interactions:
             to access it.
           status: 404
           title: Not Found
-          traceId: 45ad921e28cc4c12
+          traceId: 141fcb42d8b3bd9a
   - request:
       method: POST
       uri: http://localhost:3000/api/v1/entities/dataSources
@@ -265,9 +265,9 @@ interactions:
               enableCaching: true
               cachePath:
                 - cache_schema
+              name: Test
               type: POSTGRESQL
               schema: demo
-              name: Test
           links:
             self: http://localhost:3000/api/v1/entities/dataSources/test
   - request:
@@ -352,9 +352,9 @@ interactions:
               enableCaching: true
               cachePath:
                 - cache_schema
+              name: Test
               type: POSTGRESQL
               schema: demo
-              name: Test
           links:
             self: http://localhost:3000/api/v1/entities/dataSources/test
   - request:
@@ -439,9 +439,9 @@ interactions:
               enableCaching: true
               cachePath:
                 - cache_schema
+              name: Test
               type: POSTGRESQL
               schema: demo
-              name: Test
           links:
             self: http://localhost:3000/api/v1/entities/dataSources/test
   - request:
@@ -452,6 +452,7 @@ interactions:
           attributes:
             name: Test2
             type: POSTGRESQL
+            url: jdbc:postgresql://localhost:5432/demo?autosave=true
           id: test
           type: dataSource
       headers:
@@ -534,9 +535,9 @@ interactions:
               enableCaching: true
               cachePath:
                 - cache_schema
+              name: Test2
               type: POSTGRESQL
               schema: demo
-              name: Test2
           links:
             self: http://localhost:3000/api/v1/entities/dataSources/test
   - request:
@@ -621,9 +622,9 @@ interactions:
               enableCaching: true
               cachePath:
                 - cache_schema
+              name: Test2
               type: POSTGRESQL
               schema: demo
-              name: Test2
           links:
             self: http://localhost:3000/api/v1/entities/dataSources/test
   - request:


### PR DESCRIPTION
Caused by following change in upstream API: https://github.com/gooddata/gdc-nas/commit/4a81a447e7541bfbf5ae691342c228b3138e00dd