### PR TITLE
RELATED: CQ-1268 - add limits to ErrorInfo fields

### DIFF
--- a/gooddata-flight-server/tests/errors/error_info.py
+++ b/gooddata-flight-server/tests/errors/error_info.py
@@ -22,6 +22,17 @@ def test_serde_error_info2():
     assert deserialized.detail == error.detail
 
 
+def test_error_info_limits1():
+    error = ErrorInfo.for_reason(666, "error" * 500).with_detail("detail" * 500)
+
+    assert "truncated" in error.msg
+    assert "truncated" in error.detail
+
+    error = ErrorInfo(code=666, msg="error" * 500, detail="detail" * 500)
+    assert "truncated" in error.msg
+    assert "truncated" in error.detail
+
+
 def test_serde_retry_info1():
     retry = RetryInfo(
         flight_info=None,


### PR DESCRIPTION
- ErrorInfo is passed as FlightError.extra_info
- In turn, extra_info contents are transported via gRPC headers
- gRPC headers have hard limit of 16kB size (otherwise get gRPC Resource Exhausted: initial metadata too large)
- added code to truncate `msg` and `detail` if necessary. Limits are 256 and 512 chars respectivelly.

JIRA: CQ-1268