### PR TITLE
TRIVIAL: bump version of dependency

### DIFF
--- a/gooddata-dbt/setup.py
+++ b/gooddata-dbt/setup.py
@@ -5,7 +5,7 @@ version = {}
 with open("gooddata_dbt/_version.py") as fp:
     exec(fp.read(), version)
 
-REQUIRES = ["gooddata-sdk~=1.4.0", "pyyaml>=5.1", "attrs==21.4.0", "cattrs==22.1.0", "requests~=2.31.0"]
+REQUIRES = ["gooddata-sdk~=1.7.0", "pyyaml>=5.1", "attrs==21.4.0", "cattrs==22.1.0", "requests~=2.31.0"]
 
 setup(
     name="gooddata-dbt",


### PR DESCRIPTION
Note: This is only a temporal fix. It's necessary to adapt tbump rule for gooddata-dbt plugin.