### PR TITLE
fix: use the correct LICENSE symlink

### DIFF
--- a/gooddata-flexconnect/LICENSE.txt
+++ b/gooddata-flexconnect/LICENSE.txt
@@ -1,1 +1,1 @@
-../OSS LICENSES/LICENSE (gooddata-flexfun).txt
+../OSS LICENSES/LICENSE (gooddata-flexconnect).txt


### PR DESCRIPTION
Reflect the flexfun -> flexconnect rename in both the license file and the symlink.

JIRA: CQ-102
risk: low