### PR TITLE
feat: add classes to parse executionRequest in Flight RPC

### DIFF
--- a/.github/workflows/rw-collect-changes.yaml
+++ b/.github/workflows/rw-collect-changes.yaml
@@ -46,3 +46,4 @@ jobs:
               - 'Makefile'
               - 'gooddata-api-client/**'
               - 'gooddata-dbt/**'
+              - 'gooddata-flight-server/**'

--- a/.github/workflows/rw-python-tests.yaml
+++ b/.github/workflows/rw-python-tests.yaml
@@ -24,7 +24,7 @@ jobs:
         if: ${{ matrix.python_version == 'py312' }}
         uses: codecov/codecov-action@v3
         with:
-          files: ./gooddata-sdk/coverage.xml,./gooddata-pandas/coverage.xml,./gooddata-fdw/coverage.xml
+          files: ./gooddata-sdk/coverage.xml,./gooddata-pandas/coverage.xml,./gooddata-fdw/coverage.xml,./gooddata-flight-server/coverage.xml
   lint-and-format-check:
     runs-on: ubuntu-latest
     if: ${{inputs.changed-python-modules == 'true'}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,8 @@ RUN set -x \
   && true
 
 # install tox
-ENV PYTHON_TOX_VERSION=4.14.0
-ENV PYTHON_TOX_UV_VERSION=1.5.1
+ENV PYTHON_TOX_VERSION=4.14.1
+ENV PYTHON_TOX_UV_VERSION=1.7.0
 RUN set -x \
   && pip3 install tox==${PYTHON_TOX_VERSION} tox-uv==${PYTHON_TOX_UV_VERSION}\
   && true

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,14 @@
 ARG PY_TAG
 FROM python:${PY_TAG}
 
+ARG PY_TAG
 ARG ENV_TAG
 # tox defines all python targets, makefile recognizes TEST_ENVS and forces
 # tox to execute only tests for installed python
 ENV TEST_ENVS=${ENV_TAG}
 
 # install make and gosu
-ENV GOSU_VERSION 1.14
+ENV GOSU_VERSION=1.14
 RUN set -x \
   && apt-get update \
   && apt-get install -y --no-install-recommends make curl gnupg \
@@ -26,8 +27,8 @@ RUN set -x \
   && true
 
 # install tox
-ENV PYTHON_TOX_VERSION 4.14.0
-ENV PYTHON_TOX_UV_VERSION 1.5.1
+ENV PYTHON_TOX_VERSION=4.14.0
+ENV PYTHON_TOX_UV_VERSION=1.5.1
 RUN set -x \
   && pip3 install tox==${PYTHON_TOX_VERSION} tox-uv==${PYTHON_TOX_UV_VERSION}\
   && true

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,14 @@ dev:
 	.venv/bin/pip3 install -r dev-requirements.txt
 	.venv/bin/pre-commit install
 
+.PHONY: lint
+lint:
+	.venv/bin/ruff check .
+
+.PHONY: lint-fix
+lint-fix:
+	.venv/bin/ruff check . --fix
+
 .PHONY: format
 format:
 	.venv/bin/ruff format --check .

--- a/gooddata-flight-server/gooddata_flight_server/__init__.py
+++ b/gooddata-flight-server/gooddata_flight_server/__init__.py
@@ -9,6 +9,10 @@ from gooddata_flight_server.config.config import (
 from gooddata_flight_server.errors.error_code import ErrorCode
 from gooddata_flight_server.errors.error_info import ErrorInfo, RetryInfo
 from gooddata_flight_server.flexfun.flex_fun import FlexFun
+from gooddata_flight_server.flexfun.flex_fun_execution_context import (
+    ExecutionContext,
+    ExecutionRequest,
+)
 from gooddata_flight_server.health.server_health_monitor import ModuleHealthStatus, ServerHealthMonitor
 from gooddata_flight_server.server.auth.auth_middleware import TokenAuthMiddleware
 from gooddata_flight_server.server.auth.token_verifier import TokenVerificationStrategy

--- a/gooddata-flight-server/gooddata_flight_server/flexfun/flex_fun_execution_context.py
+++ b/gooddata-flight-server/gooddata_flight_server/flexfun/flex_fun_execution_context.py
@@ -1,0 +1,105 @@
+# (C) 2024 GoodData Corporation
+from dataclasses import dataclass
+from typing import Optional
+
+from gooddata_sdk import Attribute, ComputeToSdkConverter, Filter, Metric
+
+
+@dataclass
+class ExecutionRequest:
+    """
+    Information about the execution request that is sent to the FlexFun.
+    """
+
+    attributes: list[Attribute]
+    """
+    All the attributes that are part of the execution request.
+    """
+
+    metrics: list[Metric]
+    """
+    All the metrics that are part of the execution request.
+    """
+
+    filters: list[Filter]
+    """
+    All the filters that are part of the execution request.
+    """
+
+    @staticmethod
+    def from_dict(d: dict) -> "ExecutionRequest":
+        """
+        Create ExecutionRequest from a dictionary.
+        :param d: the dictionary to parse
+        """
+        return ExecutionRequest(
+            attributes=[ComputeToSdkConverter.convert_attribute(a) for a in d.get("attributes", [])],
+            metrics=[ComputeToSdkConverter.convert_metric(m) for m in d.get("measures", [])],
+            filters=[ComputeToSdkConverter.convert_filter(f) for f in d.get("filters", [])],
+        )
+
+
+@dataclass
+class ExecutionContext:
+    """
+    Execution context of the FlexFun
+    """
+
+    organization_id: str
+    """
+    The ID of the organization that the FlexFun is executed in.
+    """
+
+    workspace_id: str
+    """
+    The ID of the workspace that the FlexFun is executed in.
+    """
+
+    user_id: str
+    """
+    The ID of the user that invoked the FlexFun.
+    """
+
+    timestamp: Optional[str]
+    """
+    The timestamp of the execution used as "now" in date filters.
+    For example 2020-06-03T10:15:30+01:00.
+    """
+
+    timezone: Optional[str]
+    """
+    The timezone of the execution.
+    """
+
+    execution_request: ExecutionRequest
+    """
+    The execution request that the FlexFun should process.
+    """
+
+    @staticmethod
+    def from_dict(d: dict) -> Optional["ExecutionContext"]:
+        """
+        Create ExecutionContext from a dictionary.
+        :param d: the dictionary to parse
+        """
+        if not d:
+            return None
+        return ExecutionContext(
+            organization_id=d["organization_id"],
+            workspace_id=d["workspace_id"],
+            user_id=d["user_id"],
+            timestamp=d.get("timestamp"),
+            timezone=d.get("timezone"),
+            execution_request=ExecutionRequest.from_dict(d["execution_request"]),
+        )
+
+    @staticmethod
+    def from_parameters(parameters: dict) -> Optional["ExecutionContext"]:
+        """
+        Create ExecutionContext from FlexFun parameters.
+        :param parameters: the parameters dictionary of the FlexFun invocation
+        :return: None if the parameters do not contain the execution context, otherwise the execution context
+        """
+        return (
+            ExecutionContext.from_dict(parameters["execution_context"]) if "execution_context" in parameters else None
+        )

--- a/gooddata-flight-server/setup.py
+++ b/gooddata-flight-server/setup.py
@@ -8,6 +8,7 @@ long_description = (this_directory / "README.md").read_text(encoding="utf-8")
 
 REQUIRES = [
     "dynaconf>=3.1.11,<4.0.0",
+    "gooddata-sdk~=1.24.0",
     "opentelemetry-api>=1.24.0,<=2.0.0",
     "opentelemetry-sdk>=1.24.0,<=2.0.0",
     "orjson>=3.8.5,<4.0.0",

--- a/gooddata-flight-server/tox.ini
+++ b/gooddata-flight-server/tox.ini
@@ -7,6 +7,7 @@ package = wheel
 wheel_build_env = .pkg
 deps =
     -r{toxinidir}/test-requirements.txt
+    -e../gooddata-sdk
     -e../tests-support
 setenv=
     PYTHONDONTWRITEBYTECODE=1

--- a/gooddata-sdk/gooddata_sdk/catalog/data_source/service.py
+++ b/gooddata-sdk/gooddata_sdk/catalog/data_source/service.py
@@ -326,7 +326,7 @@ class CatalogDataSourceService(CatalogServiceBase):
     def scan_pdm_and_generate_logical_model(
         self,
         data_source_id: str,
-        generate_ldm_request: CatalogGenerateLdmRequest = CatalogGenerateLdmRequest(separator="__", wdf_prefix="wdf"),
+        generate_ldm_request: Optional[CatalogGenerateLdmRequest] = None,
         scan_request: CatalogScanModelRequest = CatalogScanModelRequest(),
         report_warnings: bool = False,
     ) -> tuple[CatalogDeclarativeModel, CatalogScanResultPdm]:
@@ -351,6 +351,9 @@ class CatalogDataSourceService(CatalogServiceBase):
                 An instance of CatalogScanResultPdm.
                 Containing pdm itself and a list of warnings that occurred during scanning.
         """
+        if not generate_ldm_request:
+            generate_ldm_request = CatalogGenerateLdmRequest(separator="__", wdf_prefix="wdf")
+
         scan_result = self.scan_data_source(data_source_id, scan_request, report_warnings)
         if generate_ldm_request.pdm and generate_ldm_request.pdm.tables:
             generate_ldm_request.pdm.tables.extend(scan_result.pdm.tables)

--- a/gooddata-sdk/gooddata_sdk/catalog/export/request.py
+++ b/gooddata-sdk/gooddata_sdk/catalog/export/request.py
@@ -75,7 +75,7 @@ class ExportRequest(Base):
         supported_formats = ["CSV", "XLSX", "HTML", "PDF"]
         if self.format not in supported_formats:
             raise ValueError(
-                f"format '{self.format}' is not presented " f"in supported formats {','.join(supported_formats)}"
+                f"format '{self.format}' is not presented in supported formats {','.join(supported_formats)}"
             )
 
     @staticmethod

--- a/gooddata-sdk/gooddata_sdk/catalog/export/service.py
+++ b/gooddata-sdk/gooddata_sdk/catalog/export/service.py
@@ -100,7 +100,7 @@ class ExportService(CatalogServiceBase):
                     break
         if response.status != 200:
             raise ValueError(
-                f"Server was not able to return response. " f"The last response status is '{response.status}'."
+                f"Server was not able to return response. The last response status is '{response.status}'."
             )
         return response.data
 

--- a/gooddata-sdk/gooddata_sdk/catalog/organization/service.py
+++ b/gooddata-sdk/gooddata_sdk/catalog/organization/service.py
@@ -298,7 +298,7 @@ class CatalogOrganizationService(CatalogServiceBase):
         try:
             self._entities_api.delete_entity_csp_directives(csp_directive_id)
         except NotFoundException:
-            raise ValueError(f"Can not delete {csp_directive_id} csp directive. " f"This csp directive does not exist.")
+            raise ValueError(f"Can not delete {csp_directive_id} csp directive. This csp directive does not exist.")
 
     def update_csp_directive(self, csp_directive: CatalogCspDirective) -> None:
         """Update a csp directive.
@@ -318,4 +318,4 @@ class CatalogOrganizationService(CatalogServiceBase):
             csp_directive_document = JsonApiCspDirectiveInDocument(data=csp_directive.to_api())
             self._entities_api.update_entity_csp_directives(csp_directive.id, csp_directive_document)
         except NotFoundException:
-            raise ValueError(f"Can not update {csp_directive.id} csp directive. " f"This csp directive does not exist.")
+            raise ValueError(f"Can not update {csp_directive.id} csp directive. This csp directive does not exist.")

--- a/gooddata-sdk/gooddata_sdk/catalog/workspace/service.py
+++ b/gooddata-sdk/gooddata_sdk/catalog/workspace/service.py
@@ -741,9 +741,8 @@ class CatalogWorkspaceService(CatalogServiceBase):
                 self.add_title_description(to_translate, visualization.title, visualization.description)
                 for bucket in visualization.content["buckets"]:
                     for item in bucket["items"]:
-                        if "measure" in item:
-                            if "alias" in item["measure"]:
-                                to_translate.add(item["measure"]["alias"])
+                        if "measure" in item and "alias" in item["measure"]:
+                            to_translate.add(item["measure"]["alias"])
             for dashboard in workspace_content.analytics.analytical_dashboards or []:
                 self.add_title_description(to_translate, dashboard.title, dashboard.description)
                 # Hack: translate titles in free-form, which is not processed intentionally by this SDK
@@ -795,9 +794,8 @@ class CatalogWorkspaceService(CatalogServiceBase):
                 self.set_title_description(visualization, translated)
                 for bucket in visualization.content["buckets"]:
                     for item in bucket["items"]:
-                        if "measure" in item:
-                            if "alias" in item["measure"]:
-                                item["measure"]["alias"] = translated[item["measure"]["alias"]]
+                        if "measure" in item and "alias" in item["measure"]:
+                            item["measure"]["alias"] = translated[item["measure"]["alias"]]
             for dashboard in new_workspace_content.analytics.analytical_dashboards or []:
                 self.set_title_description(dashboard, translated)
                 # Hack: translate titles in free-form, which is not processed intentionally by this SDK

--- a/gooddata-sdk/gooddata_sdk/compute/model/filter.py
+++ b/gooddata-sdk/gooddata_sdk/compute/model/filter.py
@@ -137,7 +137,6 @@ _GRANULARITY: set[str] = {
     "QUARTER",
     "MONTH",
     "WEEK",
-    "WEEK",
     "DAY",
     "HOUR",
     "MINUTE",

--- a/gooddata-sdk/tests/catalog/test_catalog_user_service.py
+++ b/gooddata-sdk/tests/catalog/test_catalog_user_service.py
@@ -127,7 +127,7 @@ def test_list_user_groups(test_config):
         "adminQA1Group",
         "visitorsGroup",
     }
-    assert set(user_group.name for user_group in user_groups) == {"demo group", None, "visitors", None}
+    assert set(user_group.name for user_group in user_groups) == {"demo group", "visitors", None}
 
 
 @gd_vcr.use_cassette(str(_fixtures_dir / "get_user_group.yaml"))
@@ -146,7 +146,7 @@ def test_create_delete_user_group(test_config):
     try:
         current_user_groups = sdk.catalog_user.list_user_groups()
         assert len(current_user_groups) == 4
-        assert set(ug.name for ug in current_user_groups) == {"demo group", None, "visitors", None}
+        assert set(ug.name for ug in current_user_groups) == {"demo group", "visitors", None}
         user_group_e = CatalogUserGroup.init(
             user_group_id=user_group_id,
             user_group_name=user_group_id.upper(),
@@ -654,7 +654,7 @@ def _assert_user_groups_default(user_groups: list[CatalogDeclarativeUserGroup]):
         "adminQA1Group",
         "visitorsGroup",
     }
-    assert set(user_group.name for user_group in user_groups) == {"demo group", None, "visitors", None}
+    assert set(user_group.name for user_group in user_groups) == {"demo group", "visitors", None}
 
 
 def _assert_users_user_groups_default(users_user_groups: CatalogDeclarativeUsersUserGroups):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,11 @@ src = "gooddata-flight-server/setup.py"
 search = "version=\"{current_version}\""
 
 [[tool.tbump.file]]
+# gooddata-flight-server setup.py dependency
+src = "gooddata-flight-server/setup.py"
+search = "gooddata-sdk~={current_version}"
+
+[[tool.tbump.file]]
 # clients README
 src = "gooddata-*-client/README.md"
 


### PR DESCRIPTION
Allow the users to parse the incoming executionRequest when invoking the Flight RPC function. Use the gooddata-sdk objects so that they can be easily reused in the gooddata-sdk itself.

Also, add the gooddata-flight-server to the CI pipelines, make sure the coverage is published and fix all warnings in the Dockerfile.

Fix some code smells along the way, see the last commit for more details.

JIRA: CQ-577
risk: low