### PR TITLE
chore: remove flight-server dependencies

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,9 +10,11 @@ pre-commit~=3.6.0
 -r ./gooddata-fdw/requirements.txt
 -r ./gooddata-dbt/requirements.txt
 -r ./gooddata-flight-server/requirements.txt
+-r ./gooddata-flexfun/requirements.txt
 -r ./gooddata-sdk/test-requirements.txt
 -r ./gooddata-pandas/test-requirements.txt
 -r ./gooddata-fdw/test-requirements.txt
 -r ./gooddata-dbt/test-requirements.txt
 -r ./gooddata-flight-server/test-requirements.txt
+-r ./gooddata-flexfun/test-requirements.txt
 -r ./tests-support/requirements.txt

--- a/gooddata-flight-server/tox.ini
+++ b/gooddata-flight-server/tox.ini
@@ -7,8 +7,6 @@ package = wheel
 wheel_build_env = .pkg
 deps =
     -r{toxinidir}/test-requirements.txt
-    -e../gooddata-api-client
-    -e../gooddata-sdk
     -e../tests-support
 setenv=
     PYTHONDONTWRITEBYTECODE=1
@@ -20,8 +18,6 @@ basepython = python3.12
 skip_install = true
 deps =
     -r{toxinidir}/type-requirements.txt
-    -e../gooddata-api-client
-    -e../gooddata-sdk
 commands =
     mypy gooddata_flight_server
 


### PR DESCRIPTION
Flight server no longer depends on SDK and API client, so let's remove that from tox.

Also add missing dev-requirements.txt entries for Flexfun.

JIRA: CQ-754
risk: low