### PR TITLE
feat(gooddata-sdk): [AUTO] Deprecate LLM Endpoint API and add resolveLlmProviders endpoint

### DIFF
--- a/packages/gooddata-sdk/src/gooddata_sdk/__init__.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/__init__.py
@@ -264,6 +264,11 @@ from gooddata_sdk.catalog.workspace.entity_model.graph_objects.graph import (
     CatalogDependentEntitiesResponse,
     CatalogEntityIdentifier,
 )
+from gooddata_sdk.catalog.workspace.entity_model.resolved_llm import (
+    CatalogResolvedLlmModel,
+    CatalogResolvedLlmProvider,
+    CatalogResolvedLlms,
+)
 from gooddata_sdk.catalog.workspace.entity_model.user_data_filter import (
     CatalogUserDataFilter,
     CatalogUserDataFilterAttributes,

--- a/packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/content_service.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/content_service.py
@@ -31,6 +31,7 @@ from gooddata_sdk.catalog.workspace.entity_model.graph_objects.graph import (
     CatalogDependentEntitiesRequest,
     CatalogDependentEntitiesResponse,
 )
+from gooddata_sdk.catalog.workspace.entity_model.resolved_llm import CatalogResolvedLlms
 from gooddata_sdk.catalog.workspace.model_container import CatalogWorkspaceContent
 from gooddata_sdk.client import GoodDataApiClient
 from gooddata_sdk.compute.model.attribute import Attribute
@@ -685,3 +686,21 @@ class CatalogWorkspaceContentService(CatalogServiceBase):
             workspace_id, request, _check_return_type=False, **paging_params
         )
         return [v["title"] for v in values["elements"]]
+
+    def resolve_llm_providers(self, workspace_id: str) -> CatalogResolvedLlms:
+        """Resolve the active LLM configuration for a given workspace.
+
+        Returns the active LLM configuration. When the ENABLE_LLM_ENDPOINT_REPLACEMENT feature
+        flag is enabled, returns LLM Providers with their associated models. Otherwise, falls
+        back to the legacy LLM Endpoints.
+
+        Args:
+            workspace_id (str):
+                Workspace identification string e.g. "demo"
+
+        Returns:
+            CatalogResolvedLlms:
+                Object containing the resolved LLM configuration, or None if no LLM is configured.
+        """
+        response = self._actions_api.resolve_llm_providers(workspace_id, _check_return_type=False)
+        return CatalogResolvedLlms.from_api(response)

--- a/packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/entity_model/resolved_llm.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/entity_model/resolved_llm.py
@@ -1,0 +1,95 @@
+# (C) 2026 GoodData Corporation
+from __future__ import annotations
+
+from typing import Any
+
+import attrs
+
+from gooddata_sdk.catalog.base import Base
+
+
+@attrs.define(kw_only=True)
+class CatalogResolvedLlmModel(Base):
+    """Represents a single LLM model available in the resolved LLM configuration."""
+
+    id: str
+    family: str | None = None
+
+    @staticmethod
+    def client_class() -> Any:
+        return NotImplemented
+
+    @classmethod
+    def from_api(cls, data: Any) -> CatalogResolvedLlmModel:
+        family = None
+        try:
+            family = data["family"]
+        except (KeyError, TypeError):
+            pass
+        return cls(
+            id=data["id"],
+            family=family,
+        )
+
+
+@attrs.define(kw_only=True)
+class CatalogResolvedLlmProvider(Base):
+    """Represents a resolved LLM provider configuration for a workspace.
+
+    Returned by the resolveLlmProviders endpoint. When the ENABLE_LLM_ENDPOINT_REPLACEMENT
+    feature flag is enabled, contains LLM provider information with associated models.
+    Otherwise, falls back to the legacy LLM endpoint representation.
+    """
+
+    id: str
+    title: str | None = None
+    models: list[CatalogResolvedLlmModel] = attrs.field(factory=list)
+
+    @staticmethod
+    def client_class() -> Any:
+        return NotImplemented
+
+    @classmethod
+    def from_api(cls, data: Any) -> CatalogResolvedLlmProvider:
+        raw_models = None
+        try:
+            raw_models = data["models"]
+        except (KeyError, TypeError):
+            pass
+        models = [CatalogResolvedLlmModel.from_api(m) for m in raw_models] if raw_models is not None else []
+        title = None
+        try:
+            title = data["title"]
+        except (KeyError, TypeError):
+            pass
+        return cls(
+            id=data["id"],
+            title=title,
+            models=models,
+        )
+
+
+@attrs.define(kw_only=True)
+class CatalogResolvedLlms(Base):
+    """Represents the resolved LLM configuration for a workspace.
+
+    Returned by the resolveLlmProviders endpoint. The data field contains the active
+    LLM configuration, or None if no LLM is configured for the workspace.
+    """
+
+    data: CatalogResolvedLlmProvider | None = None
+
+    @staticmethod
+    def client_class() -> Any:
+        return NotImplemented
+
+    @classmethod
+    def from_api(cls, response: Any) -> CatalogResolvedLlms:
+        data_raw = None
+        try:
+            data_raw = response["data"]
+        except (KeyError, TypeError):
+            pass
+        if data_raw is None:
+            return cls(data=None)
+        return cls(data=CatalogResolvedLlmProvider.from_api(data_raw))

