### PR TITLE
feat: add support for polling in FlexConnect server

### DIFF
--- a/gooddata-flexconnect/gooddata_flexconnect/function/function_invocation.py
+++ b/gooddata-flexconnect/gooddata_flexconnect/function/function_invocation.py
@@ -1,0 +1,94 @@
+#  (C) 2025 GoodData Corporation
+from dataclasses import dataclass
+from typing import Optional, Union
+
+import orjson
+import pyarrow.flight
+from gooddata_flight_server import ErrorInfo
+
+
+@dataclass(frozen=True)
+class RetryInvocation:
+    """
+    Indicates that the getting the results of the given task should be retried.
+    """
+
+    task_id: str
+
+
+@dataclass(frozen=True)
+class CancelInvocation:
+    """
+    Indicates that the given task should be cancelled.
+    """
+
+    task_id: str
+
+
+@dataclass(frozen=True)
+class SubmitInvocation:
+    """
+    Indicates that the given task should be submitted for processing.
+    """
+
+    command: bytes
+    """
+    The raw command that was sent to the Flight Server.
+    """
+
+    function_name: str
+    """
+    The name of the FlexConnect function to invoke.
+    """
+
+    parameters: dict
+    """
+    Parameters to pass to the FlexConnect function.
+    """
+
+    columns: Optional[tuple[str, ...]]
+    """
+    Columns to get from the FlexConnect function result.
+    This may be used for column trimming by the function: the function must return at least those columns.
+    """
+
+
+def extract_invocation_from_descriptor(
+    descriptor: pyarrow.flight.FlightDescriptor,
+) -> Union[RetryInvocation, CancelInvocation, SubmitInvocation]:
+    """
+    Given a flight descriptor, extract the invocation information from it.
+    """
+
+    if descriptor.command is None or not len(descriptor.command):
+        raise ErrorInfo.bad_argument(
+            "Incorrect FlexConnect function invocation. Flight descriptor must contain command "
+            "with the invocation payload."
+        )
+
+    if descriptor.command.startswith(b"c:"):
+        task_id = descriptor.command[2:].decode()
+        return CancelInvocation(task_id)
+    elif descriptor.command.startswith(b"r:"):
+        task_id = descriptor.command[2:].decode()
+        return RetryInvocation(task_id)
+    else:
+        try:
+            payload = orjson.loads(descriptor.command)
+        except Exception:
+            raise ErrorInfo.bad_argument(
+                "Incorrect FlexConnect function invocation. The invocation payload is not a valid JSON."
+            )
+
+        function_name = payload.get("functionName")
+        if function_name is None or not len(function_name):
+            raise ErrorInfo.bad_argument(
+                "Incorrect FlexConnect function invocation. The invocation payload does not specify 'functionName'."
+            )
+
+        parameters = payload.get("parameters") or {}
+        columns = parameters.get("columns")
+
+        return SubmitInvocation(
+            function_name=function_name, parameters=parameters, columns=columns, command=descriptor.command
+        )

