### PR TITLE
ci: add hugo installation to actions

### DIFF
--- a/.github/actions/hugo-build-action/action.yaml
+++ b/.github/actions/hugo-build-action/action.yaml
@@ -18,6 +18,11 @@ runs:
         node-version: 20
         cache: 'npm'
         cache-dependency-path: docs/package-lock.json
+    - name: "Install Hugo"
+      shell: bash
+      working-directory: ./docs
+      run: |
+        npm install -g hugo-extended@0.117.0
     - name: "Install Dependencies"
       shell: bash
       working-directory: ./docs

--- a/.github/actions/hugo-build-versioned-action/action.yaml
+++ b/.github/actions/hugo-build-versioned-action/action.yaml
@@ -41,6 +41,11 @@ runs:
         node-version: 20
         cache: 'npm'
         cache-dependency-path: docs/package-lock.json
+    - name: "Install Hugo"
+      shell: bash
+      working-directory: ./docs
+      run: |
+        npm install -g hugo-extended@0.117.0
     - name: "Install Dependencies"
       working-directory: ./docs
       shell: bash


### PR DESCRIPTION
It seems that Hugo was not installed by `npm ci` therefore the installation needs to be done explicitly.