### PR TITLE
WEB-4008: Clean up redirects in docs

### DIFF
--- a/docs/content/en/docs/_index.md
+++ b/docs/content/en/docs/_index.md
@@ -10,7 +10,7 @@ cascade:
     path: "/*/**"
 ---
 
-GoodData Python SDK provides a clean and convenient way to interact with the [GoodData API](https://www.gooddata.com/developers/cloud-native/doc/cloud/api-and-sdk/api/) in Python applications.
+GoodData Python SDK provides a clean and convenient way to interact with the [GoodData API](https://www.gooddata.com/docs/cloud/api-and-sdk/api/) in Python applications.
 
 Python is a popular language for working with large amounts of data and data analytics; It is for this reason that we are actively developing this SDK to let Python developers integrate the GoodData analytical engine into their own applications as seamlessly as possible, or to automate their administrative workflow.
 
@@ -108,7 +108,7 @@ You can also perform certain administration tasks:
 
 Get started with Python SDK right now by following the [Quick Start](./getting-started/#quick-start) guide.
 
-New to GoodData? Follow the [Getting Started](https://www.gooddata.com/developers/cloud-native/doc/cloud/getting-started/) series of articles that include Python SDK code examples.
+New to GoodData? Follow the [Getting Started](https://www.gooddata.com/docs/cloud/getting-started/) series of articles that include Python SDK code examples.
 
 ### Troubleshooting
 

--- a/docs/content/en/docs/administration/organization/_index.md
+++ b/docs/content/en/docs/administration/organization/_index.md
@@ -7,7 +7,7 @@ no_list: true
 
 Manage an organization.
 
-See [Manage Organizations](https://www.gooddata.com/developers/cloud-native/doc/cloud/manage-deployment/set-up-organizations/manage-organizations/) to learn how organizations work in GoodData.
+See [Manage Organizations](https://www.gooddata.com/docs/cloud/manage-deployment/set-up-organizations/manage-organizations/) to learn how organizations work in GoodData.
 
 ## Methods
 

--- a/docs/content/en/docs/administration/permissions/_index.md
+++ b/docs/content/en/docs/administration/permissions/_index.md
@@ -7,7 +7,7 @@ no_list: true
 
 Manage workspace permissions.
 
-See [Manage Permissions](https://www.gooddata.com/developers/cloud-native/doc/cloud/manage-deployment/manage-permissions/) to learn how permissions work in GoodData.
+See [Manage Permissions](https://www.gooddata.com/docs/cloud/manage-deployment/manage-permissions/) to learn how permissions work in GoodData.
 
 ### Declarative Methods
 

--- a/docs/content/en/docs/administration/user-groups/_index.md
+++ b/docs/content/en/docs/administration/user-groups/_index.md
@@ -7,7 +7,7 @@ no_list: true
 
 Manage user groups.
 
-See [Manage Permissions](https://www.gooddata.com/developers/cloud-native/doc/cloud/manage-deployment/manage-permissions/) to learn how permissions work in GoodData.
+See [Manage Permissions](https://www.gooddata.com/docs/cloud/manage-deployment/manage-permissions/) to learn how permissions work in GoodData.
 
 
 ### Entity Methods

--- a/docs/content/en/docs/administration/users-and-user-groups/_index.md
+++ b/docs/content/en/docs/administration/users-and-user-groups/_index.md
@@ -7,7 +7,7 @@ no_list: true
 
 Manage users and user groups together.
 
-See [Manage Permissions](https://www.gooddata.com/developers/cloud-native/doc/cloud/manage-deployment/manage-permissions/) to learn how permissions work in GoodData.
+See [Manage Permissions](https://www.gooddata.com/docs/cloud/manage-deployment/manage-permissions/) to learn how permissions work in GoodData.
 
 ### Declarative Methods
 

--- a/docs/content/en/docs/administration/users/_index.md
+++ b/docs/content/en/docs/administration/users/_index.md
@@ -7,7 +7,7 @@ no_list: true
 
 Manage users.
 
-See [Manage Users and UserGroups](https://www.gooddata.com/developers/cloud-native/doc/cloud/manage-deployment/manage-users/) to learn how user management works in GoodData.
+See [Manage Users and UserGroups](https://www.gooddata.com/docs/cloud/manage-deployment/manage-users/) to learn how user management works in GoodData.
 
 
 ### Entity Methods

--- a/docs/content/en/docs/data/data-source/_index.md
+++ b/docs/content/en/docs/data/data-source/_index.md
@@ -7,7 +7,7 @@ no_list: true
 
 Manage data sources.
 
-See [Connect Data](https://www.gooddata.com/developers/cloud-native/doc/cloud/connect-data/) to learn how data sources work in GoodData.
+See [Connect Data](https://www.gooddata.com/docs/cloud/connect-data/) to learn how data sources work in GoodData.
 
 
 ### Entity Methods

--- a/docs/content/en/docs/data/physical-data-model/_index.md
+++ b/docs/content/en/docs/data/physical-data-model/_index.md
@@ -7,7 +7,7 @@ no_list: true
 
 Manage physical data models.
 
-See [Create a Physical Data Model](https://www.gooddata.com/developers/cloud-native/doc/cloud/model-data/create-pdm/) to about the physical data model in GoodData.
+See [Create a Physical Data Model](https://www.gooddata.com/docs/cloud/model-data/create-pdm/) to about the physical data model in GoodData.
 
 ## Methods
 

--- a/docs/content/en/docs/getting-started.md
+++ b/docs/content/en/docs/getting-started.md
@@ -12,7 +12,7 @@ Start integrating GoodData into your Python application right now.
 
 1. Ensure you have a running instance of GoodData. If you just want to try things out, we recommend you sign up for a [trial of GoodData Cloud](https://www.gooddata.com/trial/).
 
-1. [Create a personal access token for GoodData API](https://www.gooddata.com/developers/cloud-native/doc/cloud/getting-started/create-api-token/)
+1. [Create a personal access token for GoodData API](https://www.gooddata.com/docs/cloud/getting-started/create-api-token/)
 
 1. Import Python SDK into your script:
 

--- a/docs/content/en/docs/installation.md
+++ b/docs/content/en/docs/installation.md
@@ -7,7 +7,7 @@ weight: 11
 Before installing, ensure you are using:
 
 * Python `3.8` or newer
-* [GoodData.CN](https://www.gooddata.com/developers/cloud-native/doc/cloud/deploy-and-install/cloud-native/) or [GoodData Cloud](https://www.gooddata.com/developers/cloud-native/doc/cloud/deploy-and-install/cloud/)
+* [GoodData.CN](https://www.gooddata.com/docs/cloud/deploy-and-install/cloud-native/) or [GoodData Cloud](https://www.gooddata.com/docs/cloud/deploy-and-install/cloud/)
 * The [pip](https://pypi.org/project/pip/) package management tool
 
 

--- a/docs/content/en/docs/workspace-content/logical-data-model/_index.md
+++ b/docs/content/en/docs/workspace-content/logical-data-model/_index.md
@@ -7,7 +7,7 @@ no_list: true
 
 Manage logical data models.
 
-See [Create a Logical Data Model](https://www.gooddata.com/developers/cloud-native/doc/cloud/model-data/create-ldm/) to learn abour logical data models in GoodData.
+See [Create a Logical Data Model](https://www.gooddata.com/docs/cloud/model-data/create-ldm/) to learn abour logical data models in GoodData.
 
 ## Methods
 

--- a/docs/content/en/docs/workspace/workspace-data-filters/_index.md
+++ b/docs/content/en/docs/workspace/workspace-data-filters/_index.md
@@ -7,7 +7,7 @@ no_list: true
 
 Manage workspace data filters.
 
-See [Set Up Data Filters in Workspaces](https://www.gooddata.com/developers/cloud-native/doc/cloud/manage-deployment/manage-workspaces/workspace-data-filters/) to learn how workspace data filters work in GoodData.
+See [Set Up Data Filters in Workspaces](https://www.gooddata.com/docs/cloud/manage-deployment/manage-workspaces/workspace-data-filters/) to learn how workspace data filters work in GoodData.
 
 ## Methods
 

--- a/docs/layouts/partials/navbar.html
+++ b/docs/layouts/partials/navbar.html
@@ -20,7 +20,7 @@
         <a href="https://community.gooddata.com/" class="gd-docs-header-nav__menulink gd-header-link">Community</a>
       </li>
       <li class="gd-docs-header-nav__menuitem gd-header-link-item">
-        <a href="https://www.gooddata.com/developers/cloud-native/doc/cloud/" class="gd-docs-header-nav__menulink gd-header-link gd-header-link__active">Documentation</a>
+        <a href="https://www.gooddata.com/docs/cloud/" class="gd-docs-header-nav__menulink gd-header-link gd-header-link__active">Documentation</a>
       </li>
       <li class="gd-docs-header-nav__menuitem gd-header-link-item">
         <a href="https://support.gooddata.com/hc/en-us" class="gd-docs-header-nav__menulink gd-header-link">Support</a>


### PR DESCRIPTION
Removing all the redirects by replacing  /developers/cloud-native/ to /docs/cloud/.

Tried to build the documentation locally and no /developers/cloud-native/ links were present.