### PR TITLE
feat: add on_execution_submitted to gooddata_pandas

### DIFF
--- a/gooddata-pandas/gooddata_pandas/data_access.py
+++ b/gooddata-pandas/gooddata_pandas/data_access.py
@@ -9,7 +9,6 @@ from gooddata_sdk import (
     CatalogAttribute,
     Execution,
     ExecutionDefinition,
-    ExecutionResponse,
     Filter,
     GoodDataSdk,
     Metric,
@@ -258,7 +257,7 @@ def _compute(
     columns: ColumnsDef,
     index_by: Optional[IndexDef] = None,
     filter_by: Optional[Union[Filter, list[Filter]]] = None,
-) -> tuple[ExecutionResponse, dict[str, int], dict[str, int], dict[str, int]]:
+) -> tuple[Execution, dict[str, int], dict[str, int], dict[str, int]]:
     """
     Internal function that computes an execution-by-convention to retrieve data for a data frame with the provided
     columns, optionally indexed by the index_by label and optionally filtered.
@@ -272,7 +271,7 @@ def _compute(
 
     Returns:
         tuple: A tuple containing the following elements:
-        - ExecutionResponse: The execution response.
+        - Execution: The execution response.
         - dict[str, int]: A mapping of pandas column names to attribute dimension indices.
         - dict[str, int]: A mapping of pandas column names to metric dimension indices.
         - dict[str, int]: A mapping of pandas index names to attribute dimension indices.
@@ -300,12 +299,12 @@ _RESULT_PAGE_LEN = 1000
 #
 
 
-def _extract_for_metrics_only(response: ExecutionResponse, cols: list, col_to_metric_idx: dict) -> dict:
+def _extract_for_metrics_only(response: Execution, cols: list, col_to_metric_idx: dict) -> dict:
     """
     Internal function that extracts data for metrics-only columns when there are no attribute columns.
 
     Args:
-        response (ExecutionResponse): The execution response to extract data from.
+        response (Execution): The execution response to extract data from.
         cols (list): A list of column names.
         col_to_metric_idx (dict): A mapping of pandas column names to metric dimension indices.
 
@@ -346,7 +345,7 @@ def _typed_result(attributes: list[CatalogAttribute], attribute: Attribute, resu
 
 
 def _extract_from_attributes_and_maybe_metrics(
-    response: ExecutionResponse,
+    response: Execution,
     attributes: list[CatalogAttribute],
     cols: list[str],
     col_to_attr_idx: dict[str, int],
@@ -358,7 +357,7 @@ def _extract_from_attributes_and_maybe_metrics(
     optionally metrics columns.
 
     Args:
-        response (ExecutionResponse): The execution response to extract data from.
+        response (Execution): The execution response to extract data from.
         attributes (list[CatalogAttribute]): The catalog of attributes.
         cols (list[str]): A list of column names.
         col_to_attr_idx (dict[str, int]): A mapping of pandas column names to attribute dimension indices.

--- a/gooddata-pandas/gooddata_pandas/series.py
+++ b/gooddata-pandas/gooddata_pandas/series.py
@@ -1,10 +1,10 @@
 # (C) 2021 GoodData Corporation
 from __future__ import annotations
 
-from typing import Optional, Union
+from typing import Callable, Optional, Union
 
 import pandas
-from gooddata_sdk import Attribute, Filter, GoodDataSdk, ObjId, SimpleMetric
+from gooddata_sdk import Attribute, Execution, Filter, GoodDataSdk, ObjId, SimpleMetric
 
 from gooddata_pandas.data_access import compute_and_extract
 from gooddata_pandas.utils import IndexDef, LabelItemDef, make_pandas_index
@@ -28,6 +28,7 @@ class SeriesFactory:
         index_by: IndexDef,
         data_by: Union[SimpleMetric, str, ObjId, Attribute],
         filter_by: Optional[Union[Filter, list[Filter]]] = None,
+        on_execution_submitted: Optional[Callable[[Execution], None]] = None,
     ) -> pandas.Series:
         """Creates pandas Series from data points calculated from a single `data_by`.
 
@@ -61,6 +62,9 @@ class SeriesFactory:
             - object identifier: ``ObjId(id='some_label_id', type='<type>')``
             - Attribute or Metric depending on type of filter
 
+            on_execution_submitted (Optional[Callable[[Execution], None]]): Callback to call when the execution was
+                submitted to the backend.
+
         Returns:
             pandas.Series: pandas series instance
         """
@@ -71,6 +75,7 @@ class SeriesFactory:
             index_by=index_by,
             columns={"_series": data_by},
             filter_by=filter_by,
+            on_execution_submitted=on_execution_submitted,
         )
 
         _idx = make_pandas_index(index)
@@ -82,6 +87,7 @@ class SeriesFactory:
         data_by: Union[SimpleMetric, str, ObjId, Attribute],
         granularity: Optional[Union[list[LabelItemDef], IndexDef]] = None,
         filter_by: Optional[Union[Filter, list[Filter]]] = None,
+        on_execution_submitted: Optional[Callable[[Execution], None]] = None,
     ) -> pandas.Series:
         """
         Creates a pandas.Series from data points calculated from a single `data_by` without constructing an index.
@@ -108,6 +114,8 @@ class SeriesFactory:
                     - ObjId: ObjId(id='some_label_id', type='<type>')
                     - Attribute or Metric depending on the type of filter
                 Defaults to None.
+            on_execution_submitted (Optional[Callable[[Execution], None]]): Callback to call when the execution was
+                submitted to the backend.
 
         Returns:
             pandas.Series: The resulting pandas Series instance.
@@ -124,6 +132,7 @@ class SeriesFactory:
             index_by=_index,
             columns={"_series": data_by},
             filter_by=filter_by,
+            on_execution_submitted=on_execution_submitted,
         )
 
         return pandas.Series(data=data["_series"])


### PR DESCRIPTION
Users can now provide a callback that will be called with the Execution object as soon as it is available. This is useful for getting some of the information available in the Execution object before the actual data is loaded. The Execution object can also be used to cancel the execution result operation.

Also unify Execution types in data_access.py: no need to use the ExecutionResponse alias anymore.

JIRA: CQ-1387
risk: low