### PR TITLE
fix: compute.cancel_executions

### DIFF
--- a/gooddata-sdk/gooddata_sdk/__init__.py
+++ b/gooddata-sdk/gooddata_sdk/__init__.py
@@ -231,7 +231,6 @@ from gooddata_sdk.compute.model.attribute import Attribute
 from gooddata_sdk.compute.model.base import ExecModelEntity, ObjId
 from gooddata_sdk.compute.model.execution import (
     BareExecutionResponse,
-    Execution,
     ExecutionDefinition,
     ExecutionResponse,
     ExecutionResult,


### PR DESCRIPTION
- fixed one bug in compute.cancel_executions
- Execution is unusable outside of our codebase,
removed from export and refactored arguments in cancel_executions
- fixed header retrieval in ComputeService

risk: low