### PR TITLE
feat: add JSON schemas for the execution contexts

### DIFF
--- a/gooddata-flexfun/README.md
+++ b/gooddata-flexfun/README.md
@@ -19,7 +19,13 @@ Finally, they provide a set of methods that can be called to provide data in res
 * `cancel` - called to cancel a query if GoodData Cloud decides to stop requesting data (e.g. if there is a timeout)
 * `on_load` - called when the FlexFun is created before any `call` or `cancel` methods are called
 
-## Usage
+## Getting Started using the FlexFun Template
+
+The easiest way to get started writing FlexFuns is to use [the template repository](https://github.com/gooddata/gooddata-flexfun-template).
+It provides a simple example of a FlexFun that can be used as a starting point for your own FlexFun with all the necessary infrastructure in place.
+It also has a README that explains how to get started with the template and some general tips on how to write FlexFuns.
+
+## Getting started using the FlexFun package directly
 
 Install the package alongside the gooddata-flight-server using pip:
 

--- a/gooddata-flexfun/gooddata_flexfun/flexfun/flex_fun_execution_context.py
+++ b/gooddata-flexfun/gooddata_flexfun/flexfun/flex_fun_execution_context.py
@@ -368,17 +368,20 @@ class LabelElementsExecutionRequest:
 
     offset: Optional[int]
     """
-    The offset of the elements.
+    The number of elements to skip before returning.
     """
 
     limit: Optional[int]
     """
-    The limit of the elements.
+    The maximum number of elements to return.
     """
 
     exclude_primary_label: Optional[bool]
     """
-    Whether to exclude primary label from the result.
+    Excludes items from the result that differ only by primary label
+
+    * false - return items with distinct primary label
+    * true - return items with distinct requested label
     """
 
     exact_filter: Optional[list[str]]

--- a/gooddata-flexfun/json_schemas/execution-context/attribute.json
+++ b/gooddata-flexfun/json_schemas/execution-context/attribute.json
@@ -1,0 +1,58 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "execution-context/attribute.json",
+    "title": "Attribute",
+    "description": "Attribute used in the execution context.",
+    "type": "object",
+    "properties": {
+        "attributeIdentifier": {
+            "type": "string",
+            "description": "Identifier of the attribute used."
+        },
+        "attributeTitle": {
+            "type": "string",
+            "description": "Title of the attribute used."
+        },
+        "labelIdentifier": {
+            "type": "string",
+            "description": "Identifier of the label used."
+        },
+        "labelTitle": {
+            "type": "string",
+            "description": "Title of the label used."
+        },
+        "dateGranularity": {
+            "$ref": "date-granularity.json",
+            "description": "Date granularity of the attribute if it is a date attribute."
+        },
+        "sorting": {
+            "$ref": "#/$defs/sorting"
+        }
+    },
+    "required": [
+        "attributeIdentifier",
+        "attributeTitle",
+        "labelIdentifier",
+        "labelTitle"
+    ],
+    "$defs": {
+        "sorting": {
+            "type": "object",
+            "properties": {
+                "sortColumn": {
+                    "type": "string"
+                },
+                "sortDirection": {
+                    "enum": [
+                        "ASC",
+                        "DESC"
+                    ]
+                }
+            },
+            "required": [
+                "sortColumn",
+                "sortDirection"
+            ]
+        }
+    }
+}

--- a/gooddata-flexfun/json_schemas/execution-context/date-granularity.json
+++ b/gooddata-flexfun/json_schemas/execution-context/date-granularity.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "execution-context/date-granularity.json",
+    "title": "Date Granularity",
+    "description": "All the supported granularities of the date attributes.",
+    "enum": [
+        "TIMESTAMP",
+        "MINUTE",
+        "HOUR",
+        "DAY",
+        "WEEK",
+        "MONTH",
+        "QUARTER",
+        "YEAR",
+        "MINUTE_OF_HOUR",
+        "HOUR_OF_DAY",
+        "DAY_OF_WEEK",
+        "DAY_OF_MONTH",
+        "DAY_OF_YEAR",
+        "WEEK_OF_YEAR",
+        "MONTH_OF_YEAR",
+        "QUARTER_OF_YEAR"
+    ]
+}

