### PR TITLE
feat(gooddata-sdk): [AUTO] Add GEO_ICON and HYPERLOGLOG to attribute value type enums

### DIFF
--- a/cluster-info.txt
+++ b/cluster-info.txt
@@ -1,0 +1,2 @@
+- `f9a6963` Merge pull request #21320 from Vojtasii/vto/geo-icon
+- `6faf4e2` Merge pull request #21484 from pcerny/pce/cq-2118_hll_sr

--- a/cluster.json
+++ b/cluster.json
@@ -1,0 +1,25 @@
+{
+  "id": "C003",
+  "title": "Add GEO_ICON and HYPERLOGLOG to attribute value type enums",
+  "services": [
+    "gooddata-afm-client",
+    "gooddata-metadata-client"
+  ],
+  "commits": [
+    {
+      "sha": "f9a6963e5a59c6dd1c6f6a9a46b9b5e2b0eab239",
+      "author": "Vojt\u011bch Tollar",
+      "author_email": "vojtech.tollar@gooddata.com",
+      "message": "Merge pull request #21320 from Vojtasii/vto/geo-icon"
+    },
+    {
+      "sha": "6faf4e20862d0b9b62ef3f8521dc942fa6afb230",
+      "author": "pcerny",
+      "author_email": "pavel.cerny@gooddata.com",
+      "message": "Merge pull request #21484 from pcerny/pce/cq-2118_hll_sr"
+    }
+  ],
+  "diff": "--- a/gooddata-afm-client.json\n+++ b/gooddata-afm-client.json\n@@ AttributeLabelValueTypeDto enum @@\n               \"GEO_LONGITUDE\",\n               \"GEO_LATITUDE\",\n               \"GEO_AREA\",\n-              \"IMAGE\"\n+              \"GEO_ICON\",\n+              \"IMAGE\",\n+              \"HYPERLOGLOG\"\n--- a/gooddata-metadata-client.json\n+++ b/gooddata-metadata-client.json\n@@ AttributeLabel valueType enum @@\n               \"GEO_LONGITUDE\",\n               \"GEO_LATITUDE\",\n               \"GEO_AREA\",\n-              \"IMAGE\"\n+              \"GEO_ICON\",\n+              \"IMAGE\",\n+              \"HYPERLOGLOG\"",
+  "jira_tickets": [],
+  "sdk_impact": "enum_addition"
+}

--- a/packages/gooddata-dbt/src/gooddata_dbt/dbt/base.py
+++ b/packages/gooddata-dbt/src/gooddata_dbt/dbt/base.py
@@ -23,6 +23,7 @@ class GoodDataLabelType(Enum):
     GEO_LONGITUDE = "GEO_LONGITUDE"
     GEO_AREA = "GEO_AREA"
     GEO_ICON = "GEO_ICON"
+    HYPERLOGLOG = "HYPERLOGLOG"
 
 
 class GoodDataSortDirection(Enum):

--- a/result.json
+++ b/result.json
@@ -1,0 +1,10 @@
+{
+  "status": "implemented",
+  "cluster_id": "C003",
+  "summary": "Added HYPERLOGLOG to the GoodDataLabelType enum in the gooddata-dbt package. GEO_ICON was already present in the enum from a prior PR. The main gooddata-sdk package uses str | None for value_type fields so it requires no changes — all string values including GEO_ICON and HYPERLOGLOG are already accepted. The auto-generated gooddata-api-client already contains both new enum values.",
+  "files_changed": [
+    "packages/gooddata-dbt/src/gooddata_dbt/dbt/base.py"
+  ],
+  "reason": "The OpenAPI diff adds GEO_ICON and HYPERLOGLOG to AttributeLabelValueTypeDto (gooddata-afm-client) and AttributeLabel.valueType (gooddata-metadata-client). In the SDK: (1) the gooddata-api-client (auto-generated) already carries both new values — no changes there; (2) the main gooddata-sdk wrapper uses `value_type: str | None` throughout, accepting any string, so no Python code changes are required; (3) the gooddata-dbt package defines GoodDataLabelType as a Python Enum that gates which label types users can declare in dbt YAML files — GEO_ICON was already present but HYPERLOGLOG was missing, causing cattrs deserialization failures for users who try to use `label_type: HYPERLOGLOG`. Added HYPERLOGLOG = \"HYPERLOGLOG\" to the enum.",
+  "cost_usd": 0.8441104499999998
+}


### PR DESCRIPTION
## Summary

Automated SDK sync for cluster **C003**: Add GEO_ICON and HYPERLOGLOG to attribute value type enums

## Source commits (gdc-nas)

- `f9a6963` Merge pull request #21320 from Vojtasii/vto/geo-icon
- `6faf4e2` Merge pull request #21484 from pcerny/pce/cq-2118_hll_sr

## Workflow run

[https://github.com/gooddata/gdc-nas/actions/runs/24334800467](https://github.com/gooddata/gdc-nas/actions/runs/24334800467)

---
*Generated by SDK OpenAPI Sync workflow*