### PR TITLE
feat: add exections_cancellable to sdk.create and export Execution

### DIFF
--- a/gooddata-sdk/gooddata_sdk/__init__.py
+++ b/gooddata-sdk/gooddata_sdk/__init__.py
@@ -231,6 +231,7 @@ from gooddata_sdk.compute.model.attribute import Attribute
 from gooddata_sdk.compute.model.base import ExecModelEntity, ObjId
 from gooddata_sdk.compute.model.execution import (
     BareExecutionResponse,
+    Execution,
     ExecutionDefinition,
     ExecutionResponse,
     ExecutionResult,

--- a/gooddata-sdk/gooddata_sdk/sdk.py
+++ b/gooddata-sdk/gooddata_sdk/sdk.py
@@ -46,6 +46,8 @@ class GoodDataSdk:
         host_: str,
         token_: str,
         extra_user_agent_: Optional[str] = None,
+        *,
+        executions_cancellable: bool = False,
         **custom_headers_: Optional[str],
     ) -> GoodDataSdk:
         """
@@ -56,7 +58,13 @@ class GoodDataSdk:
         This is preferred way of creating GoodDataSdk, when no tweaks are needed.
         """
         filtered_headers = {key: value for key, value in custom_headers_.items() if value is not None}
-        client = GoodDataApiClient(host_, token_, custom_headers=filtered_headers, extra_user_agent=extra_user_agent_)
+        client = GoodDataApiClient(
+            host_,
+            token_,
+            custom_headers=filtered_headers,
+            extra_user_agent=extra_user_agent_,
+            executions_cancellable=executions_cancellable,
+        )
         return cls(client)
 
     def __init__(self, client: GoodDataApiClient) -> None:

--- a/gooddata-sdk/tests/sdk/test_sdk.py
+++ b/gooddata-sdk/tests/sdk/test_sdk.py
@@ -79,3 +79,35 @@ def test_non_existing_token(setenvvar):
 def test_corrupted_config():
     with pytest.raises(ValueError):
         GoodDataSdk.create_from_profile(profiles_path=CORRUPTED_PROFILES)
+
+
+def test_new_options(setenvvar):
+    sdk1 = GoodDataSdk.create("host", "token", "agent_foo", header1="header1", header2="header2")
+    assert sdk1._client._hostname == "host"
+    assert sdk1._client._token == "token"
+    assert sdk1._client._api_client.user_agent[-9:] == "agent_foo"
+    assert sdk1._client._custom_headers == {"header1": "header1", "header2": "header2"}
+    assert not sdk1._client.executions_cancellable
+
+    sdk2 = GoodDataSdk.create(
+        "host", "token", "agent_foo", header1="header1", executions_cancellable=True, header2="header2"
+    )
+    assert sdk1._client._hostname == sdk2._client._hostname
+    assert sdk1._client._token == sdk2._client._token
+    assert sdk1._client._api_client.user_agent == sdk2._client._api_client.user_agent
+    assert sdk1._client._custom_headers == sdk2._client._custom_headers
+    assert sdk2._client.executions_cancellable
+
+    sdk3 = GoodDataSdk.create(
+        "host", "token", "agent_foo", executions_cancellable=True, header1="header1", header2="header2"
+    )
+    assert sdk1._client._api_client.user_agent == sdk3._client._api_client.user_agent
+    assert sdk1._client._custom_headers == sdk3._client._custom_headers
+    assert sdk3._client.executions_cancellable
+
+    sdk4 = GoodDataSdk.create(
+        "host", "token", "agent_foo", header1="header1", header2="header2", executions_cancellable=True
+    )
+    assert sdk1._client._api_client.user_agent == sdk4._client._api_client.user_agent
+    assert sdk1._client._custom_headers == sdk4._client._custom_headers
+    assert sdk4._client.executions_cancellable


### PR DESCRIPTION
- add `executions_cancellable` to `GoodDataSdk.create`
- Execution() instances are needed for the new cancelation method

risk: high