--- a/gooddata-flexfun/json_schemas/execution-context/execution-context.json
+++ b/gooddata-flexfun/json_schemas/execution-context/execution-context.json
@@ -1,0 +1,118 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "execution-context/execution-context.json",
+    "title": "Execution Context",
+    "description": "The context in which the FlexFun is executed. Contains all the information needed to execute the FlexFun.",
+    "properties": {
+        "executionType": {
+            "enum": [
+                "REPORT",
+                "LABEL_ELEMENTS"
+            ],
+            "description": "Type of the execution."
+        },
+        "organizationId": {
+            "type": "string",
+            "description": "The ID of the organization that the FlexFun is executed in."
+        },
+        "workspaceId": {
+            "type": "string",
+            "description": "The ID of the workspace that the FlexFun is executed in."
+        },
+        "userId": {
+            "type": "string",
+            "description": "The ID of the user that invoked the FlexFun."
+        },
+        "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The timestamp of the execution used as 'now' in date filters. For example 2020-06-03T10:15:30+01:00."
+        },
+        "timezone": {
+            "type": "string",
+            "description": "The timezone of the execution."
+        },
+        "weekStart": {
+            "enum": [
+                "SUNDAY",
+                "MONDAY"
+            ],
+            "description": "The day of the week that the week starts on."
+        },
+        "attributes": {
+            "type": "array",
+            "description": "The attributes used in the execution.",
+            "items": {
+                "$ref": "attribute.json"
+            }
+        },
+        "filters": {
+            "type": "array",
+            "description": "The filters used in the execution.",
+            "items": {
+                "$ref": "filter.json"
+            }
+        }
+    },
+    "allOf": [
+        {
+            "if": {
+                "properties": {
+                    "executionType": {
+                        "const": "REPORT"
+                    }
+                }
+            },
+            "then": {
+                "properties": {
+                    "reportExecutionRequest": {
+                        "type": "object",
+                        "$comment": "This is currently a free-form object with the full AFM, we might want to define a schema for it in the future."
+                    }
+                },
+                "required": [
+                    "executionType",
+                    "organizationId",
+                    "workspaceId",
+                    "userId",
+                    "attributes",
+                    "filters",
+                    "reportExecutionRequest"
+                ]
+            }
+        },
+        {
+            "if": {
+                "properties": {
+                    "executionType": {
+                        "const": "LABEL_ELEMENTS"
+                    }
+                }
+            },
+            "then": {
+                "properties": {
+                    "labelElementsExecutionRequest": {
+                        "$ref": "label-elements/execution-request.json"
+                    }
+                },
+                "required": [
+                    "executionType",
+                    "organizationId",
+                    "workspaceId",
+                    "userId",
+                    "attributes",
+                    "filters",
+                    "labelElementsExecutionRequest"
+                ]
+            }
+        }
+    ],
+    "required": [
+        "executionType",
+        "organizationId",
+        "workspaceId",
+        "userId",
+        "attributes",
+        "filters"
+    ]
+}

--- a/gooddata-flexfun/json_schemas/execution-context/filter.json
+++ b/gooddata-flexfun/json_schemas/execution-context/filter.json
@@ -1,0 +1,124 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "execution-context/filter.json",
+    "title": "Filter",
+    "anyOf": [
+        {
+            "type": "object",
+            "description": "Filter for including elements based on a label.",
+            "properties": {
+                "filterType": {
+                    "const": "positiveAttributeFilter"
+                },
+                "labelIdentifier": {
+                    "type": "string",
+                    "description": "Identifier of the label used."
+                },
+                "values": {
+                    "type": "array",
+                    "description": "The values of the label for element filtering.",
+                    "items": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    }
+                }
+            },
+            "required": [
+                "filterType",
+                "labelIdentifier",
+                "values"
+            ]
+        },
+        {
+            "type": "object",
+            "description": "Filter for excluding elements based on a label.",
+            "properties": {
+                "filterType": {
+                    "const": "negativeAttributeFilter"
+                },
+                "labelIdentifier": {
+                    "type": "string",
+                    "description": "Identifier of the label used."
+                },
+                "values": {
+                    "type": "array",
+                    "description": "The values of the label for element filtering.",
+                    "items": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    }
+                }
+            },
+            "required": [
+                "filterType",
+                "labelIdentifier",
+                "values"
+            ]
+        },
+        {
+            "type": "object",
+            "description": "Filter for relative date ranges.",
+            "properties": {
+                "filterType": {
+                    "const": "relativeDateFilter"
+                },
+                "from": {
+                    "type": "integer",
+                    "description": "The start date of the filter."
+                },
+                "to": {
+                    "type": "integer",
+                    "description": "The end date of the filter."
+                },
+                "granularity": {
+                    "$ref": "date-granularity.json",
+                    "description": "The granularity of the date filter."
+                },
+                "datasetIdentifier": {
+                    "type": "string",
+                    "description": "The dataset to filter by."
+                }
+            },
+            "required": [
+                "filterType",
+                "from",
+                "to",
+                "granularity",
+                "datasetIdentifier"
+            ]
+        },
+        {
+            "type": "object",
+            "description": "Filter for absolute date ranges.",
+            "properties": {
+                "filterType": {
+                    "const": "absoluteDateFilter"
+                },
+                "from": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{1,2}-\\d{1,2}( \\d{1,2}:\\d{1,2})?$",
+                    "description": "The start date of the filter."
+                },
+                "to": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{1,2}-\\d{1,2}( \\d{1,2}:\\d{1,2})?$",
+                    "description": "The end date of the filter."
+                },
+                "datasetIdentifier": {
+                    "type": "string",
+                    "description": "The dataset to filter by."
+                }
+            },
+            "required": [
+                "filterType",
+                "from",
+                "to",
+                "datasetIdentifier"
+            ]
+        }
+    ]
+}

