### PR TITLE
RELATED: CQ-670 - docs improvements

### DIFF
--- a/gooddata-flexfun/gooddata_flexfun/flexfun/flex_fun.py
+++ b/gooddata-flexfun/gooddata_flexfun/flexfun/flex_fun.py
@@ -16,16 +16,25 @@ class FlexFun(abc.ABC):
 
     - a full schema of the result and all it's columns must be known up-front
 
-    - the function may return only subset of columns if the caller only
-      asks for certain columns
+    - the function receives `parameters` (arguments) that describe the context
+      in which it was invoked. The function _may_ use this information as input
+      to algorithms that it uses to generate the result data
 
-      NOTE: this is only about trimming columns - the result cardinality is
-      the same just that some columns are not returned.
+    - the caller may indicate to the function that out of all columns in the
+      schema, it is only interested in a subset of `columns`
+
+      NOTE: the list of `columns` is provided as hint for column-trimming purposes.
+      The function _should_ use the `columns` hint and only return the desired columns.
+      The function _may_ ignore this and always return all columns / superset of columns:
+      the caller will ignore the extra information.
+
+      At the same time, the `columns` hint is _not_ an indication that the function
+      should perform particular aggregation or do computation differently. To determine this,
+      the function _must_ inspect the `parameters` to actually determine what the caller
+      is interested in.
 
     Programming detail: a new instance of the FlexFun will be created
     for every call using the `create` method.
-
-    TODO: rename the class... i'm not very creative right now
     """
 
     Name: Optional[str] = None
@@ -77,9 +86,9 @@ class FlexFun(abc.ABC):
         Function call.
 
         :param parameters: parameters sent from the GoodData Cloud / FlexQuery.
-        :param columns: hints which columns SHOULD be returned; the FlexFun may decide to ignore
+        :param columns: hints which columns _should_ be returned; the FlexFun may decide to ignore
          this and always return all columns. The extraneous columns will be trimmed when received
-         by FlexQuery.
+         by FlexQuery. See comments of FlexFun class to learn more.
         :param headers: Flight RPC headers
         :return: result of the call
         """

--- a/gooddata-flexfun/gooddata_flexfun/flexfun/flex_fun_task.py
+++ b/gooddata-flexfun/gooddata_flexfun/flexfun/flex_fun_task.py
@@ -1,40 +1,12 @@
 #  (C) 2024 GoodData Corporation
-from collections.abc import Iterable
 from typing import Optional, Union
 
-import pyarrow
 import structlog
-from gooddata_flight_server import ArrowData, FlightDataTaskResult, Task, TaskError, TaskResult
+from gooddata_flight_server import FlightDataTaskResult, Task, TaskError, TaskResult
 
 from gooddata_flexfun.flexfun.flex_fun import FlexFun
 
 _LOGGER = structlog.get_logger("gooddata_flexfun.task")
-
-
-class _FlexFunResult(FlightDataTaskResult):
-    __slots__ = ("_result",)
-
-    def __init__(self, result: ArrowData) -> None:
-        # if function returns result as a reader, then naturally it can only be
-        # consumed once.
-        #
-        # on the other hand, if the result is table, it can be read as long as
-        # the result is present in the system (influenced by result TTL setting)
-        super().__init__(single_use_data=isinstance(result, pyarrow.RecordBatchReader))
-
-        self._result = result
-
-    def get_schema(self) -> pyarrow.Schema:
-        return self._result.schema
-
-    def _get_data(self) -> Union[Iterable[ArrowData], ArrowData]:
-        return self._result
-
-    def _close(self) -> None:
-        if isinstance(self._result, pyarrow.RecordBatchReader):
-            self._result.close()
-
-        self._result = None
 
 
 class FlexFunTask(Task):
@@ -73,7 +45,7 @@ class FlexFunTask(Task):
             headers=self._headers,
         )
 
-        return _FlexFunResult(result)
+        return FlightDataTaskResult.for_data(result)
 
     def on_task_cancel(self) -> None:
         _LOGGER.info("flexfun_task_cancel", fun=self._fun.Name, task_id=self._task_id)

--- a/gooddata-flight-server/gooddata_flight_server/server/flight_rpc/server_methods.py
+++ b/gooddata-flight-server/gooddata_flight_server/server/flight_rpc/server_methods.py
@@ -1,17 +1,25 @@
 # (C) 2024 GoodData Corporation
 from collections.abc import Generator
+from typing import Optional
 
 import pyarrow.flight
+import structlog
 
+from gooddata_flight_server.errors.error_info import ErrorCode, ErrorInfo
 from gooddata_flight_server.server.flight_rpc.flight_middleware import (
     CallFinalizer,
     CallInfo,
 )
