### PR TITLE
RELATED: CQ-670 - Implement & tweak OpenTelemetry propagation logic

### DIFF
--- a/gooddata-flight-server/gooddata_flight_server/config/config.py
+++ b/gooddata-flight-server/gooddata_flight_server/config/config.py
@@ -38,6 +38,7 @@ class OtelConfig:
     service_name: str
     service_namespace: Optional[str]
     service_instance_id: Optional[str]
+    extract_context_from_headers: bool
 
 
 @dataclass(frozen=True)
@@ -122,6 +123,7 @@ class _Settings:
     OtelServiceName = "otel_service_name"
     OtelServiceNamespace = "otel_service_namespace"
     OtelServiceInstanceId = "otel_service_instance_id"
+    OtelExtractContext = "otel_extract_context"
 
 
 _LOCALHOST = "127.0.0.1"
@@ -408,6 +410,15 @@ _VALIDATORS = [
             "condition": f"{_Settings.OtelServiceInstanceId} must be a non-empty string.",
         },
     ),
+    Validator(
+        _fqsn(_Settings.OtelExtractContext),
+        cast=bool,
+        default=False,
+        condition=_validate_boolean,
+        messages={
+            "condition": f"{_Settings.OtelExtractContext} must be a boolean value.",
+        },
+    ),
 ]
 
 
@@ -491,6 +502,7 @@ def _create_server_config(settings: Dynaconf) -> ServerConfig:
             service_name=server_settings.get(_Settings.OtelServiceName),
             service_namespace=server_settings.get(_Settings.OtelServiceNamespace),
             service_instance_id=server_settings.get(_Settings.OtelServiceInstanceId),
+            extract_context_from_headers=server_settings.get(_Settings.OtelExtractContext),
         ),
     )
 

--- a/gooddata-flight-server/gooddata_flight_server/server/flight_rpc/flight_middleware.py
+++ b/gooddata-flight-server/gooddata_flight_server/server/flight_rpc/flight_middleware.py
@@ -96,11 +96,17 @@ class CallFinalizer(pyarrow.flight.ServerMiddleware):
 class OtelMiddleware(pyarrow.flight.ServerMiddleware):
     MiddlewareName = "otel_middleware"
 
-    def __init__(self, info: pyarrow.flight.CallInfo, headers: dict[str, list[str]]) -> None:
+    def __init__(
+        self, info: pyarrow.flight.CallInfo, headers: dict[str, list[str]], extract_context: bool = False
+    ) -> None:
         super().__init__()
         method_name = info.method.name
 
