### PR TITLE
fix: add missing __init__.py file

### DIFF
--- a/gooddata-sdk/gooddata_sdk/catalog/organization/layout/__init__.py
+++ b/gooddata-sdk/gooddata_sdk/catalog/organization/layout/__init__.py
@@ -1,0 +1,1 @@
+# (C) 2024 GoodData Corporation


### PR DESCRIPTION
Missing `__init__.py` file caused `from gooddata_sdk import *` to fail.

JIRA: TRIVIAL
risk: low