+from gooddata_flight_server.tasks.task_executor import TaskExecutor
+from gooddata_flight_server.tasks.task_result import FlightDataTaskResult
+
+_LOGGER = structlog.get_logger("gooddata_flight_server.rpc")
 
 
 class FlightServerMethods:
     """
-    Base class for implementations of Flight RPC server methods.
+    Base class for implementations of Flight RPC server methods. This class contains a couple of utility
+    methods that may be useful in subclasses.
 
     Typings reverse-engineered from PyArrow's Cython code.
     """
@@ -51,6 +59,91 @@ class FlightServerMethods:
         assert isinstance(mw, CallFinalizer)
 
         return mw
+
+    @staticmethod
+    def do_get_task_result(
+        context: pyarrow.flight.ServerCallContext, task_executor: TaskExecutor, task_id: str
+    ) -> pyarrow.flight.FlightDataStream:
+        """
+        Utility method that creates a FlightDataStream from a result of a task that was
+        previously executed. You typically want to use this in implementation of `do_get`.
+
+        This method ensures that once the data is sent out, all necessary locks it previously
+        acquired to protect the data are freed. Single-use results will be closed once they
+        are sent out. The method uses current's call finalizer middleware to accomplish this.
+
+        :param context: server call context
+        :param task_executor: task executor where the task run
+        :param task_id: task identifier
+        :return: FlightDataStream, can be returned as-is as result of do_get
+        """
+        try:
+            task_result = task_executor.wait_for_result(task_id)
+            if task_result is None:
+                raise ErrorInfo.for_reason(
+                    ErrorCode.INVALID_TICKET,
+                    f"Unable to serve data for task '{task_id}'. The task result is not present.",
+                ).to_user_error()
+
+            if task_result.error is not None:
+                raise task_result.error.as_flight_error()
+
+            if task_result.cancelled:
+                raise ErrorInfo.for_reason(
+                    ErrorCode.COMMAND_CANCELLED,
+                    f"FlexFun invocation was cancelled. Invocation task was: '{task_result.task_id}'.",
+                ).to_server_error()
+
+            result = task_result.result
+            if not isinstance(result, FlightDataTaskResult):
+                raise ErrorInfo.for_reason(
+                    ErrorCode.INTERNAL_ERROR,
+                    f"An internal error has occurred while attempting read result for '{task_id}'."
+                    f"While the result exists, it is of an unexpected type: {type(result).__name__} ",
+                ).to_internal_error()
+
+            rlock, data = result.acquire_data()
+
+            def _on_end(_: Optional[pyarrow.ArrowException]) -> None:
+                """
+                Once the request that streams the data out is done, make sure
+                to release the read-lock. Single-use results are closed at
+                this point because the data cannot be read again anyway.
+                """
+                rlock.release()
+
+                if result.single_use_data:
+                    # note: results with single-use data can only ever have one active
+                    #  reader (e.g. this one). since the rlock is now released the
+                    #  close will proceed without chance of being blocked
+                    try:
+                        result.close()
+                    except Exception:
+                        # log and sink these Exceptions - not much to do
+                        _LOGGER.error("do_get_close_failed", exc_info=True)
+
+            finalizer = FlightServerMethods.call_finalizer_middleware(context)
+            finalizer.register_on_end(_on_end)
+
+            if isinstance(data, pyarrow.Table):
+                _LOGGER.info("do_get_table", task_id=task_id, num_rows=data.num_rows)
+
+                return pyarrow.flight.RecordBatchStream(data)
+            elif isinstance(data, pyarrow.RecordBatchReader):
+                _LOGGER.info("do_get_reader", task_id=task_id)
+
+                return pyarrow.flight.RecordBatchStream(data)
+
+            _LOGGER.info("do_get_generator", task_id=task_id)
+            return pyarrow.flight.GeneratorStream(data)
+        except Exception:
+            _LOGGER.error("do_get_failed", exc_info=True)
+            raise
+
+    ###################################################################
+    # Flight RPC methods - to be implemented as needed by
+    # subclasses.
+    ###################################################################
 
     def list_flights(
         self, context: pyarrow.flight.ServerCallContext, criteria: bytes


### PR DESCRIPTION
- Added docs introducing and giving example how to use the TaskExecutor
- Discovered that the infra was missing some common convenience
- Added utilities / convenience methods to create TaskResult from Arrow Table or RecordBatchReader
- Added utility to create FlightDataStream for a task result; this can be used to conveniently implement do_get() when tasks are involved
- Removed some dead todos + clarified contract in FlexFun