### PR TITLE
chore: fix gh-action-pypi-publish version

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -103,7 +103,7 @@ jobs:
           name: artifacts_${{ matrix.component }}
           path: dist/${{ matrix.component }}
       - name: Push ${{ matrix.component}} to pypi
-        uses: pypa/gh-action-pypi-publish@v1
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -43,7 +43,7 @@ jobs:
           cd ${{ matrix.component }}
           python -m build
       - name: Push ${{ matrix.component}} to pypi
-        uses: pypa/gh-action-pypi-publish@v1
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
JIRA: TRIVIAL
risk: low