--- a/gooddata-flexconnect/tests/server/conftest.py
+++ b/gooddata-flexconnect/tests/server/conftest.py
@@ -80,7 +80,7 @@ def flexconnect_server(
     funs = f"[{funs}]"
 
     os.environ["GOODDATA_FLIGHT_FLEXCONNECT__FUNCTIONS"] = funs
-    os.environ["GOODDATA_FLIGHT_FLEXCONNECT__CALL_DEADLINE_MS"] = "1000"
+    os.environ["GOODDATA_FLIGHT_FLEXCONNECT__CALL_DEADLINE_MS"] = "1200"
     os.environ["GOODDATA_FLIGHT_FLEXCONNECT__POLLING_INTERVAL_MS"] = "500"
 
     with server(create_flexconnect_flight_methods, tls, mtls) as s:

--- a/gooddata-flexconnect/tests/server/conftest.py
+++ b/gooddata-flexconnect/tests/server/conftest.py
@@ -80,7 +80,8 @@ def flexconnect_server(
     funs = f"[{funs}]"
 
     os.environ["GOODDATA_FLIGHT_FLEXCONNECT__FUNCTIONS"] = funs
-    os.environ["GOODDATA_FLIGHT_FLEXCONNECT__CALL_DEADLINE_MS"] = "500"
+    os.environ["GOODDATA_FLIGHT_FLEXCONNECT__CALL_DEADLINE_MS"] = "1000"
+    os.environ["GOODDATA_FLIGHT_FLEXCONNECT__POLLING_INTERVAL_MS"] = "500"
 
     with server(create_flexconnect_flight_methods, tls, mtls) as s:
         yield s

--- a/gooddata-flexconnect/tests/server/funs/fun3.py
+++ b/gooddata-flexconnect/tests/server/funs/fun3.py
@@ -27,7 +27,7 @@ class _LongRunningFun(FlexConnectFunction):
     ) -> ArrowData:
         # sleep is intentionally setup to be longer than the deadline for
         # the function invocation (see conftest.py // flexconnect_server fixture)
-        time.sleep(1.5)
+        time.sleep(2)
 
         return pyarrow.table(
             data={

--- a/gooddata-flexconnect/tests/server/funs/fun4.py
+++ b/gooddata-flexconnect/tests/server/funs/fun4.py
@@ -9,8 +9,8 @@ from gooddata_flight_server import ArrowData
 _DATA: Optional[pyarrow.Table] = None
 
 
-class _LongRunningFun(FlexConnectFunction):
-    Name = "LongRunningFun"
+class _PollableFun(FlexConnectFunction):
+    Name = "PollableFun"
     Schema = pyarrow.schema(
         fields=[
             pyarrow.field("col1", pyarrow.int64()),
@@ -25,9 +25,9 @@ class _LongRunningFun(FlexConnectFunction):
         columns: tuple[str, ...],
         headers: dict[str, list[str]],
     ) -> ArrowData:
-        # sleep is intentionally setup to be longer than the deadline for
-        # the function invocation (see conftest.py // flexconnect_server fixture)
-        time.sleep(1.5)
+        # sleep is intentionally setup to be longer than one polling interval
+        # (see conftest.py // flexconnect_server fixture)
+        time.sleep(0.7)
 
         return pyarrow.table(
             data={

--- a/gooddata-flexconnect/tests/server/test_flexconnect_server.py
+++ b/gooddata-flexconnect/tests/server/test_flexconnect_server.py
@@ -3,16 +3,21 @@
 import orjson
 import pyarrow.flight
 import pytest
+from gooddata_flexconnect.function.flight_methods import POLLING_HEADER_NAME
 from gooddata_flight_server import ErrorCode, ErrorInfo, RetryInfo
 
 from tests.assert_error_info import assert_error_code
 from tests.server.conftest import flexconnect_server
 
 
+@pytest.fixture
+def call_options_with_polling():
+    return pyarrow.flight.FlightCallOptions(headers=[(POLLING_HEADER_NAME.encode(), b"true")])
+
+
 def test_basic_function():
     """
-    This function should return immediately when called, no polling necessary.
-    :return:
+    This function should return immediately when called, no polling allowed.
     """
     with flexconnect_server(["tests.server.funs.fun1"]) as s:
         c = pyarrow.flight.FlightClient(s.location)
@@ -94,7 +99,66 @@ def test_basic_function_tls(tls_ca_cert):
         assert data.column_names == ["col1", "col2", "col3"]
 
 
-def test_function_with_polling():
+def test_cancellable_function(call_options_with_polling):
+    """
+    This function should return immediately when called, no polling necessary even if enabled.
+    """
+    with flexconnect_server(["tests.server.funs.fun1"]) as s:
+        c = pyarrow.flight.FlightClient(s.location)
+        fun_infos = list(c.list_flights())
+        assert len(fun_infos) == 1
+        fun_info: pyarrow.flight.FlightInfo = fun_infos[0]
+
+        assert fun_info.schema.names == ["col1", "col2", "col3"]
+        assert fun_info.descriptor.command is not None
+        assert len(fun_info.descriptor.command)
+        cmd = orjson.loads(fun_info.descriptor.command)
+        assert cmd["functionName"] == "SimpleFun1"
+
+        descriptor = pyarrow.flight.FlightDescriptor.for_command(
+            orjson.dumps(
+                {
+                    "functionName": "SimpleFun1",
+                    "parameters": {"test1": 1, "test2": 2, "test3": 3},
+                }
+            )
+        )
+        info = c.get_flight_info(descriptor, call_options_with_polling)
+        data: pyarrow.Table = c.do_get(info.endpoints[0].ticket).read_all()
+
+        assert len(data) == 3
+        assert data.column_names == ["col1", "col2", "col3"]
+
+
+def test_cancellable_function_tls(tls_ca_cert, call_options_with_polling):
+    with flexconnect_server(["tests.server.funs.fun1"], tls=True) as s:
+        c = pyarrow.flight.FlightClient(s.location, tls_root_certs=tls_ca_cert)
+        fun_infos = list(c.list_flights())
+        assert len(fun_infos) == 1
+        fun_info: pyarrow.flight.FlightInfo = fun_infos[0]
+
+        assert fun_info.schema.names == ["col1", "col2", "col3"]
+        assert fun_info.descriptor.command is not None
+        assert len(fun_info.descriptor.command)
+        cmd = orjson.loads(fun_info.descriptor.command)
+        assert cmd["functionName"] == "SimpleFun1"
+
+        descriptor = pyarrow.flight.FlightDescriptor.for_command(
+            orjson.dumps(
+                {
+                    "functionName": "SimpleFun1",
+                    "parameters": {"test1": 1, "test2": 2, "test3": 3},
+                }
+            )
+        )
+        info = c.get_flight_info(descriptor, call_options_with_polling)
+        data: pyarrow.Table = c.do_get(info.endpoints[0].ticket).read_all()
+
+        assert len(data) == 3
+        assert data.column_names == ["col1", "col2", "col3"]
+
+
+def test_cancellable_function_with_polling(call_options_with_polling):
     """
     Flight RPC implementation that invokes FlexConnect can return a polling info.
 
@@ -114,7 +178,7 @@ def test_function_with_polling():
         # the function is set to sleep a bit longer than the polling interval,
         # so the first iteration returns retry info in the exception
         with pytest.raises(pyarrow.flight.FlightTimedOutError) as e:
-            c.get_flight_info(descriptor)
+            c.get_flight_info(descriptor, call_options_with_polling)
 
         assert e.value is not None
         assert_error_code(ErrorCode.POLL, e.value)
@@ -124,7 +188,7 @@ def test_function_with_polling():
 
         # use the retry info to poll again for the result,
         # now it should be ready and returned normally
-        info = c.get_flight_info(retry_info.retry_descriptor)
+        info = c.get_flight_info(retry_info.retry_descriptor, call_options_with_polling)
         data: pyarrow.Table = c.do_get(info.endpoints[0].ticket).read_all()
 
         assert len(data) == 3
@@ -132,13 +196,13 @@ def test_function_with_polling():
 
         # also check that trying to cancel already completed task results in cancelled with correct code
         with pytest.raises(pyarrow.flight.FlightCancelledError) as e:
-            c.get_flight_info(retry_info.cancel_descriptor)
+            c.get_flight_info(retry_info.cancel_descriptor, call_options_with_polling)
 
         assert e.value is not None
         assert_error_code(ErrorCode.COMMAND_CANCELLED, e.value)
 
 
-def test_function_with_call_deadline():
+def test_cancellable_function_with_call_deadline(call_options_with_polling):
     """
     Flight RPC implementation that invokes FlexConnect can be setup with
     deadline for the invocation duration (done by GetFlightInfo).
@@ -163,7 +227,7 @@ def test_function_with_call_deadline():
 
         # the initial submit returns polling info
         with pytest.raises(pyarrow.flight.FlightTimedOutError) as e:
-            c.get_flight_info(descriptor)
+            c.get_flight_info(descriptor, call_options_with_polling)
 
         assert e.value is not None
         assert_error_code(ErrorCode.POLL, e.value)
@@ -173,19 +237,19 @@ def test_function_with_call_deadline():
 
         # the next poll still returns polling info
         with pytest.raises(pyarrow.flight.FlightTimedOutError) as e:
-            c.get_flight_info(retry_info.retry_descriptor)
+            c.get_flight_info(retry_info.retry_descriptor, call_options_with_polling)
 
         assert e.value is not None
         assert_error_code(ErrorCode.POLL, e.value)
 
         # the third one reaches the deadline so the Timeout code is returned instead
         with pytest.raises(pyarrow.flight.FlightTimedOutError) as e:
-            c.get_flight_info(retry_info.retry_descriptor)
+            c.get_flight_info(retry_info.retry_descriptor, call_options_with_polling)
 
         assert_error_code(ErrorCode.TIMEOUT, e.value)
 
 
-def test_function_with_cancellation():
+def test_cancellable_function_with_cancellation(call_options_with_polling):
     """
     Run a long-running function and cancel it after one poll iteration.
     """
@@ -202,7 +266,7 @@ def test_function_with_cancellation():
 
         # the initial submit returns polling info
         with pytest.raises(pyarrow.flight.FlightTimedOutError) as e:
-            c.get_flight_info(descriptor)
+            c.get_flight_info(descriptor, call_options_with_polling)
 
         assert e.value is not None
         assert_error_code(ErrorCode.POLL, e.value)
@@ -212,14 +276,14 @@ def test_function_with_cancellation():
 
         # use the poll info to cancel the task
         with pytest.raises(pyarrow.flight.FlightCancelledError) as e:
-            c.get_flight_info(retry_info.cancel_descriptor)
+            c.get_flight_info(retry_info.cancel_descriptor, call_options_with_polling)
 
         assert e.value is not None
         assert_error_code(ErrorCode.COMMAND_CANCELLED, e.value)
 
         # even multiple cancellations return the same error
         with pytest.raises(pyarrow.flight.FlightCancelledError) as e:
-            c.get_flight_info(retry_info.cancel_descriptor)
+            c.get_flight_info(retry_info.cancel_descriptor, call_options_with_polling)
 
         assert e.value is not None
         assert_error_code(ErrorCode.COMMAND_CANCELLED, e.value)

--- a/gooddata-flight-server/gooddata_flight_server/tasks/task_executor.py
+++ b/gooddata-flight-server/gooddata_flight_server/tasks/task_executor.py
@@ -55,6 +55,15 @@ class TaskExecutor(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
+    def get_task_submitted_timestamp(self, task_id: str) -> Optional[float]:
+        """
+        Returns the timestamp of when the task with the given id was submitted.
+        :param task_id: task id to get the timestamp for
+        :return: Timestamp in seconds since epoch of when the task was submitted or None if there is no such task
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
     def wait_for_result(self, task_id: str, timeout: Optional[float] = None) -> Optional[TaskExecutionResult]:
         """
         Wait for the task with the provided task id to finish.

--- a/gooddata-flight-server/gooddata_flight_server/tasks/thread_task_executor.py
+++ b/gooddata-flight-server/gooddata_flight_server/tasks/thread_task_executor.py
@@ -565,6 +565,14 @@ class ThreadTaskExecutor(TaskExecutor, _TaskExecutionCallbacks):
         execution.start()
         self._metrics.queue_size.set(self._queue_size)
 
+    def get_task_submitted_timestamp(self, task_id: str) -> Optional[float]:
+        with self._task_lock:
+            execution = self._executions.get(task_id)
+
+        if execution is not None:
+            return execution.stats.created
+        return None
+
     def wait_for_result(self, task_id: str, timeout: Optional[float] = None) -> Optional[TaskExecutionResult]:
         with self._task_lock:
             execution = self._executions.get(task_id)

--- a/gooddata-flight-server/gooddata_flight_server/tasks/thread_task_executor.py
+++ b/gooddata-flight-server/gooddata_flight_server/tasks/thread_task_executor.py
@@ -605,8 +605,8 @@ class ThreadTaskExecutor(TaskExecutor, _TaskExecutionCallbacks):
             return True
 
         if execution is None:
-            # the task was not and is not running - cancel not possible
-            return False
+            # the task was not and is not running - cancel not necessary
+            return True
 
         return execution.cancel()
 


### PR DESCRIPTION
Add a polling mechanism to the FlexConnect functions so that long-running tasks can be polled for and canceled.
The polling is opt-in via a call header: this is to ensure compatibility with GoodData versions that do not support this yet.

The TaskExecutor now supports returning a timestamp of when a particular task was submitted. This is to keep track of the call deadline breaches.

JIRA: CQ-1124
risk: low