### PR TITLE
Remove unnecessary `peaceiris/actions-hugo` from hugo build actions

### DIFF
--- a/.github/actions/hugo-build-action/action.yaml
+++ b/.github/actions/hugo-build-action/action.yaml
@@ -8,24 +8,25 @@ inputs:
 runs:
   using: "composite"
   steps:
-  - name: "Setup GO"
-    uses: actions/setup-go@v4
-    with:
-      go-version: '>=1.20.1'
-  - name: "Setup Node"
-    uses: actions/setup-node@v3
-    with:
-      node-version: 18
-  - name: "Setup Hugo"
-    uses: peaceiris/actions-hugo@v3
-    with:
-      extended: true
-      hugo-version: '0.110.0'
-  - name: "Build"
-    env:
-      BASE_URL: ${{ inputs.base-url }}
-    shell: bash
-    run: |
-      cd docs
-      npm install
-      hugo --minify ${BASE_URL:+--baseURL $BASE_URL} -e _default
+    - name: "Setup GO"
+      uses: actions/setup-go@v5
+      with:
+        go-version: '>=1.20.1'
+    - name: "Setup Node"
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: 'npm'
+        cache-dependency-path: docs/package-lock.json
+    - name: "Install Dependencies"
+      shell: bash
+      working-directory: ./docs
+      run: |
+        npm ci
+    - name: "Build documentation"
+      working-directory: ./docs
+      env:
+        BASE_URL: ${{ inputs.base-url }}
+      shell: bash
+      run: |
+        hugo --minify ${BASE_URL:+--baseURL $BASE_URL} -e _default

--- a/.github/actions/hugo-build-versioned-action/action.yaml
+++ b/.github/actions/hugo-build-versioned-action/action.yaml
@@ -32,28 +32,34 @@ runs:
       run: |
         python -m pip install --upgrade pip
         pip install -r scripts/script-requirements.txt
-    - uses: actions/setup-go@v4
+    - uses: actions/setup-go@v5
       with:
         go-version: '>=1.20.1'
-    - uses: actions/setup-node@v3
+    - name: "Setup Node"
+      uses: actions/setup-node@v4
       with:
-        node-version: 18
-    - name: "Setup Hugo"
-      uses: peaceiris/actions-hugo@v3
-      with:
-        extended: true
-        hugo-version: '0.110.0'
-    - name: "Build"
+        node-version: 20
+        cache: 'npm'
+        cache-dependency-path: docs/package-lock.json
+    - name: "Install Dependencies"
+      working-directory: ./docs
+      shell: bash
+      run: |
+        npm ci
+    - name: "Generate version docs"
+      working-directory: ./docs
+      shell: bash
+      run: |
+        rm -f generate.sh
+        wget https://raw.githubusercontent.com/gooddata/gooddata-python-sdk/master/scripts/generate.sh
+        chmod +x ./generate.sh
+        ./generate.sh ${{ inputs.fetch-from }} master
+    - name: "Build documentation"
+      working-directory: ./docs
       env:
         THIS_BRANCH: ${{ inputs.this-branch }}
         BASE_URL: ${{ inputs.base-url }}
         HUGO_ENV: ${{ inputs.hugo-env }}
       shell: bash
       run: |
-        cd docs
-        rm -f generate.sh
-        wget https://raw.githubusercontent.com/gooddata/gooddata-python-sdk/master/scripts/generate.sh
-        chmod +x ./generate.sh
-        ./generate.sh ${{ inputs.fetch-from }} master
-        npm install
         hugo --minify ${BASE_URL:+--baseURL $BASE_URL}


### PR DESCRIPTION
This PR contains refactoring and removal of the `peaceiris/actions-hugo` action, which is not necessary anymore due to the presence of Go and node, and installation of node dependencies, including extended Hugo.