### PR TITLE
fix: `get_visualization` failed for missing included

### DIFF
--- a/gooddata-sdk/gooddata_sdk/visualization.py
+++ b/gooddata-sdk/gooddata_sdk/visualization.py
@@ -782,6 +782,8 @@ class VisualizationService:
             _check_return_type=False,
             _request_timeout=timeout,
         )
-        side_loads = SideLoads(vis_obj.included)
+        side_loads = None
+        if hasattr(vis_obj, "included"):
+            side_loads = SideLoads(vis_obj.included)
 
         return Visualization(vis_obj.data, side_loads)


### PR DESCRIPTION
For some reason it could happen that `get_visualization` did not have any `included` and get failed.

JIRA: TRIVIAL
risk: low