### PR TITLE
feat(gooddata-sdk): [AUTO] Add DashboardArbitraryAttributeFilter and DashboardMatchAttributeFilter

### DIFF
--- a/packages/gooddata-sdk/src/gooddata_sdk/compute/model/filter.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/compute/model/filter.py
@@ -96,11 +96,17 @@ def _to_identifier(val: Union[ObjId, str]) -> Union[afm_models.AfmLocalIdentifie
 
 
 class AttributeFilter(Filter):
-    def __init__(self, label: Union[ObjId, str, Attribute], values: list[str] | None = None) -> None:
+    def __init__(
+        self,
+        label: Union[ObjId, str, Attribute],
+        values: list[str] | None = None,
+        uses_arbitrary_values: bool | None = None,
+    ) -> None:
         super().__init__()
 
         self._label = _extract_id_or_local_id(label)
         self._values = values or []
+        self._uses_arbitrary_values = uses_arbitrary_values
 
     @property
     def label(self) -> Union[ObjId, str]:
@@ -113,6 +119,10 @@ class AttributeFilter(Filter):
     @property
     def values(self) -> list[str]:
         return self._values
+
+    @property
+    def uses_arbitrary_values(self) -> bool | None:
+        return self._uses_arbitrary_values
 
     def is_noop(self) -> bool:
         return False
@@ -128,7 +138,10 @@ class PositiveAttributeFilter(AttributeFilter):
     def as_api_model(self) -> afm_models.PositiveAttributeFilter:
         label_id = _to_identifier(self._label)
         elements = afm_models.AttributeFilterElements(values=self.values)
-        body = PositiveAttributeFilterBody(label=label_id, _in=elements, _check_type=False)
+        kwargs: dict[str, Any] = {}
+        if self._uses_arbitrary_values is not None:
+            kwargs["uses_arbitrary_values"] = self._uses_arbitrary_values
+        body = PositiveAttributeFilterBody(label=label_id, _in=elements, _check_type=False, **kwargs)
         return afm_models.PositiveAttributeFilter(body, _check_type=False)
 
     def description(self, labels: dict[str, str], format_locale: str | None = None) -> str:
@@ -144,7 +157,10 @@ class NegativeAttributeFilter(AttributeFilter):
     def as_api_model(self) -> afm_models.NegativeAttributeFilter:
         label_id = _to_identifier(self._label)
         elements = afm_models.AttributeFilterElements(values=self.values)
-        body = NegativeAttributeFilterBody(label=label_id, not_in=elements, _check_type=False)
+        kwargs: dict[str, Any] = {}
+        if self._uses_arbitrary_values is not None:
+            kwargs["uses_arbitrary_values"] = self._uses_arbitrary_values
+        body = NegativeAttributeFilterBody(label=label_id, not_in=elements, _check_type=False, **kwargs)
         return afm_models.NegativeAttributeFilter(body)
 
     def description(self, labels: dict[str, str], format_locale: str | None = None) -> str:

--- a/packages/gooddata-sdk/tests/compute_model/test_attribute_filters.py
+++ b/packages/gooddata-sdk/tests/compute_model/test_attribute_filters.py
@@ -188,3 +188,51 @@ def test_match_filter_inequality_different_case_sensitive():
     f1 = MatchAttributeFilter(label="test", literal="foo", match_type="CONTAINS")
     f2 = MatchAttributeFilter(label="test", literal="foo", match_type="CONTAINS", case_sensitive=True)
     assert f1 != f2
+
+
+def test_positive_filter_uses_arbitrary_values_true():
+    f = PositiveAttributeFilter(label="local_id", values=["val1"], uses_arbitrary_values=True)
+    assert f.uses_arbitrary_values is True
+    api_model = f.as_api_model()
+    body = api_model.positive_attribute_filter
+    assert body.uses_arbitrary_values is True
+
+
+def test_positive_filter_uses_arbitrary_values_false():
+    f = PositiveAttributeFilter(label="local_id", values=["val1"], uses_arbitrary_values=False)
+    assert f.uses_arbitrary_values is False
+    api_model = f.as_api_model()
+    body = api_model.positive_attribute_filter
+    assert body.uses_arbitrary_values is False
+
+
+def test_positive_filter_uses_arbitrary_values_default_none():
+    f = PositiveAttributeFilter(label="local_id", values=["val1"])
+    assert f.uses_arbitrary_values is None
+    api_model = f.as_api_model()
+    body = api_model.positive_attribute_filter
+    assert not hasattr(body, "uses_arbitrary_values") or body.uses_arbitrary_values is None
+
+
+def test_negative_filter_uses_arbitrary_values_true():
+    f = NegativeAttributeFilter(label="local_id", values=["val1"], uses_arbitrary_values=True)
+    assert f.uses_arbitrary_values is True
+    api_model = f.as_api_model()
+    body = api_model.negative_attribute_filter
+    assert body.uses_arbitrary_values is True
+
+
+def test_negative_filter_uses_arbitrary_values_false():
+    f = NegativeAttributeFilter(label="local_id", values=["val1"], uses_arbitrary_values=False)
+    assert f.uses_arbitrary_values is False
+    api_model = f.as_api_model()
+    body = api_model.negative_attribute_filter
+    assert body.uses_arbitrary_values is False
+
+
+def test_negative_filter_uses_arbitrary_values_default_none():
+    f = NegativeAttributeFilter(label="local_id", values=["val1"])
+    assert f.uses_arbitrary_values is None
+    api_model = f.as_api_model()
+    body = api_model.negative_attribute_filter
+    assert not hasattr(body, "uses_arbitrary_values") or body.uses_arbitrary_values is None


### PR DESCRIPTION
## Summary

Added `uses_arbitrary_values: bool | None = None` optional parameter to `AttributeFilter.__init__()` (with a corresponding property), and updated `PositiveAttributeFilter.as_api_model()` and `NegativeAttributeFilter.as_api_model()` to conditionally pass this field to the generated API client body models. The `DashboardArbitraryAttributeFilter` and `DashboardMatchAttributeFilter` are new schemas added to the `DashboardFilter` oneOf — but the SDK stores dashboard content as raw `dict[str, Any]` (no typed wrappers exist for any `DashboardFilter` variants), so no SDK wrapper changes are needed for those types; the auto-generated API client already handles them. Unit tests were added for the new `uses_arbitrary_values` field on both positive and negative attribute filters.

**Impact:** new_feature | **Services:** `gooddata-automation-client`, `gooddata-export-client`, `gooddata-metadata-client`, `gooddata-afm-client`
**Tickets:** CQ-2114

## Files changed

- `packages/gooddata-sdk/src/gooddata_sdk/compute/model/filter.py`
- `packages/gooddata-sdk/tests/compute_model/test_attribute_filters.py`

## Source commits (gdc-nas)

- `af3e42d` Merge pull request #21504 from gooddata/dho/cq-2114-automation-filters
- `0468f7f` Merge pull request #21536 from gooddata/dho/cq-2114-prop
- `c9c966b` Merge pull request #21589 from gooddata/dho/cq-2114-flag

<details><summary>OpenAPI diff</summary>

```diff
+      "DashboardArbitraryAttributeFilter": {
+        "properties": { "arbitraryAttributeFilter": {
+            "properties": { "displayForm": {...}, "values": {...}, "negativeSelection": {...}, "validateElementsBy": {...} },
+            "required": ["displayForm", "negativeSelection", "values"]
+        } },
+        "required": ["arbitraryAttributeFilter"]
+      },
+      "DashboardMatchAttributeFilter": {
+        "properties": { "matchAttributeFilter": {
+            "properties": { "caseSensitive": {...}, "displayForm": {...}, "literal": {...}, "operator": { "enum": ["contains","startsWith","endsWith"] } },
+            "required": ["caseSensitive","displayForm","literal","negativeSelection","operator"]
+        } },
+        "required": ["matchAttributeFilter"]
+      },
       (DashboardFilter oneOf)
+          { "$ref": "#/components/schemas/DashboardArbitraryAttributeFilter" },
+          { "$ref": "#/components/schemas/DashboardMatchAttributeFilter" },
       (NegativeAttributeFilter / PositiveAttributeFilter)
+              "usesArbitraryValues": { "description": "If true, values were filled free-form.", "type": "boolean" }
```
</details>

## [Workflow run](https://github.com/gooddata/gdc-nas/actions/runs/24345174224)

---
*Generated by SDK OpenAPI Sync workflow*