--- a/packages/gooddata-sdk/tests/catalog/test_catalog_workspace_content.py
+++ b/packages/gooddata-sdk/tests/catalog/test_catalog_workspace_content.py
@@ -18,6 +18,7 @@ from gooddata_sdk import (
     CatalogDependsOn,
     CatalogDependsOnDateFilter,
     CatalogEntityIdentifier,
+    CatalogResolvedLlms,
     CatalogValidateByItem,
     CatalogWorkspace,
     DataSourceValidator,
@@ -502,3 +503,10 @@ def test_export_definition_analytics_layout(test_config):
         assert deep_eq(analytics_o.analytics.export_definitions, analytics_e.analytics.export_definitions)
     finally:
         safe_delete(_refresh_workspaces, sdk)
+
+
+@gd_vcr.use_cassette(str(_fixtures_dir / "test_resolve_llm_providers.yaml"))
+def test_resolve_llm_providers(test_config):
+    sdk = GoodDataSdk.create(host_=test_config["host"], token_=test_config["token"])
+    result = sdk.catalog_workspace_content.resolve_llm_providers(test_config["workspace"])
+    assert isinstance(result, CatalogResolvedLlms)


### PR DESCRIPTION
## Summary

Implemented the `resolveLlmProviders` endpoint in the Python SDK wrapper. Created three new model classes (`CatalogResolvedLlmModel`, `CatalogResolvedLlmProvider`, `CatalogResolvedLlms`) in a new file `catalog/workspace/entity_model/resolved_llm.py`. Added `resolve_llm_providers(workspace_id)` service method to `CatalogWorkspaceContentService`. Exported all new classes from `gooddata_sdk/__init__.py`. Added an integration test in `test_catalog_workspace_content.py` referencing a VCR cassette to be recorded. The deprecated LLM endpoint APIs don't require SDK changes as they were already only exposed via the auto-generated API client layer, not the SDK wrapper.

**Impact:** deprecation | **Services:** `gooddata-afm-client`, `gooddata-metadata-client`

## Files changed

- `packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/entity_model/resolved_llm.py`
- `packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/content_service.py`
- `packages/gooddata-sdk/src/gooddata_sdk/__init__.py`
- `packages/gooddata-sdk/tests/catalog/test_catalog_workspace_content.py`

## Source commits (gdc-nas)

- `a19eb19` Merge pull request #21393 from hkad98/jkd/llm-endpoint-deprecation

<details><summary>OpenAPI diff</summary>

```diff
     "/api/v1/actions/ai/llmEndpoint/test": { "post": {
+        "deprecated": true,
+        "description": "Will be soon removed and replaced by testLlmProvider."
     "/api/v1/actions/ai/llmEndpoint/{llmEndpointId}/test": { "post": {
+        "deprecated": true,
+        "description": "Will be soon removed and replaced by testLlmProviderById."
     "/api/v1/actions/workspaces/{workspaceId}/ai/resolveLlmEndpoints": { "get": {
+        "deprecated": true,
+        "description": "Will be soon removed and replaced by LlmProvider-based resolution."
+    "/api/v1/actions/workspaces/{workspaceId}/ai/resolveLlmProviders": {
+      "get": { "operationId": "resolveLlmProviders", "summary": "Get Active LLM configuration for this workspace" }
+    },
       "JsonApiLlmEndpointIn": {
+        "deprecated": true, "description": "Will be soon removed and replaced by LlmProvider."
       "JsonApiLlmEndpointOut": { "deprecated": true },
       "JsonApiLlmEndpointPatch": { "deprecated": true },
+      "ResolvedLlm": { "description": "The resolved LLM configuration, or null if none is configured." },
+      "ResolvedLlmProvider": { "allOf": [{ "$ref": "ResolvedLlm" }, { "properties": { "id": {...}, "models": {...}, "title": {...} } }] },
+      "ResolvedLlms": { "properties": { "data": { "oneOf": [{ "$ref": "ResolvedLlmEndpoint" }, { "$ref": "ResolvedLlmProvider" }] } } }
```
</details>

## [Workflow run](https://github.com/gooddata/gdc-nas/actions/runs/24345174224)

---
*Generated by SDK OpenAPI Sync workflow*