### PR TITLE
feat: add convertor from Compute dicts to SDK model

### DIFF
--- a/gooddata-sdk/gooddata_sdk/__init__.py
+++ b/gooddata-sdk/gooddata_sdk/__init__.py
@@ -191,6 +191,7 @@ from gooddata_sdk.catalog.workspace.entity_model.user_data_filter import (
 )
 from gooddata_sdk.catalog.workspace.entity_model.workspace import CatalogWorkspace
 from gooddata_sdk.client import GoodDataApiClient
+from gooddata_sdk.compute.compute_to_sdk_converter import ComputeToSdkConverter
 from gooddata_sdk.compute.model.attribute import Attribute
 from gooddata_sdk.compute.model.base import ExecModelEntity, ObjId
 from gooddata_sdk.compute.model.execution import (
@@ -235,6 +236,7 @@ from gooddata_sdk.visualization import (
     Visualization,
     VisualizationAttribute,
     VisualizationBucket,
+    VisualizationFilter,
     VisualizationMetric,
     VisualizationService,
 )

--- a/gooddata-sdk/gooddata_sdk/compute/compute_to_sdk_converter.py
+++ b/gooddata-sdk/gooddata_sdk/compute/compute_to_sdk_converter.py
@@ -1,0 +1,183 @@
+# (C) 2024 GoodData Corporation
+from typing import Any, Dict, Union, cast
+
+from gooddata_sdk.compute.model.attribute import Attribute
+from gooddata_sdk.compute.model.base import ObjId
+from gooddata_sdk.compute.model.filter import (
+    AbsoluteDateFilter,
+    AllTimeFilter,
+    Filter,
+    MetricValueFilter,
+    NegativeAttributeFilter,
+    PositiveAttributeFilter,
+    RankingFilter,
+    RelativeDateFilter,
+)
+from gooddata_sdk.compute.model.metric import (
+    ArithmeticMetric,
+    Metric,
+    PopDate,
+    PopDateDataset,
+    PopDateMetric,
+    PopDatesetMetric,
+    SimpleMetric,
+)
+from gooddata_sdk.utils import ref_extract, ref_extract_obj_id
+
+
+class ComputeToSdkConverter:
+    """
+    Provides functions to convert Compute API model objects represented as dictionaries to the SDK Compute model.
+    We cannot use the Visualization converter as the Compute API model is different:
+    - there are differences in naming: e.g. "label" vs "displayForm", "dataset" vs "dataSet"
+    - there are differences in structure: e.g. "measure" vs "measureDefinition"
+
+    The inputs to this converter should be dictionaries that come from parsing the JSON payloads
+    used with the backend's /execute API endpoint.
+    """
+
+    @staticmethod
+    def convert_attribute(attribute_dict: Dict[str, Any]) -> Attribute:
+        """
+        Converts attribute dictionary to the SDK Compute model.
+        :param attribute_dict: the attribute dictionary to convert
+        :return: the converted attribute
+        """
+        return Attribute(
+            local_id=attribute_dict["localIdentifier"],
+            label=attribute_dict["label"]["identifier"]["id"],
+            show_all_values=attribute_dict["showAllValues"],
+        )
+
+    @staticmethod
+    def convert_filter(filter_dict: Dict[str, Any]) -> Filter:
+        """
+        Converts filter dictionary to the SDK Compute model.
+        :param filter_dict: the filter dictionary to convert
+        :return: the converted filter
+        """
+        if "positiveAttributeFilter" in filter_dict:
+            f = filter_dict["positiveAttributeFilter"]
+            return PositiveAttributeFilter(label=ref_extract(f["label"]), values=f["in"]["values"])
+
+        if "negativeAttributeFilter" in filter_dict:
+            f = filter_dict["negativeAttributeFilter"]
+            return NegativeAttributeFilter(label=ref_extract(f["label"]), values=f["notIn"]["values"])
+
+        if "relativeDateFilter" in filter_dict:
+            f = filter_dict["relativeDateFilter"]
+
+            # there is a filter present, but means all time
+            if ("from" not in f) or ("to" not in f):
+                return AllTimeFilter(ref_extract_obj_id(f["dataset"]))
+
+            return RelativeDateFilter(
+                dataset=ref_extract_obj_id(f["dataset"]),
+                granularity=f["granularity"],
+                from_shift=f["from"],
+                to_shift=f["to"],
+            )
+
+        if "absoluteDateFilter" in filter_dict:
+            f = filter_dict["absoluteDateFilter"]
+
+            return AbsoluteDateFilter(dataset=ref_extract_obj_id(f["dataset"]), from_date=f["from"], to_date=f["to"])
+
+        if "comparisonMeasureValueFilter" in filter_dict:
+            f = filter_dict["comparisonMeasureValueFilter"]
+
+            return MetricValueFilter(
+                metric=ref_extract(f["measure"]),
+                operator=f["operator"],
+                values=f["value"],
+                treat_nulls_as=f.get("treatNullValuesAs"),
+            )
+
+        if "rangeMeasureValueFilter" in filter_dict:
+            f = filter_dict["rangeMeasureValueFilter"]
+
+            return MetricValueFilter(
+                metric=ref_extract(f["measure"]),
+                operator=f["operator"],
+                values=(f["from"], f["to"]),
+                treat_nulls_as=f.get("treatNullValuesAs"),
+            )
+
+        if "rankingFilter" in filter_dict:
+            f = filter_dict["rankingFilter"]
+
+            # mypy is unable to automatically convert Union[str, ObjId] to Union[str, ObjId, Attribute, Metric]
+            # so use explicit cast here
+            dimensionality = (
+                [cast(Union[str, ObjId, Attribute, Metric], ref_extract(a)) for a in f["attributes"]]
+                if "attributes" in f
+                else None
+            )
+
+            return RankingFilter(
+                metrics=[ref_extract(m) for m in f["measures"]],
+                dimensionality=dimensionality,
+                operator=f["operator"],
+                value=f["value"],
+            )
+
+        raise ValueError(f"Unsupported filter definition type: {filter_dict}")
+
+    @staticmethod
+    def convert_metric(metric_dict: Dict[str, Any]) -> Metric:
+        """
+        Converts metric dictionary to the SDK Compute model.
+        :param metric_dict: the metric dictionary to convert
+        :return: the converted metric
+        """
+        definition = metric_dict["definition"]
+        local_id = metric_dict["localIdentifier"]
+
+        if "measure" in definition:
+            d = definition["measure"]
+            aggregation = d.get("aggregation", None)
+            compute_ratio = d.get("computeRatio", False)
+
+            filters = [ComputeToSdkConverter.convert_filter(f) for f in d["filters"]] if "filters" in d else None
+
+            return SimpleMetric(
+                local_id=local_id,
+                item=ref_extract_obj_id(d["item"]),
+                aggregation=aggregation,
+                compute_ratio=compute_ratio,
+                filters=filters,
+            )
+
+        if "arithmeticMeasure" in definition:
+            d = definition["arithmeticMeasure"]
+            return ArithmeticMetric(
+                local_id=local_id,
+                operator=d["operator"],
+                operands=[o["localIdentifier"] for o in d["measureIdentifiers"]],
+            )
+
+        if "overPeriodMeasure" in definition:
+            d = definition["overPeriodMeasure"]
+            date_attributes = [
+                PopDate(attribute=ref_extract_obj_id(item["attribute"]), periods_ago=item["periodsAgo"])
+                for item in d["dateAttributes"]
+            ]
+
+            return PopDateMetric(
+                local_id=local_id,
+                metric=d["measureIdentifier"]["localIdentifier"],
+                date_attributes=date_attributes,
+            )
+
+        if "previousPeriodMeasure" in definition:
+            d = definition["previousPeriodMeasure"]
+
+            date_datasets = [PopDateDataset(ref_extract(dd["dataset"]), dd["periodsAgo"]) for dd in d["dateDatasets"]]
+
+            return PopDatesetMetric(
+                local_id=local_id,
+                metric=d["measureIdentifier"]["localIdentifier"],
+                date_datasets=date_datasets,
+            )
+
+        raise ValueError(f"Unsupported metric definition type: {metric_dict}")

--- a/gooddata-sdk/gooddata_sdk/utils.py
+++ b/gooddata-sdk/gooddata_sdk/utils.py
@@ -391,3 +391,34 @@ def read_json(path: Union[str, Path]) -> Any:
     path = Path(path) if isinstance(path, str) else path
     with open(path, "r", encoding="utf-8") as f:
         return json.loads(f.read())
+
+
+def ref_extract_obj_id(ref: Dict[str, Any]) -> ObjId:
+    """
+    Extracts ObjId from a ref dictionary.
+    :param ref: the ref to extract from
+    :return: the extracted ObjId
+    :raises ValueError: if the ref is not an identifier
+    """
+    if "identifier" in ref:
+        return ObjId(id=ref["identifier"]["id"], type=ref["identifier"]["type"])
+
+    raise ValueError("invalid ref. must be identifier")
+
+
+def ref_extract(ref: Dict[str, Any]) -> Union[str, ObjId]:
+    """
+    Extracts an object id from a ref dictionary: either an identifier or a localIdentifier.
+    :param ref: the ref to extract from
+    :return: thr extracted object id
+    :raises ValueError: if the ref is not an identifier or localIdentifier
+    """
+    try:
+        return ref_extract_obj_id(ref)
+    except ValueError:
+        pass
+
+    if "localIdentifier" in ref:
+        return ref["localIdentifier"]
+
+    raise ValueError("invalid ref. must be identifier or localIdentifier")

--- a/gooddata-sdk/tests/compute/__init__.py
+++ b/gooddata-sdk/tests/compute/__init__.py
@@ -1,0 +1,1 @@
+# (C) 2024 GoodData Corporation

--- a/gooddata-sdk/tests/compute/test_compute_to_sdk_converter.py
+++ b/gooddata-sdk/tests/compute/test_compute_to_sdk_converter.py
@@ -1,0 +1,330 @@
+# (C) 2024 GoodData Corporation
+import json
+
+from gooddata_sdk import (
+    AbsoluteDateFilter,
+    ArithmeticMetric,
+    Attribute,
+    ComputeToSdkConverter,
+    MetricValueFilter,
+    NegativeAttributeFilter,
+    PopDateMetric,
+    PopDatesetMetric,
+    PositiveAttributeFilter,
+    RankingFilter,
+    RelativeDateFilter,
+    SimpleMetric,
+)
+
+
+def test_attribute_conversion():
+    attribute_dict = json.loads(
+        """
+        {
+          "label": {
+            "identifier": { "id": "attribute1", "type": "label" }
+          },
+          "localIdentifier": "a_attribute1",
+          "showAllValues": true
+        }
+        """
+    )
+
+    result = ComputeToSdkConverter.convert_attribute(attribute_dict)
+
+    assert isinstance(result, Attribute)
+    assert result.local_id == "a_attribute1"
+    assert result.label.id == "attribute1"
+    assert result.show_all_values is True
+
+
+def test_positive_attribute_filter_conversion():
+    filter_dict = json.loads(
+        """
+        {
+          "positiveAttributeFilter": {
+            "label": {
+              "identifier": { "id": "attribute1", "type": "label" }
+            },
+            "in": {
+              "values": [ "val1", "val2" ]
+            }
+          }
+        }
+        """
+    )
+
+    result = ComputeToSdkConverter.convert_filter(filter_dict)
+
+    assert isinstance(result, PositiveAttributeFilter)
+    assert result.label.id == "attribute1"
+    assert result.values == ["val1", "val2"]
+
+
+def test_negative_attribute_filter_conversion():
+    filter_dict = json.loads(
+        """
+        {
+          "negativeAttributeFilter": {
+            "label": {
+              "identifier": { "id": "attribute1", "type": "label" }
+            },
+            "notIn": {
+              "values": [ "val1", "val2" ]
+            }
+          }
+        }
+        """
+    )
+
+    result = ComputeToSdkConverter.convert_filter(filter_dict)
+
+    assert isinstance(result, NegativeAttributeFilter)
+    assert result.label.id == "attribute1"
+    assert result.values == ["val1", "val2"]
+
+
+def test_relative_date_filter_conversion():
+    filter_dict = json.loads(
+        """
+        {
+          "relativeDateFilter": {
+            "dataset": {
+              "identifier": { "id": "date", "type": "dataset" }
+            },
+            "granularity": "QUARTER",
+            "from": -3,
+            "to": 0
+          }
+        }
+        """
+    )
+
+    result = ComputeToSdkConverter.convert_filter(filter_dict)
+
+    assert isinstance(result, RelativeDateFilter)
+    assert result.dataset.id == "date"
+    assert result.granularity == "QUARTER"
+    assert result.from_shift == -3
+    assert result.to_shift == 0
+
+
+def test_absolute_date_filter_conversion():
+    filter_dict = json.loads(
+        """
+        {
+          "absoluteDateFilter": {
+            "dataset": {
+              "identifier": { "id": "date", "type": "dataset" }
+            },
+            "from": "2024-07-12 10:00",
+            "to": "2024-08-12 20:59"
+          }
+        }
+        """
+    )
+
+    result = ComputeToSdkConverter.convert_filter(filter_dict)
+
+    assert isinstance(result, AbsoluteDateFilter)
+    assert result.dataset.id == "date"
+    assert result.from_date == "2024-07-12 10:00"
+    assert result.to_date == "2024-08-12 20:59"
+
+
+def test_comparison_measure_value_filter_conversion():
+    filter_dict = json.loads(
+        """
+        {
+          "comparisonMeasureValueFilter": {
+            "measure": { "localIdentifier": "measureLocalId" },
+            "operator": "GREATER_THAN",
+            "value": 100,
+            "treatNullValuesAs": 0
+          }
+        }
+        """
+    )
+
+    result = ComputeToSdkConverter.convert_filter(filter_dict)
+
+    assert isinstance(result, MetricValueFilter)
+    assert result.metric == "measureLocalId"
+    assert result.operator == "GREATER_THAN"
+    assert result.values == (100,)
+    assert result.treat_nulls_as == 0
+
+
+def test_range_measure_value_filter_conversion():
+    filter_dict = json.loads(
+        """
+        {
+          "rangeMeasureValueFilter": {
+            "measure": { "localIdentifier": "measureLocalId" },
+            "operator": "BETWEEN",
+            "from": 100,
+            "to": 200,
+            "treatNullValuesAs": 42
+          }
+        }
+        """
+    )
+
+    result = ComputeToSdkConverter.convert_filter(filter_dict)
+
+    assert isinstance(result, MetricValueFilter)
+    assert result.metric == "measureLocalId"
+    assert result.operator == "BETWEEN"
+    assert result.values == (100, 200)
+    assert result.treat_nulls_as == 42
+
+
+def test_ranking_filter_conversion():
+    filter_dict = json.loads(
+        """
+        {
+          "rankingFilter": {
+            "measures": [{
+                "localIdentifier": "measure1.localId"
+            }],
+            "operator": "TOP",
+            "value": 5
+          }
+        }
+        """
+    )
+
+    result = ComputeToSdkConverter.convert_filter(filter_dict)
+
+    assert isinstance(result, RankingFilter)
+    assert result.metrics[0] == "measure1.localId"
+    assert result.operator == "TOP"
+    assert result.value == 5
+
+
+def test_simple_metric_conversion():
+    metric_dict = json.loads(
+        """
+        {
+          "localIdentifier": "m_fact1_max",
+          "definition": {
+            "measure": {
+              "item": {
+                "identifier": { "id": "fact1", "type": "fact" }
+              },
+              "filters": [
+                {
+                  "positiveAttributeFilter": {
+                    "label": {
+                      "identifier": { "id": "attribute1", "type": "label" }
+                    },
+                    "in": {
+                      "values": [ "value2", "value1" ]
+                    }
+                  }
+                }
+              ],
+              "aggregation": "MAX"
+            }
+          }
+        }
+        """
+    )
+
+    result = ComputeToSdkConverter.convert_metric(metric_dict)
+
+    assert isinstance(result, SimpleMetric)
+    assert result.local_id == "m_fact1_max"
+    assert result.item.id == "fact1"
+    assert result.aggregation == "MAX"
+    assert isinstance(result.filters[0], PositiveAttributeFilter)
+
+
+def test_arithmetic_metric_conversion():
+    metric_dict = json.loads(
+        """
+        {
+          "localIdentifier": "m_arithmetic",
+          "definition": {
+            "arithmeticMeasure": {
+              "measureIdentifiers": [
+                { "localIdentifier": "m_fact1_max" },
+                { "localIdentifier": "m_fact2_runsum" }
+              ],
+              "operator": "MULTIPLICATION"
+            }
+          }
+        }
+        """
+    )
+
+    result = ComputeToSdkConverter.convert_metric(metric_dict)
+
+    assert isinstance(result, ArithmeticMetric)
+    assert result.local_id == "m_arithmetic"
+    assert result.operator == "MULTIPLICATION"
+    assert result.operand_local_ids == ["m_fact1_max", "m_fact2_runsum"]
+
+
+def test_over_period_metric_conversion():
+    metric_dict = json.loads(
+        """
+        {
+          "localIdentifier": "m_over_period",
+          "definition": {
+            "overPeriodMeasure": {
+              "measureIdentifier": {
+                "localIdentifier": "m_price_sum"
+              },
+              "dateAttributes": [
+                {
+                  "attribute": {
+                    "identifier": { "id": "date.year", "type": "attribute" }
+                  },
+                  "periodsAgo": 1
+                }
+              ]
+            }
+          }
+        }
+        """
+    )
+
+    result = ComputeToSdkConverter.convert_metric(metric_dict)
+
+    assert isinstance(result, PopDateMetric)
+    assert result.local_id == "m_over_period"
+    assert result.metric_local_id == "m_price_sum"
+    assert result.date_attributes[0].attribute.id == "date.year"
+
+
+def test_previous_period_metric_conversion():
+    metric_dict = json.loads(
+        """
+        {
+          "localIdentifier": "m_previous_period",
+          "definition": {
+            "previousPeriodMeasure": {
+              "measureIdentifier": {
+                "localIdentifier": "m_price_sum"
+              },
+              "dateDatasets": [
+                {
+                  "dataset": {
+                    "identifier": { "id": "date", "type": "dataset" }
+                  },
+                  "periodsAgo": 1
+                }
+              ]
+            }
+          }
+        }
+        """
+    )
+
+    result = ComputeToSdkConverter.convert_metric(metric_dict)
+
+    assert isinstance(result, PopDatesetMetric)
+    assert result.local_id == "m_previous_period"
+    assert result.metric_local_id == "m_price_sum"
+    assert result.date_datasets[0].dataset.id == "date"


### PR DESCRIPTION
This will be useful in the Flight RPC functions as they will get the execution as a JSON from the server and we want to make them more ergonomic by converting them to the SDK model (e.g. to launch another execution from the SDK).

JIRA: CQ-577
risk: low