--- a/gooddata-flexfun/json_schemas/execution-context/label-elements/depends-on-date-filter.json
+++ b/gooddata-flexfun/json_schemas/execution-context/label-elements/depends-on-date-filter.json
@@ -1,0 +1,110 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "execution-context/label-elements/depends-on-date-filter.json",
+    "title": "Depends On Date Filter",
+    "description": "Definition of additional filtering for the label based on date filter.",
+    "type": "object",
+    "properties": {
+        "dateFilter": {
+            "description": "The relevant date filter.",
+            "type": "object",
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "relativeDateFilter": {
+                            "$ref": "#/$defs/relativeDateFilter"
+                        }
+                    },
+                    "required": [
+                        "relativeDateFilter"
+                    ]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "absoluteDateFilter": {
+                            "$ref": "#/$defs/absoluteDateFilter"
+                        }
+                    },
+                    "required": [
+                        "absoluteDateFilter"
+                    ]
+                }
+            ]
+        }
+    },
+    "required": [
+        "dateFilter"
+    ],
+    "$defs": {
+        "absoluteDateFilter": {
+            "type": "object",
+            "properties": {
+                "from": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{1,2}-\\d{1,2}( \\d{1,2}:\\d{1,2})?$",
+                    "description": "The start date of the filter."
+                },
+                "to": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{1,2}-\\d{1,2}( \\d{1,2}:\\d{1,2})?$",
+                    "description": "The end date of the filter."
+                },
+                "dataset": {
+                    "$ref": "#/$defs/datasetId",
+                    "description": "The dataset to filter by."
+                }
+            },
+            "required": [
+                "from",
+                "to",
+                "dataset"
+            ]
+        },
+        "relativeDateFilter": {
+            "type": "object",
+            "properties": {
+                "from": {
+                    "type": "integer",
+                    "description": "The start date of the filter."
+                },
+                "to": {
+                    "type": "integer",
+                    "description": "The end date of the filter."
+                },
+                "granularity": {
+                    "$ref": "../date-granularity.json",
+                    "description": "The granularity of the filter."
+                },
+                "dataset": {
+                    "$ref": "#/$defs/datasetId",
+                    "description": "The dataset to filter by."
+                }
+            },
+            "required": [
+                "from",
+                "to",
+                "granularity",
+                "dataset"
+            ]
+        },
+        "datasetId": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "The dataset ID."
+                },
+                "type": {
+                    "const": "dataset",
+                    "description": "The dataset type."
+                }
+            },
+            "required": [
+                "id",
+                "type"
+            ]
+        }
+    }
+}

--- a/gooddata-flexfun/json_schemas/execution-context/label-elements/depends-on.json
+++ b/gooddata-flexfun/json_schemas/execution-context/label-elements/depends-on.json
@@ -1,0 +1,32 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "execution-context/label-elements/depends-on.json",
+    "title": "Depends On",
+    "description": "Definition of additional filtering for the label.",
+    "type": "object",
+    "properties": {
+        "label": {
+            "type": "string",
+            "description": "The label of the item that the current item depends on."
+        },
+        "values": {
+            "type": "array",
+            "description": "The values of the label for element filtering.",
+            "items": {
+                "type": [
+                    "string",
+                    "null"
+                ]
+            }
+        },
+        "complementFilter": {
+            "type": "boolean",
+            "description": "If true, return items that do NOT match value.",
+            "default": false
+        }
+    },
+    "required": [
+        "label",
+        "values"
+    ]
+}

