### PR TITLE
RELATED: CQ-1005 - make FlexConnect function call deadline configurable

### DIFF
--- a/gooddata-flexconnect/gooddata_flexconnect/function/flight_methods.py
+++ b/gooddata-flexconnect/gooddata_flexconnect/function/flight_methods.py
@@ -150,6 +150,11 @@ class _FlexConnectServerMethods(FlightServerMethods):
                 # XXX: this should be enhanced to implement polling
                 task_result = self._ctx.task_executor.wait_for_result(task.task_id, self._call_deadline)
             except TaskWaitTimeoutError:
+                cancelled = self._ctx.task_executor.cancel(task.task_id)
+                _LOGGER.warning(
+                    "flexconnect_fun_call_timeout", task_id=task.task_id, fun=task.fun_name, cancelled=cancelled
+                )
+
                 raise ErrorInfo.for_reason(
                     ErrorCode.TIMEOUT, f"GetFlightInfo timed out while waiting for task {task.task_id}."
                 ).to_timeout_error()

--- a/gooddata-flexconnect/gooddata_flexconnect/function/flight_methods.py
+++ b/gooddata-flexconnect/gooddata_flexconnect/function/flight_methods.py
@@ -21,13 +21,13 @@ from gooddata_flexconnect.function.function_registry import FlexConnectFunctionR
 from gooddata_flexconnect.function.function_task import FlexConnectFunctionTask
 
 _LOGGER = structlog.get_logger("gooddata_flexconnect.rpc")
-_DEFAULT_TASK_WAIT = 60.0
 
 
 class _FlexConnectServerMethods(FlightServerMethods):
-    def __init__(self, ctx: ServerContext, registry: FlexConnectFunctionRegistry) -> None:
+    def __init__(self, ctx: ServerContext, registry: FlexConnectFunctionRegistry, call_deadline_ms: float) -> None:
         self._ctx = ctx
         self._registry = registry
+        self._call_deadline = call_deadline_ms / 1000
 
     @staticmethod
     def _create_descriptor(fun_name: str, metadata: Optional[dict]) -> pyarrow.flight.FlightDescriptor:
@@ -148,7 +148,7 @@ class _FlexConnectServerMethods(FlightServerMethods):
 
             try:
                 # XXX: this should be enhanced to implement polling
