### PR TITLE
RELATED: CQ-670 - add forgotten re-exports

### DIFF
--- a/gooddata-flight-server/gooddata_flight_server/__init__.py
+++ b/gooddata-flight-server/gooddata_flight_server/__init__.py
@@ -13,6 +13,7 @@ from gooddata_flight_server.flexfun.flex_fun_execution_context import (
     ExecutionContext,
     ExecutionRequest,
 )
+from gooddata_flight_server.flexfun.flight_methods import create_flexfun_flight_methods
 from gooddata_flight_server.health.server_health_monitor import ModuleHealthStatus, ServerHealthMonitor
 from gooddata_flight_server.server.auth.auth_middleware import TokenAuthMiddleware
 from gooddata_flight_server.server.auth.token_verifier import TokenVerificationStrategy
@@ -22,6 +23,7 @@ from gooddata_flight_server.server.flight_rpc.flight_middleware import (
     CallInfo,
 )
 from gooddata_flight_server.server.flight_rpc.server_methods import FlightServerMethods
+from gooddata_flight_server.server.server_main import GoodDataFlightServer, create_server
 from gooddata_flight_server.tasks.base import TaskWaitTimeoutError
 from gooddata_flight_server.tasks.task import Task
 from gooddata_flight_server.tasks.task_error import TaskError


### PR DESCRIPTION
- the create_server, create_flexfun_methods and the server class itself should be exposed
- this is essential for programmatic usage of the infra from the outside

JIRA: CQ-670