--- a/gooddata-flexfun/json_schemas/execution-context/label-elements/execution-request.json
+++ b/gooddata-flexfun/json_schemas/execution-context/label-elements/execution-request.json
@@ -1,0 +1,91 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "execution-context/label-elements/execution-request.json",
+    "title": "Label Elements Execution Request",
+    "description": "Request to get elements of a label.",
+    "type": "object",
+    "properties": {
+        "label": {
+            "type": "string",
+            "description": "The label to get the elements for."
+        },
+        "limit": {
+            "type": "integer",
+            "description": "The maximum number of elements to return.",
+            "minimum": 1
+        },
+        "offset": {
+            "type": "integer",
+            "description": "The number of elements to skip before returning.",
+            "minimum": 0
+        },
+        "excludePrimaryLabel": {
+            "type": "boolean",
+            "description": "Excludes items from the result that differ only by primary label\n* false - return items with distinct primary label\n* true - return items with distinct requested label",
+            "default": false
+        },
+        "exactFilter": {
+            "type": "array",
+            "description": "Return only items, whose label exactly matches one of filter values.",
+            "items": {
+                "type": "string"
+            }
+        },
+        "patternFilter": {
+            "type": "string",
+            "description": "Return only items whose label matches the pattern."
+        },
+        "complementFilter": {
+            "type": "boolean",
+            "description": "If true, return items that do not match the exactFilter or patternFilter.",
+            "default": false
+        },
+        "dependsOn": {
+            "type": "array",
+            "description": "Return only items that are not filtered-out by the parent filters.",
+            "items": {
+                "anyOf": [
+                    {
+                        "$ref": "depends-on.json"
+                    },
+                    {
+                        "$ref": "depends-on-date-filter.json"
+                    }
+                ]
+            }
+        },
+        "validateBy": {
+            "type": "array",
+            "description": "Return only items that are valid by the specified item.",
+            "items": {
+                "$ref": "#/$defs/validateByItem"
+            }
+        }
+    },
+    "required": [
+        "label"
+    ],
+    "$defs": {
+        "validateByItem": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "The id of the item to validate."
+                },
+                "type": {
+                    "enum": [
+                        "label",
+                        "attribute",
+                        "fact",
+                        "metric"
+                    ]
+                }
+            },
+            "required": [
+                "id",
+                "type"
+            ]
+        }
+    }
+}

--- a/gooddata-flexfun/test-requirements.txt
+++ b/gooddata-flexfun/test-requirements.txt
@@ -1,2 +1,3 @@
+jsonschema~=4.23.0
 pytest~=8.3.3
 pytest-cov~=5.0.0

--- a/gooddata-flexfun/tests/json_schemas/__init__.py
+++ b/gooddata-flexfun/tests/json_schemas/__init__.py
@@ -1,0 +1,1 @@
+# (C) 2024 GoodData Corporation

--- a/gooddata-flexfun/tests/json_schemas/conftest.py
+++ b/gooddata-flexfun/tests/json_schemas/conftest.py
@@ -1,0 +1,31 @@
+# (C) 2024 GoodData Corporation
+from pathlib import Path
+from typing import Any
+
+import pytest
+from jsonschema.validators import Draft202012Validator
+from orjson import orjson
+from referencing import Registry, Resource
+
+SCHEMAS = Path("json_schemas")
+
+
+def retrieve_from_filesystem(uri: str):
+    path = SCHEMAS / Path(uri)
+    contents = orjson.loads(path.read_text())
+    return Resource.from_contents(contents)
+
+
+@pytest.fixture
+def schema_registry() -> Registry[Any]:
+    return Registry(retrieve=retrieve_from_filesystem)
+
+
+@pytest.fixture
+def get_validator(schema_registry):
+    def get_validator_for_schema(schema_uri):
+        """Return a JSON schema validator for the given schema URI."""
+        schema = schema_registry.get_or_retrieve(schema_uri)
+        return Draft202012Validator(schema.value.contents, registry=schema_registry)
+
+    return get_validator_for_schema