-        self._otel_ctx = otelpropagate.extract(headers)
+        if extract_context:
+            self._otel_ctx = otelpropagate.extract(headers)
+        else:
+            self._otel_ctx = otelctx.get_current()
+
         self._otel_span = SERVER_TRACER.start_span(
             f"{method_name}",
             kind=SpanKind.SERVER,

--- a/gooddata-flight-server/gooddata_flight_server/server/flight_rpc/flight_middleware.py
+++ b/gooddata-flight-server/gooddata_flight_server/server/flight_rpc/flight_middleware.py
@@ -1,9 +1,16 @@
 #  (C) 2024 GoodData Corporation
 from typing import Any, Callable, Optional
 
+import opentelemetry.context as otelctx
+import opentelemetry.propagate as otelpropagate
 import pyarrow.flight
 import structlog
+from opentelemetry import trace
+from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.trace import SpanKind, StatusCode, use_span
 from typing_extensions import TypeAlias
+
+from gooddata_flight_server.utils.otel_tracing import SERVER_TRACER
 
 _LOGGER = structlog.get_logger("gooddata_flight_server.rpc")
 
@@ -84,3 +91,66 @@ class CallFinalizer(pyarrow.flight.ServerMiddleware):
                 fun(exception)
         except Exception:
             _LOGGER.critical("call_finalization_failed", exc_info=True)
+
+
+class OtelMiddleware(pyarrow.flight.ServerMiddleware):
+    MiddlewareName = "otel_middleware"
+
+    def __init__(self, info: pyarrow.flight.CallInfo, headers: dict[str, list[str]]) -> None:
+        super().__init__()
+        method_name = info.method.name
+
+        self._otel_ctx = otelpropagate.extract(headers)
+        self._otel_span = SERVER_TRACER.start_span(
+            f"{method_name}",
+            kind=SpanKind.SERVER,
+            context=self._otel_ctx,
+            attributes={
+                SpanAttributes.RPC_SYSTEM: "grpc",
+                SpanAttributes.RPC_SERVICE: "FlightRPC",
+                SpanAttributes.RPC_METHOD: method_name,
+            },
+        )
+
+        # note: the code does not set context / use span at this point because
+        # the middleware creation is done in a separate call, before the actual
+        # method invocation.
+        #
+        # the context has to be set & span used during the actual Flight RPC
+        # method handling
+
+    @property
+    def call_tracing(self) -> tuple[otelctx.Context, trace.Span]:
+        """
+        :return: tracing context & span for the current call
+        """
+        return self._otel_ctx, self._otel_span
+
+    def call_completed(self, exception: Optional[pyarrow.lib.ArrowException]) -> None:
+        # OpenTelemetry context/span restore;
+        #
+        # this has to happen because this method is done from thread managed
+        # by gRPC server / Flight & during a separate call after the request handling
+        # completes - any context juggling done previously is lost.
+        #
+        # - attach context extracted over the wire (see constructor)
+        # - use current method call's span (created during middleware init)
+        #
+        # code can then complete the span accordingly and finally detach the context
+        old_ctx = otelctx.attach(self._otel_ctx)
+        try:
+            with use_span(
+                self._otel_span,
+                end_on_exit=False,
+                record_exception=False,
+                set_status_on_exception=False,
+            ):
+                if exception is None:
+                    self._otel_span.set_status(StatusCode.OK)
+                else:
+                    self._otel_span.set_status(StatusCode.ERROR)
+                    self._otel_span.record_exception(exception)
+
+                self._otel_span.end()
+        finally:
+            otelctx.detach(old_ctx)

--- a/gooddata-flight-server/sample-config.toml
+++ b/gooddata-flight-server/sample-config.toml
@@ -259,6 +259,27 @@ otel_service_namespace = "your-namespace"
 # Default is to use current hostname.
 otel_service_instance_id = "your-service-instance-id"
 
+# optionally specify whether OpenTelemetry integration within the server should look
+# for, extract and use an OpenTelemetry context coming through the Flight RPC
+# request headers.
+#
+# When this option is enabled, the code will use OpenTelemetry's context
+# propagation `extract` method to obtain the context from Flight RPC request headers. This
+# context will then be used when creating OpenTelemetry span representing the Flight
+# RPC call.
+#
+# In simple words:
+#
+# - IF your server is configured to export traces to same backend where your server's clients
+#   also export their traces AND the clients inject the trace context into the Flight RPC headers AND
+#   you turn this option on, THEN you will be able to correlate all calls under one trace ID.
+#
+# - ELSE, you should keep this turned off; each Flight RPC request to your server will create
+#   a new trace ID.
+#
+# Default is false.
+otel_extract_context = false
+
 [flexfun]
 
 # specify one or more modules that contain FlexFun implementations

--- a/gooddata-flight-server/tests/config/sample-config.toml
+++ b/gooddata-flight-server/tests/config/sample-config.toml
@@ -31,3 +31,4 @@ otel_exporter_type = "otlp-grpc"
 otel_service_name = "your-service-name"
 otel_service_namespace = "your-namespace"
 otel_service_instance_id = "your-service-instance-id"
+otel_extract_context = true

--- a/gooddata-flight-server/tests/config/test_config.py
+++ b/gooddata-flight-server/tests/config/test_config.py
@@ -31,6 +31,7 @@ def test_read_valid():
     assert server_config.otel_config.service_name == "your-service-name"
     assert server_config.otel_config.service_namespace == "your-namespace"
     assert server_config.otel_config.service_instance_id == "your-service-instance-id"
+    assert server_config.otel_config.extract_context_from_headers is True
 
 
 def test_read_empty():
@@ -49,6 +50,7 @@ def test_read_empty():
     assert server_config.otel_config.service_name is None
     assert server_config.otel_config.service_namespace is None
     assert server_config.otel_config.service_instance_id is None
+    assert server_config.otel_config.extract_context_from_headers is False
 
     assert server_config.authentication_method == AuthenticationMethod.NoAuth
     assert server_config.token_header_name is None

--- a/gooddata-flight-server/tox.ini
+++ b/gooddata-flight-server/tox.ini
@@ -1,6 +1,6 @@
 # (C) 2024 GoodData Corporation
 [tox]
-envlist = py3{8,9,10,11}
+envlist = py3{9,10,11}
 
 [testenv]
 package = wheel


### PR DESCRIPTION
- The configs & a lot of code were in place already from day-1
  - However, the server did not have proper open telemetry middleware & handling of contexts / spans in the 'core' of the request handling logic
  - This is now implemented
- Added new option `otel_extract_context` that influences whether the middleware should extract  & use context coming 'over the wire' in the headers or not. Extracting & using context makes sense when server exports to same backend as its clients -> one can get nice long traces. If this is not the case, then this option should stay off (which is the default) => meaning every Flight RPC call will create new trace id (which the plugged in Flight RPC methods may then access and propagate to whatever calls they make)

Sample config + tests of config updated. The otel propagation logic is not auto-tested (too much work atm); was verified using manual e2e tests.