### PR TITLE
fix: type ExecutionContext attribute filter values properly

### DIFF
--- a/gooddata-flight-server/gooddata_flight_server/flexfun/flex_fun_execution_context.py
+++ b/gooddata-flight-server/gooddata_flight_server/flexfun/flex_fun_execution_context.py
@@ -83,7 +83,7 @@ class ExecutionContextPositiveAttributeFilter:
     Identifier of the label used.
     """
 
-    values: list[str]
+    values: list[Optional[str]]
     """
     Values of the filter.
     """
@@ -100,7 +100,7 @@ class ExecutionContextNegativeAttributeFilter:
     Identifier of the label used.
     """
 
-    values: list[str]
+    values: list[Optional[str]]
     """
     Values of the filter.
     """


### PR DESCRIPTION
The attribute filter values can contain None values so reflect that in the typings appropriately.

JIRA: CQ-743
risk: low