-                task_result = self._ctx.task_executor.wait_for_result(task.task_id, _DEFAULT_TASK_WAIT)
+                task_result = self._ctx.task_executor.wait_for_result(task.task_id, self._call_deadline)
             except TaskWaitTimeoutError:
                 raise ErrorInfo.for_reason(
                     ErrorCode.TIMEOUT, f"GetFlightInfo timed out while waiting for task {task.task_id}."
@@ -195,6 +195,27 @@ class _FlexConnectServerMethods(FlightServerMethods):
 
 _FLEX_CONNECT_CONFIG_SECTION = "flexconnect"
 _FLEX_CONNECT_FUNCTION_LIST = "functions"
+_FLEX_CONNECT_CALL_DEADLINE_MS = "call_deadline_ms"
+_DEFAULT_FLEX_CONNECT_CALL_DEADLINE_MS = 180_000
+
+
+def _read_call_deadline_ms(ctx: ServerContext) -> int:
+    call_deadline = ctx.settings.get(f"{_FLEX_CONNECT_CONFIG_SECTION}.{_FLEX_CONNECT_CALL_DEADLINE_MS}")
+    if call_deadline is None:
+        return _DEFAULT_FLEX_CONNECT_CALL_DEADLINE_MS
+
+    try:
+        call_deadline_ms = int(call_deadline)
+        if call_deadline_ms <= 0:
+            raise ValueError()
+
+        return call_deadline_ms
+    except ValueError:
+        raise ValueError(
+            f"Value of {_FLEX_CONNECT_CONFIG_SECTION}.{_FLEX_CONNECT_CALL_DEADLINE_MS} must "
+            f"be a positive number - duration, in milliseconds, that FlexConnect function "
+            f"calls are expected to run."
+        )
 
 
 @flight_server_methods
@@ -209,7 +230,9 @@ def create_flexconnect_flight_methods(ctx: ServerContext) -> FlightServerMethods
     :return: new instance of Flight RPC server methods to integrate into the server
     """
     modules = list(ctx.settings.get(f"{_FLEX_CONNECT_CONFIG_SECTION}.{_FLEX_CONNECT_FUNCTION_LIST}") or [])
+    call_deadline_ms = _read_call_deadline_ms(ctx)
+
     _LOGGER.info("flexconnect_init", modules=modules)
     registry = FlexConnectFunctionRegistry().load(ctx, modules)
 
-    return _FlexConnectServerMethods(ctx, registry)
+    return _FlexConnectServerMethods(ctx, registry, call_deadline_ms)

--- a/gooddata-flexconnect/gooddata_flexconnect/function/function_task.py
+++ b/gooddata-flexconnect/gooddata_flexconnect/function/function_task.py
@@ -45,6 +45,14 @@ class FlexConnectFunctionTask(Task):
             headers=self._headers,
         )
 
+        # switch task to non-cancellable state; once the code creates
+        # and returns the result, the task successfully executed and there
+        # is nothing to cancel.
+        #
+        # NOTE: if the switch finds that task got cancelled already, it
+        # bails and raises error.
+        self.switch_non_cancellable()
+
         return FlightDataTaskResult.for_data(result)
 
     def on_task_cancel(self) -> None:

--- a/gooddata-flexconnect/tests/server/conftest.py
+++ b/gooddata-flexconnect/tests/server/conftest.py
@@ -76,10 +76,11 @@ def flexconnect_server(
     tls: bool = False,
     mtls: bool = False,
 ) -> GoodDataFlightServer:
-    envvar = ", ".join([f'"{module}"' for module in modules])
-    envvar = f"[{envvar}]"
+    funs = ", ".join([f'"{module}"' for module in modules])
+    funs = f"[{funs}]"
 
-    os.environ["GOODDATA_FLIGHT_FLEXCONNECT__FUNCTIONS"] = envvar
+    os.environ["GOODDATA_FLIGHT_FLEXCONNECT__FUNCTIONS"] = funs
+    os.environ["GOODDATA_FLIGHT_FLEXCONNECT__CALL_DEADLINE_MS"] = "500"
 
     with server(create_flexconnect_flight_methods, tls, mtls) as s:
         yield s

--- a/gooddata-flexconnect/tests/server/funs/fun1.py
+++ b/gooddata-flexconnect/tests/server/funs/fun1.py
@@ -5,8 +5,8 @@ from gooddata_flexconnect.function.function import FlexConnectFunction
 from gooddata_flight_server import ArrowData
 
 
-class _SimpleFun(FlexConnectFunction):
-    Name = "SimpleFun"
+class _SimpleFun1(FlexConnectFunction):
+    Name = "SimpleFun1"
     Schema = pyarrow.schema(
         fields=[
             pyarrow.field("col1", pyarrow.int64()),

--- a/gooddata-flexconnect/tests/server/test_flexconnect_server.py
+++ b/gooddata-flexconnect/tests/server/test_flexconnect_server.py
@@ -1,7 +1,10 @@
 #  (C) 2024 GoodData Corporation
 import orjson
 import pyarrow.flight
+import pytest
+from gooddata_flight_server import ErrorCode
 
+from tests.assert_error_info import assert_error_code
 from tests.server.conftest import flexconnect_server
 
 
@@ -16,12 +19,12 @@ def test_basic_function():
         assert fun_info.descriptor.command is not None
         assert len(fun_info.descriptor.command)
         cmd = orjson.loads(fun_info.descriptor.command)
-        assert cmd["functionName"] == "SimpleFun"
+        assert cmd["functionName"] == "SimpleFun1"
 
         descriptor = pyarrow.flight.FlightDescriptor.for_command(
             orjson.dumps(
                 {
-                    "functionName": "SimpleFun",
+                    "functionName": "SimpleFun1",
                     "parameters": {"test1": 1, "test2": 2, "test3": 3},
                 }
             )
@@ -45,7 +48,7 @@ def test_function_with_on_load():
         descriptor = pyarrow.flight.FlightDescriptor.for_command(
             orjson.dumps(
                 {
-                    "functionName": "SimpleFun",
+                    "functionName": "SimpleFun2",
                     "parameters": {"test1": 1, "test2": 2, "test3": 3},
                 }
             )
@@ -69,12 +72,12 @@ def test_basic_function_tls(tls_ca_cert):
         assert fun_info.descriptor.command is not None
         assert len(fun_info.descriptor.command)
         cmd = orjson.loads(fun_info.descriptor.command)
-        assert cmd["functionName"] == "SimpleFun"
+        assert cmd["functionName"] == "SimpleFun1"
 
         descriptor = pyarrow.flight.FlightDescriptor.for_command(
             orjson.dumps(
                 {
-                    "functionName": "SimpleFun",
+                    "functionName": "SimpleFun1",
                     "parameters": {"test1": 1, "test2": 2, "test3": 3},
                 }
             )
@@ -84,3 +87,32 @@ def test_basic_function_tls(tls_ca_cert):
 
         assert len(data) == 3
         assert data.column_names == ["col1", "col2", "col3"]
+
+
+def test_function_with_call_deadline():
+    """
+    Flight RPC implementation that invokes FlexConnect can be setup with
+    deadline for the invocation duration (done by GetFlightInfo).
+
+    If the function invocation (or wait for the invocation) exceeds the
+    deadline, the GetFlightInfo will fail with timeout and the underlying
+    task will be cancelled (if possible).
+
+    In these cases, the GetFlightInfo raises FlightTimedOutError with
+    appropriate error code.
+    """
+    with flexconnect_server(["tests.server.funs.fun3"]) as s:
+        c = pyarrow.flight.FlightClient(s.location)
+        descriptor = pyarrow.flight.FlightDescriptor.for_command(
+            orjson.dumps(
+                {
+                    "functionName": "LongRunningFun",
+                    "parameters": {"test1": 1, "test2": 2, "test3": 3},
+                }
+            )
+        )
+
+        with pytest.raises(pyarrow.flight.FlightTimedOutError) as e:
+            c.get_flight_info(descriptor)
+
+        assert_error_code(ErrorCode.TIMEOUT, e.value)

--- a/gooddata-flight-server/gooddata_flight_server/tasks/thread_task_executor.py
+++ b/gooddata-flight-server/gooddata_flight_server/tasks/thread_task_executor.py
@@ -270,7 +270,7 @@ class _TaskExecution:
         """
         Cancels the execution.
 
-        IMPORTANT: task executor most not hold any locks at the time of cancellation.
+        IMPORTANT: task executor must not hold any locks at the time of cancellation.
 
         :return: True if cancel was successful, false if it was not possible
         """


### PR DESCRIPTION
FlexConnect's implementation of GetFlightInfo uses task executor to submit tasks that will invoke the FlexConnect functions. The GetFlightInfo will then wait for the task to complete (generate flight) and return result.

The GetFlightInfo implementation had hardcoded (in a constant) timeout that was used for waiting. This timeout was set to 60 seconds. This can sometimes be too little. And what's worse, it cannot be changed.

This PR introduces new setting `call_deadline_ms` that is expected to appear in the `[flexconnect]` configuration section. It is deadline in milliseconds. The default was bumped to 180 seconds.

---

Part of this PR are two additional changes:

- Try to cancel the task for when the deadline was exceeded. This is basic sanity. The task may be stuck in queue -> cancel will throw it out immediately. The task may be invoking function that is cancellable -> propagate cancel indicator to the function so that it can act on it.

- When task that executes FlexConnect function finishes invocation (and has result), it should check whether it was cancelled & switch itself to non-cancellable state before it returns the result. This is also basic hygiene. Tasks that run non-cancellable functions may be cancelled, the function still finishes the execution and returns result which is then retained by the server for configured amount of time. However, since the task was cancelled, there is no chance a client will ever come for the results -> they will hang in the memory unnecessarily.