--- a/gooddata-flexfun/tests/json_schemas/test_attribute_schema.py
+++ b/gooddata-flexfun/tests/json_schemas/test_attribute_schema.py
@@ -1,0 +1,51 @@
+# (C) 2024 GoodData Corporation
+import pytest
+from jsonschema.exceptions import ValidationError
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        {
+            "attributeIdentifier": "attr1",
+            "attributeTitle": "Attribute 1",
+            "labelIdentifier": "label1",
+            "labelTitle": "Label 1",
+        },
+        {
+            "attributeIdentifier": "attr1",
+            "attributeTitle": "Attribute 1",
+            "labelIdentifier": "label1",
+            "labelTitle": "Label 1",
+            "dateGranularity": "DAY",
+            "sorting": {"sortColumn": "column1", "sortDirection": "ASC"},
+        },
+    ],
+)
+def test_valid_attribute_schema(value, get_validator):
+    validator = get_validator("execution-context/attribute.json")
+    validator.validate(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        {"attributeIdentifier": "attr1"},  # missing attributeTitle
+        {"attributeTitle": "Attribute 1"},  # missing attributeIdentifier
+        # missing labelTitle
+        {"attributeIdentifier": "attr1", "attributeTitle": "Attribute 1", "labelIdentifier": "label1"},
+        # missing sortDirection
+        {
+            "attributeIdentifier": "attr1",
+            "attributeTitle": "Attribute 1",
+            "labelIdentifier": "label1",
+            "labelTitle": "Label 1",
+            "dateGranularity": "DAY",
+            "sorting": {"sortColumn": "column1"},
+        },
+    ],
+)
+def test_invalid_attribute_schema(value, get_validator):
+    validator = get_validator("execution-context/attribute.json")
+    with pytest.raises(ValidationError):
+        validator.validate(value)

--- a/gooddata-flexfun/tests/json_schemas/test_depends_on_date_filter_schema.py
+++ b/gooddata-flexfun/tests/json_schemas/test_depends_on_date_filter_schema.py
@@ -1,0 +1,55 @@
+# (C) 2024 GoodData Corporation
+import pytest
+from jsonschema.exceptions import ValidationError
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        {
+            "dateFilter": {
+                "relativeDateFilter": {
+                    "from": -1,
+                    "to": 0,
+                    "granularity": "DAY",
+                    "dataset": {"id": "dataset1", "type": "dataset"},
+                }
+            }
+        },
+        {
+            "dateFilter": {
+                "absoluteDateFilter": {
+                    "from": "2021-01-01",
+                    "to": "2021-12-31",
+                    "dataset": {"id": "dataset1", "type": "dataset"},
+                }
+            }
+        },
+    ],
+)
+def test_valid_depends_on_date_filter_schema(value, get_validator):
+    validator = get_validator("execution-context/label-elements/depends-on-date-filter.json")
+    validator.validate(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        {"dateFilter": {"relativeDateFilter": {"from": -1, "to": 0, "granularity": "DAY"}}},  # missing dataset
+        {"dateFilter": {"absoluteDateFilter": {"from": "2021-01-01", "to": "2021-12-31"}}},  # missing dataset
+        {
+            "dateFilter": {
+                "relativeDateFilter": {
+                    "from": "-1",  # wrong value type
+                    "to": "0",
+                    "granularity": "DAY",
+                    "dataset": {"id": "dataset1", "type": "dataset"},
+                }
+            }
+        },
+    ],
+)
+def test_invalid_depends_on_date_filter_schema(value, get_validator):
+    validator = get_validator("execution-context/label-elements/depends-on-date-filter.json")
+    with pytest.raises(ValidationError):
+        validator.validate(value)

--- a/gooddata-flexfun/tests/json_schemas/test_depends_on_schema.py
+++ b/gooddata-flexfun/tests/json_schemas/test_depends_on_schema.py
@@ -1,0 +1,29 @@
+# (C) 2024 GoodData Corporation
+import pytest
+from jsonschema.exceptions import ValidationError
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        {"label": "exampleLabel", "values": ["value1", "value2", None]},
+        {"label": "exampleLabel", "values": ["value1", "value2", None], "complementFilter": True},
+    ],
+)
+def test_valid_depends_on_schema(value, get_validator):
+    validator = get_validator("execution-context/label-elements/depends-on.json")
+    validator.validate(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        {"label": "exampleLabel"},  # missing values
+        {"values": ["value1", "value2", None]},  # missing label
+        {"label": "exampleLabel", "values": [1, 2, None], "complementFilter": "True"},  # wrong value type
+    ],
+)
+def test_invalid_depends_on_schema(value, get_validator):
+    validator = get_validator("execution-context/label-elements/depends-on.json")
+    with pytest.raises(ValidationError):
+        validator.validate(value)

