### PR TITLE
fix: add missing Execution export

### DIFF
--- a/gooddata-sdk/gooddata_sdk/__init__.py
+++ b/gooddata-sdk/gooddata_sdk/__init__.py
@@ -231,6 +231,7 @@ from gooddata_sdk.compute.model.attribute import Attribute
 from gooddata_sdk.compute.model.base import ExecModelEntity, ObjId
 from gooddata_sdk.compute.model.execution import (
     BareExecutionResponse,
+    Execution,
     ExecutionDefinition,
     ExecutionResponse,
     ExecutionResult,


### PR DESCRIPTION
The Execution class needs to be exported by gooddata_sdk, so that users can hold a reference to it in a type-safe way.

JIRA: CQ-1124
risk: low