### PR TITLE
fix: proper cred loading for Databricks

### DIFF
--- a/gooddata-sdk/gooddata_sdk/catalog/data_source/declarative_model/data_source.py
+++ b/gooddata-sdk/gooddata_sdk/catalog/data_source/declarative_model/data_source.py
@@ -35,7 +35,7 @@ class CatalogDeclarativeDataSources(Base):
                     token = TokenCredentialsFromFile.token_from_file(credentials[data_source.id])
                     data_sources.append(data_source.to_api(token=token))
                 elif data_source.type == DATABRICKS_TYPE:
-                    if data_source.client_id is not None:
+                    if data_source.client_id and data_source.client_id.strip():
                         client_secret = ClientSecretCredentialsFromFile.client_secret_from_file(
                             credentials[data_source.id]
                         )


### PR DESCRIPTION
client_id field may be empty string, improved check to account for this

JIRA: LX-691
risk: low