--- a/gooddata-flexfun/tests/json_schemas/test_execution_context_schema.py
+++ b/gooddata-flexfun/tests/json_schemas/test_execution_context_schema.py
@@ -1,0 +1,118 @@
+# (C) 2024 GoodData Corporation
+import pytest
+from jsonschema.exceptions import ValidationError
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        # minimal valid schema for REPORT execution type
+        {
+            "executionType": "REPORT",
+            "organizationId": "org1",
+            "workspaceId": "ws1",
+            "userId": "user1",
+            "attributes": [],
+            "filters": [],
+            "reportExecutionRequest": {},
+        },
+        # minimal valid schema for LABEL_ELEMENTS execution type
+        {
+            "executionType": "LABEL_ELEMENTS",
+            "organizationId": "org2",
+            "workspaceId": "ws2",
+            "userId": "user2",
+            "attributes": [],
+            "filters": [],
+            "labelElementsExecutionRequest": {"label": "label1"},
+        },
+        # full valid schema for LABEL_ELEMENTS execution type
+        {
+            "executionType": "LABEL_ELEMENTS",
+            "organizationId": "org3",
+            "workspaceId": "ws3",
+            "userId": "user3",
+            "timestamp": "2023-10-01T10:15:30+01:00",
+            "timezone": "UTC",
+            "week_start": "MONDAY",
+            "attributes": [
+                {
+                    "attributeIdentifier": "attr1",
+                    "attributeTitle": "Attribute 1",
+                    "labelIdentifier": "label1",
+                    "labelTitle": "Label 1",
+                }
+            ],
+            "filters": [],
+            "labelElementsExecutionRequest": {
+                "label": "label2",
+                "limit": 5,
+                "offset": 2,
+                "excludePrimaryLabel": False,
+                "exactFilter": ["value3"],
+                "patternFilter": "pattern?",
+                "complementFilter": True,
+                "dependsOn": [{"label": "parent1", "values": ["foo", "bar"]}],
+                "validateBy": [{"id": "validator2", "type": "attribute"}],
+            },
+        },
+    ],
+)
+def test_valid_execution_context_schema(value, get_validator):
+    validator = get_validator("execution-context/execution-context.json")
+    validator.validate(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        # missing required properties
+        {"executionType": "REPORT"},
+        {"organizationId": "org1"},
+        {"workspaceId": "ws1"},
+        {"userId": "user1"},
+        {"attributes": []},
+        {"filters": []},
+        # invalid executionType
+        {
+            "executionType": "INVALID",
+            "organizationId": "org1",
+            "workspaceId": "ws1",
+            "userId": "user1",
+            "attributes": [],
+            "filters": [],
+        },
+        # missing reportExecutionRequest for REPORT type
+        {
+            "executionType": "REPORT",
+            "organizationId": "org1",
+            "workspaceId": "ws1",
+            "userId": "user1",
+            "attributes": [],
+            "filters": [],
+        },
+        # missing labelElementsExecutionRequest for LABEL_ELEMENTS type
+        {
+            "executionType": "LABEL_ELEMENTS",
+            "organizationId": "org2",
+            "workspaceId": "ws2",
+            "userId": "user2",
+            "attributes": [],
+            "filters": [],
+        },
+        # invalid attribute structure
+        {
+            "executionType": "LABEL_ELEMENTS",
+            "organizationId": "org3",
+            "workspaceId": "ws3",
+            "userId": "user3",
+            "attributes": [{"attributeIdentifier": "attr1"}],  # missing required properties
+            "filters": [],
+            "labelElementsExecutionRequest": {"label": "label2"},
+        },
+    ],
+)
+def test_invalid_execution_context_schema(value, get_validator):
+    validator = get_validator("execution-context/execution-context.json")
+    with pytest.raises(ValidationError):
+        validator.validate(value)

