### PR TITLE
feat: Support filterBy and exactFilter options for collectLabelElement API

### DIFF
--- a/gooddata-sdk/gooddata_sdk/__init__.py
+++ b/gooddata-sdk/gooddata_sdk/__init__.py
@@ -67,6 +67,7 @@ from gooddata_sdk.catalog.export.request import (
     ExportRequest,
     ExportSettings,
 )
+from gooddata_sdk.catalog.filter_by import CatalogFilterBy
 from gooddata_sdk.catalog.identifier import (
     CatalogAssigneeIdentifier,
     CatalogDatasetWorkspaceDataFilterIdentifier,

--- a/gooddata-sdk/gooddata_sdk/catalog/filter_by.py
+++ b/gooddata-sdk/gooddata_sdk/catalog/filter_by.py
@@ -1,0 +1,18 @@
+# (C) 2024 GoodData Corporation
+from __future__ import annotations
+
+from typing import Type
+
+import attr
+from gooddata_api_client.model.filter_by import FilterBy
+
+from gooddata_sdk.catalog.base import Base
+
+
+@attr.s(auto_attribs=True, kw_only=True)
+class CatalogFilterBy(Base):
+    label_type: str
+
+    @staticmethod
+    def client_class() -> Type[FilterBy]:
+        return FilterBy

--- a/gooddata-sdk/gooddata_sdk/catalog/workspace/content_service.py
+++ b/gooddata-sdk/gooddata_sdk/catalog/workspace/content_service.py
@@ -12,6 +12,7 @@ from gooddata_api_client.model.elements_request import ElementsRequest
 from gooddata_sdk.catalog.catalog_service_base import CatalogServiceBase
 from gooddata_sdk.catalog.data_source.validation.data_source import DataSourceValidator
 from gooddata_sdk.catalog.depends_on import CatalogDependsOn, CatalogDependsOnDateFilter
+from gooddata_sdk.catalog.filter_by import CatalogFilterBy
 from gooddata_sdk.catalog.types import ValidObjects
 from gooddata_sdk.catalog.validate_by_item import CatalogValidateByItem
 from gooddata_sdk.catalog.workspace.declarative_model.workspace.analytics_model.analytics_model import (
@@ -564,6 +565,8 @@ class CatalogWorkspaceContentService(CatalogServiceBase):
         label_id: LabelElementsInputType,
         depends_on: Optional[List[DependsOnItem]] = None,
         validate_by: Optional[List[CatalogValidateByItem]] = None,
+        exact_filter: Optional[List[str]] = None,
+        filter_by: Optional[CatalogFilterBy] = None,
     ) -> List[str]:
         """
         Get existing values for a label.
@@ -580,6 +583,11 @@ class CatalogWorkspaceContentService(CatalogServiceBase):
                 Optional parameter specifying dependencies on other labels or date filters.
             validate_by (Optional[List[CatalogValidateByItem]]):
                 Optional parameter specifying validation metrics, attributes, labels or facts.
+            exact_filter (Optional[List[str]]):
+                Optional parameter specifying exact filter values.
+            filter_by (Optional[CatalogFilterBy]):
+                Optional parameter specifying which label is used for filtering - primary or requested.
+                If omitted the server will use the default value of "REQUESTED"
         Returns:
             list of label values
         """
@@ -597,6 +605,13 @@ class CatalogWorkspaceContentService(CatalogServiceBase):
         request = ElementsRequest(
             label=label_id, depends_on=[d.to_api() for d in depends_on], validate_by=[v.to_api() for v in validate_by]
         )
+
+        if exact_filter is not None:
+            request.exact_filter = exact_filter
+
+        if filter_by is not None:
+            request.filter_by = filter_by.to_api()
+
         # TODO - fix return type of Paging.next in Backend + add support for this API to SDK
         values = self._actions_api.compute_label_elements_post(workspace_id, request, _check_return_type=False)
         return [v["title"] for v in values["elements"]]

--- a/gooddata-sdk/tests/catalog/fixtures/workspace_content/label_elements.yaml
+++ b/gooddata-sdk/tests/catalog/fixtures/workspace_content/label_elements.yaml
@@ -368,3 +368,153 @@ interactions:
             offset: 0
             next: null
           cacheId: 7fe933d079b4018b591f0cd7ea30185f
+  - request:
+      method: POST
+      uri: http://localhost:3000/api/v1/actions/workspaces/demo/execution/collectLabelElements
+      body:
+        label: order_status
+        dependsOn:
+          - label: order_status
+            values:
+              - Canceled
+              - Delivered
+            complementFilter: false
+        validateBy: [ ]
+      headers:
+        Accept:
+          - application/json
+        Accept-Encoding:
+          - br, gzip, deflate
+        Content-Type:
+          - application/json
+        X-GDC-VALIDATE-RELATIONS:
+          - 'true'
+        X-Requested-With:
+          - XMLHttpRequest
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Cache-Control:
+          - no-cache, no-store, max-age=0, must-revalidate
+        Content-Length:
+          - '261'
+        Content-Type:
+          - application/json
+        DATE: *id001
+        Expires:
+          - '0'
+        Featurepolicy:
+          - geolocation 'none'; midi 'none'; notifications 'none'; push 'none'; sync-xhr
+            'none'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope
+            'none'; speaker 'none'; vibrate 'none'; fullscreen 'none'; payment 'none';
+        Pragma:
+          - no-cache
+        Referrer-Policy:
+          - same-origin
+        Set-Cookie:
+          - SPRING_REDIRECT_URI=; Path=/; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00
+            GMT; HttpOnly; SameSite=Lax
+        Vary:
+          - Origin
+          - Access-Control-Request-Method
+          - Access-Control-Request-Headers
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - SAMEORIGIN
+        X-GDC-TRACE-ID: *id001
+        X-Xss-Protection:
+          - 1; mode=block
+      body:
+        string:
+          primaryLabel:
+            id: order_status
+            type: label
+          elements:
+            - title: Canceled
+              primaryTitle: Canceled
+            - title: Delivered
+              primaryTitle: Delivered
+          paging:
+            total: 2
+            count: 2
+            offset: 0
+            next: null
+          cacheId: 11c8c486e7cc0402e6f14bc0dd3f1d35
+  - request:
+      method: POST
+      uri: http://localhost:3000/api/v1/actions/workspaces/demo/execution/collectLabelElements
+      body:
+        label: customer_name
+        dependsOn: [ ]
+        validateBy: [ ]
+        exactFilter:
+          - 'C-02AZUA9H'
+          - 'C-0159TVP7'
+        filterBy:
+          labelType: PRIMARY
+      headers:
+        Accept:
+          - application/json
+        Accept-Encoding:
+          - br, gzip, deflate
+        Content-Type:
+          - application/json
+        X-GDC-VALIDATE-RELATIONS:
+          - 'true'
+        X-Requested-With:
+          - XMLHttpRequest
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Cache-Control:
+          - no-cache, no-store, max-age=0, must-revalidate
+        Content-Length:
+          - '273'
+        Content-Type:
+          - application/json
+        DATE: *id001
+        Expires:
+          - '0'
+        Featurepolicy:
+          - geolocation 'none'; midi 'none'; notifications 'none'; push 'none'; sync-xhr
+            'none'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope
+            'none'; speaker 'none'; vibrate 'none'; fullscreen 'none'; payment 'none';
+        Pragma:
+          - no-cache
+        Referrer-Policy:
+          - same-origin
+        Set-Cookie:
+          - SPRING_REDIRECT_URI=; Path=/; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00
+            GMT; HttpOnly; SameSite=Lax
+        Vary:
+          - Origin
+          - Access-Control-Request-Method
+          - Access-Control-Request-Headers
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - SAMEORIGIN
+        X-GDC-TRACE-ID: *id001
+        X-Xss-Protection:
+          - 1; mode=block
+      body:
+        string:
+          primaryLabel:
+            id: customer_id
+            type: label
+          elements:
+            - title: Jennifer Miller
+              primaryTitle: C-02AZUA9H
+            - title: William Ross
+              primaryTitle: C-0159TVP7
+          paging:
+            total: 2
+            count: 2
+            offset: 0
+            next: null
+          cacheId: 940798a736c77273652b9cfd53254528

--- a/gooddata-sdk/tests/catalog/test_catalog_workspace_content.py
+++ b/gooddata-sdk/tests/catalog/test_catalog_workspace_content.py
@@ -16,6 +16,7 @@ from gooddata_sdk import (
     CatalogDependsOn,
     CatalogDependsOnDateFilter,
     CatalogEntityIdentifier,
+    CatalogFilterBy,
     CatalogValidateByItem,
     CatalogWorkspace,
     DataSourceValidator,
@@ -407,6 +408,18 @@ def test_label_elements(test_config):
         test_config["workspace"], "order_status", [depends_on_date_relative], []
     )
     assert label_values == []
+    exact_filter = None
+    filter_by = None
+    label_values = sdk.catalog_workspace_content.get_label_elements(
+        test_config["workspace"], "order_status", [depends_on], [], exact_filter, filter_by
+    )
+    assert label_values == ["Canceled", "Delivered"]
+    exact_filter = ["C-02AZUA9H", "C-0159TVP7"]
+    filter_by: CatalogFilterBy = CatalogFilterBy(label_type="PRIMARY")
+    label_values = sdk.catalog_workspace_content.get_label_elements(
+        test_config["workspace"], "customer_name", [], [], exact_filter, filter_by
+    )
+    assert label_values == ["Jennifer Miller", "William Ross"]
 
 
 @gd_vcr.use_cassette(str(_fixtures_dir / "explicit_workspace_data_filter.yaml"))


### PR DESCRIPTION
…t api

Added `exactFilter` and `filterBy` options for the `collectLabelElement` API. Tests updated accordingly as well. Note: no new catalog type for `exactFilter` as it is just a `List[str]`.

JIRA: LX-432
risk: low