### PR TITLE
chore: add missing export

### DIFF
--- a/gooddata-flexconnect/gooddata_flexconnect/__init__.py
+++ b/gooddata-flexconnect/gooddata_flexconnect/__init__.py
@@ -5,6 +5,7 @@ from gooddata_flexconnect.function.execution_context import (
     ExecutionContextAbsoluteDateFilter,
     ExecutionContextAttribute,
     ExecutionContextAttributeSorting,
+    ExecutionContextFilter,
     ExecutionContextNegativeAttributeFilter,
     ExecutionContextPositiveAttributeFilter,
     ExecutionContextRelativeDateFilter,


### PR DESCRIPTION
To enable proper type safety in client code, we need to export the "umbrella" ExecutionContextFilter type as well.

JIRA: CQ-893
risk: low