--- a/gooddata-flexfun/tests/json_schemas/test_filter_schema.py
+++ b/gooddata-flexfun/tests/json_schemas/test_filter_schema.py
@@ -1,0 +1,50 @@
+# (C) 2024 GoodData Corporation
+import pytest
+from jsonschema.exceptions import ValidationError
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        {
+            "filterType": "positiveAttributeFilter",
+            "labelIdentifier": "attribute1",
+            "values": ["id1", "id2", "id3", None],
+        },
+        {
+            "filterType": "negativeAttributeFilter",
+            "labelIdentifier": "attribute1",
+            "values": ["id1", "id2", "id3", None],
+        },
+        {
+            "filterType": "relativeDateFilter",
+            "from": -5,
+            "to": 0,
+            "granularity": "DAY",
+            "datasetIdentifier": "dataset1",
+        },
+        {"filterType": "absoluteDateFilter", "from": "2021-01-01", "to": "2021-12-31", "datasetIdentifier": "dataset1"},
+    ],
+)
+def test_valid_filter_schema(value, get_validator):
+    validator = get_validator("execution-context/filter.json")
+    validator.validate(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        {"labelIdentifier": "attribute1", "values": ["id1", "id2", "id3", None]},  # missing filterType
+        # invalid filterType
+        {"filterType": "invalid", "labelIdentifier": "attribute1", "values": ["id1", "id2", "id3", None]},
+        {"filterType": "positiveAttributeFilter", "labelIdentifier": "attribute1"},  # missing values
+        {"filterType": "positiveAttributeFilter", "labelIdentifier": "attribute1", "values": [5]},  # invalid values
+        {"filterType": "negativeAttributeFilter", "labelIdentifier": "attribute1"},  # missing values
+        {"filterType": "relativeDateFilter", "from": -5, "to": 0, "granularity": "DAY"},  # missing datasetIdentifier
+        {"filterType": "absoluteDateFilter", "from": "2021-01-01", "to": "2021-12-31"},  # missing datasetIdentifier
+    ],
+)
+def test_invalid_filter_schema(value, get_validator):
+    validator = get_validator("execution-context/filter.json")
+    with pytest.raises(ValidationError):
+        validator.validate(value)

--- a/gooddata-flexfun/tests/json_schemas/test_label_elements_execution_request_schema.py
+++ b/gooddata-flexfun/tests/json_schemas/test_label_elements_execution_request_schema.py
@@ -1,0 +1,49 @@
+# (C) 2024 GoodData Corporation
+import pytest
+from jsonschema.exceptions import ValidationError
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        # bare minimum
+        {
+            "label": "label1",
+        },
+        # all properties
+        {
+            "label": "label2",
+            "limit": 5,
+            "offset": 2,
+            "excludePrimaryLabel": False,
+            "exactFilter": ["value3"],
+            "patternFilter": "pattern?",
+            "complementFilter": True,
+            "dependsOn": [{"label": "parent1", "values": ["foo", "bar"]}],
+            "validateBy": [{"id": "validator2", "type": "attribute"}],
+        },
+    ],
+)
+def test_valid_execution_request_schema(value, get_validator):
+    validator = get_validator("execution-context/label-elements/execution-request.json")
+    validator.validate(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        {"label": "label2", "limit": "5"},  # wrong value type
+        {"label": "label2", "offset": "2"},  # wrong value type
+        {"label": "label2", "excludePrimaryLabel": "False"},  # wrong value type
+        {"label": "label2", "exactFilter": "value3"},  # wrong value type
+        {"label": "label2", "patternFilter": 5},  # wrong value type
+        {"label": "label2", "complementFilter": "True"},  # wrong value type
+        {"label": "label2", "dependsOn": {"label": "parent1", "values": ["foo", "bar"]}},  # wrong value type
+        {"label": "label2", "validateBy": {"id": "validator2", "type": "attribute"}},  # wrong value type
+        {"label": "label2", "validateBy": {"id": "validator2", "type": "invalid"}},  # wrong validateBy type
+    ],
+)
+def test_invalid_execution_request_schema(value, get_validator):
+    validator = get_validator("execution-context/label-elements/execution-request.json")
+    with pytest.raises(ValidationError):
+        validator.validate(value)


### PR DESCRIPTION
Add schemata for the execution requests coming from the server. Does not type the AFM part yet, but all the others are covered. Includes several tests making sure the schemata behave as expected.

Also improve the flexfun README file: link to the much more information-rich template repo.

JIRA: CQ-755, CQ-756
risk: low