### PR TITLE
feat(gooddata-sdk): [AUTO] Add /binary endpoint for Apache Arrow execution results (BETA)

### DIFF
--- a/packages/gooddata-sdk/src/gooddata_sdk/compute/model/execution.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/compute/model/execution.py
@@ -504,6 +504,15 @@ class Execution:
     ) -> ExecutionResult:
         return self.bare_exec_response.read_result(limit, offset, timeout)
 
+    def read_result_arrow(self) -> pyarrow.Table:
+        """
+        Reads the full execution result as a pyarrow Table.
+
+        The binary endpoint returns the complete result in one shot (no paging).
+        Requires pyarrow to be installed (pip install gooddata-sdk[arrow]).
+        """
+        return self.bare_exec_response.read_result_arrow()
+
     def cancel(self) -> None:
         """
         Cancels the execution.

--- a/packages/gooddata-sdk/tests/compute/test_bare_execution_response.py
+++ b/packages/gooddata-sdk/tests/compute/test_bare_execution_response.py
@@ -108,3 +108,57 @@ def test_read_result_arrow_no_pyarrow_raises() -> None:
 
     with patch.object(_exec_mod, "_ipc", None), pytest.raises(ImportError, match="pyarrow is required"):
         bare.read_result_arrow()
+
+
+def _make_execution(ipc_bytes: bytes):
+    """Return an Execution backed by a mock API client."""
+    from gooddata_sdk.compute.model.execution import Execution, ExecutionDefinition, TableDimension
+
+    mock_api_client = MagicMock()
+    mock_response = _FakeResponse(ipc_bytes)
+    mock_api_client.actions_api.api_client.call_api.return_value = mock_response
+    mock_api_client.executions_cancellable = False
+
+    afm_exec_response = {
+        "execution_response": {
+            "links": {"executionResult": "result-id-456"},
+            "dimensions": [],
+        }
+    }
+    exec_def = ExecutionDefinition(
+        attributes=None,
+        metrics=None,
+        filters=None,
+        dimensions=[TableDimension(item_ids=["measureGroup"])],
+    )
+    execution = Execution(
+        api_client=mock_api_client,
+        workspace_id="ws-id",
+        exec_def=exec_def,
+        response=afm_exec_response,
+    )
+    return execution, mock_response
+
+
+def test_execution_read_result_arrow_delegates() -> None:
+    """Execution.read_result_arrow() delegates to BareExecutionResponse.read_result_arrow()."""
+    import pyarrow as pa
+
+    ipc_bytes = _make_ipc_stream_bytes()
+    execution, mock_response = _make_execution(ipc_bytes)
+
+    result = execution.read_result_arrow()
+
+    assert isinstance(result, pa.Table)
+    mock_response.release_conn.assert_called_once()
+
+
+def test_execution_read_result_arrow_calls_binary_endpoint() -> None:
+    """Execution.read_result_arrow() calls the /binary endpoint via the API client."""
+    ipc_bytes = _make_ipc_stream_bytes()
+    execution, _ = _make_execution(ipc_bytes)
+
+    execution.read_result_arrow()
+
+    call_kwargs = execution.bare_exec_response._actions_api.api_client.call_api.call_args.kwargs
+    assert "binary" in call_kwargs["resource_path"]


### PR DESCRIPTION
## Summary

Added `read_result_arrow()` to the `Execution` class, delegating to `BareExecutionResponse.read_result_arrow()`. The `/binary` endpoint for Apache Arrow execution results was already implemented in `BareExecutionResponse` using the raw `call_api` approach; the missing piece was exposing this method on the higher-level `Execution` class (which already delegated `read_result()` and `cancel()` to `BareExecutionResponse` but not `read_result_arrow()`). Added two unit tests verifying the delegation returns a `pyarrow.Table` and calls the correct `/binary` endpoint path.

**Impact:** new_feature | **Services:** `gooddata-afm-client`
**Tickets:** CQ-104

## Files changed

- `packages/gooddata-sdk/src/gooddata_sdk/compute/model/execution.py`
- `packages/gooddata-sdk/tests/compute/test_bare_execution_response.py`

## Source commits (gdc-nas)

- `78be9c1` Merge pull request #21285 from gooddata/dho/cq-104-arrow-api
- `81eb97a` Merge pull request #21382 from gooddata/dho/cq-104-arrow-api-2

<details><summary>OpenAPI diff</summary>

```diff
+    "/api/v1/actions/workspaces/{workspaceId}/execution/afm/execute/result/{resultId}/binary": {
+      "get": {
+        "description": "(BETA) Gets a single execution result as an Apache Arrow IPC File or Stream format.",
+        "operationId": "retrieveResultBinary",
+        "responses": {
+          "200": {
+            "content": {
+              "application/vnd.apache.arrow.file": { "schema": { "format": "binary", "type": "string" } },
+              "application/vnd.apache.arrow.stream": { "schema": { "format": "binary", "type": "string" } }
+            }
+          }
+        },
+        "summary": "(BETA) Get a single execution result in Apache Arrow File or Stream format",
+        "x-gdc-security-info": { "permissions": ["VIEW"] }
+      }
+    }
```
</details>

## [Workflow run](https://github.com/gooddata/gdc-nas/actions/runs/24346012445)

---
*Generated by SDK OpenAPI Sync workflow*