### PR TITLE
feat(gooddata-sdk): [AUTO] Add resolveLlmProviders endpoint and ResolvedLlm polymorphic schemas

### DIFF
--- a/packages/gooddata-sdk/src/gooddata_sdk/__init__.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/__init__.py
@@ -264,6 +264,12 @@ from gooddata_sdk.catalog.workspace.entity_model.graph_objects.graph import (
     CatalogDependentEntitiesResponse,
     CatalogEntityIdentifier,
 )
+from gooddata_sdk.catalog.workspace.entity_model.resolved_llm import (
+    CatalogResolvedLlmEndpoint,
+    CatalogResolvedLlmModelItem,
+    CatalogResolvedLlmProvider,
+    CatalogResolvedLlms,
+)
 from gooddata_sdk.catalog.workspace.entity_model.user_data_filter import (
     CatalogUserDataFilter,
     CatalogUserDataFilterAttributes,

--- a/packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/content_service.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/content_service.py
@@ -31,6 +31,7 @@ from gooddata_sdk.catalog.workspace.entity_model.graph_objects.graph import (
     CatalogDependentEntitiesRequest,
     CatalogDependentEntitiesResponse,
 )
+from gooddata_sdk.catalog.workspace.entity_model.resolved_llm import CatalogResolvedLlms
 from gooddata_sdk.catalog.workspace.model_container import CatalogWorkspaceContent
 from gooddata_sdk.client import GoodDataApiClient
 from gooddata_sdk.compute.model.attribute import Attribute
@@ -209,6 +210,24 @@ class CatalogWorkspaceContentService(CatalogServiceBase):
         agg_facts = load_all_entities(get_agg_facts)
         catalog_agg_facts = [CatalogAggregatedFact.from_api(agg_fact) for agg_fact in agg_facts.data]
         return catalog_agg_facts
+
+    def resolve_llm_providers(self, workspace_id: str) -> CatalogResolvedLlms:
+        """Resolve the active LLM configuration for the given workspace.
+
+        The returned :class:`~gooddata_sdk.CatalogResolvedLlms` object contains
+        the active LLM configuration (endpoint or provider) or ``None`` when no
+        LLM has been configured for the workspace.
+
+        Args:
+            workspace_id (str):
+                Workspace identification string e.g. "demo"
+
+        Returns:
+            CatalogResolvedLlms:
+                Resolved LLM configuration for the workspace.
+        """
+        response = self._actions_api.resolve_llm_providers(workspace_id, _check_return_type=False)
+        return CatalogResolvedLlms.from_api(response)
 
     def get_dependent_entities_graph(self, workspace_id: str) -> CatalogDependentEntitiesResponse:
         """There are dependencies among all catalog objects, the chain is the following:

--- a/packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/entity_model/resolved_llm.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/entity_model/resolved_llm.py
@@ -1,0 +1,96 @@
+# (C) 2026 GoodData Corporation
+from __future__ import annotations
+
+from typing import Any, Union
+
+import attrs
+
+from gooddata_sdk.catalog.base import Base
+
+
+@attrs.define(kw_only=True)
+class CatalogResolvedLlmModelItem(Base):
+    """A model entry returned as part of a resolved LLM provider."""
+
+    id: str
+    family: str
+
+    @staticmethod
+    def client_class() -> Any:
+        from gooddata_api_client.model.llm_model import LlmModel
+
+        return LlmModel
+
+    @classmethod
+    def from_api(cls, entity: dict[str, Any]) -> CatalogResolvedLlmModelItem:
+        return cls(id=entity["id"], family=entity["family"])
+
+
+@attrs.define(kw_only=True)
+class CatalogResolvedLlmEndpoint(Base):
+    """Resolved LLM configuration backed by an LLM endpoint."""
+
+    id: str
+    title: str
+
+    @staticmethod
+    def client_class() -> Any:
+        from gooddata_api_client.model.resolved_llm_endpoint import ResolvedLlmEndpoint
+
+        return ResolvedLlmEndpoint
+
+    @classmethod
+    def from_api(cls, entity: dict[str, Any]) -> CatalogResolvedLlmEndpoint:
+        return cls(id=entity["id"], title=entity["title"])
+
+
+@attrs.define(kw_only=True)
+class CatalogResolvedLlmProvider(Base):
+    """Resolved LLM configuration backed by an LLM provider."""
+
+    id: str
+    title: str
+    models: list[CatalogResolvedLlmModelItem] = attrs.field(factory=list)
+
+    @staticmethod
+    def client_class() -> Any:
+        from gooddata_api_client.model.resolved_llm_provider import ResolvedLlmProvider
+
+        return ResolvedLlmProvider
+
+    @classmethod
+    def from_api(cls, entity: dict[str, Any]) -> CatalogResolvedLlmProvider:
+        models = [CatalogResolvedLlmModelItem.from_api(m) for m in entity.get("models", [])]
+        return cls(id=entity["id"], title=entity["title"], models=models)
+
+
+CatalogResolvedLlmData = Union[CatalogResolvedLlmEndpoint, CatalogResolvedLlmProvider]
+
+
+@attrs.define(kw_only=True)
+class CatalogResolvedLlms(Base):
+    """Container for the active LLM configuration resolved for a given workspace.
+
+    The ``data`` field is ``None`` when no LLM is configured for the workspace.
+    Otherwise it is either a :class:`CatalogResolvedLlmEndpoint` (when the
+    workspace uses an LLM endpoint) or a :class:`CatalogResolvedLlmProvider`
+    (when the workspace uses an LLM provider with associated models).
+    """
+
+    data: CatalogResolvedLlmData | None = None
+
+    @staticmethod
+    def client_class() -> Any:
+        from gooddata_api_client.model.resolved_llms import ResolvedLlms
+
+        return ResolvedLlms
+
+    @classmethod
+    def from_api(cls, entity: dict[str, Any]) -> CatalogResolvedLlms:
+        raw_data = entity.get("data")
+        if raw_data is None:
+            return cls(data=None)
+        # Distinguish endpoint from provider by the presence of the "models" key.
+        if "models" in raw_data:
+            return cls(data=CatalogResolvedLlmProvider.from_api(raw_data))
+        return cls(data=CatalogResolvedLlmEndpoint.from_api(raw_data))

--- a/packages/gooddata-sdk/tests/catalog/test_resolved_llm.py
+++ b/packages/gooddata-sdk/tests/catalog/test_resolved_llm.py
@@ -1,0 +1,88 @@
+# (C) 2026 GoodData Corporation
+from __future__ import annotations
+
+import pytest
+from gooddata_sdk import (
+    CatalogResolvedLlmEndpoint,
+    CatalogResolvedLlmModelItem,
+    CatalogResolvedLlmProvider,
+    CatalogResolvedLlms,
+)
+
+
+class TestCatalogResolvedLlms:
+    """Unit tests for ResolvedLlm model classes — no network I/O required."""
+
+    def test_from_api_no_data(self):
+        """data=None means no LLM is configured."""
+        result = CatalogResolvedLlms.from_api({"data": None})
+        assert result.data is None
+
+    def test_from_api_missing_data_key(self):
+        """Absent 'data' key is treated the same as None."""
+        result = CatalogResolvedLlms.from_api({})
+        assert result.data is None
+
+    def test_from_api_endpoint(self):
+        """When data has no 'models' key it is parsed as a CatalogResolvedLlmEndpoint."""
+        payload = {
+            "data": {
+                "id": "my-endpoint",
+                "title": "My Endpoint",
+            }
+        }
+        result = CatalogResolvedLlms.from_api(payload)
+        assert isinstance(result.data, CatalogResolvedLlmEndpoint)
+        assert result.data.id == "my-endpoint"
+        assert result.data.title == "My Endpoint"
+
+    def test_from_api_provider(self):
+        """When data contains a 'models' key it is parsed as a CatalogResolvedLlmProvider."""
+        payload = {
+            "data": {
+                "id": "my-provider",
+                "title": "My Provider",
+                "models": [{"id": "gpt-4", "family": "OPENAI"}],
+            }
+        }
+        result = CatalogResolvedLlms.from_api(payload)
+        assert isinstance(result.data, CatalogResolvedLlmProvider)
+        assert result.data.id == "my-provider"
+        assert result.data.title == "My Provider"
+        assert len(result.data.models) == 1
+        model = result.data.models[0]
+        assert isinstance(model, CatalogResolvedLlmModelItem)
+        assert model.id == "gpt-4"
+        assert model.family == "OPENAI"
+
+    def test_from_api_provider_empty_models(self):
+        """Provider with an empty models list is still parsed as CatalogResolvedLlmProvider."""
+        payload = {
+            "data": {
+                "id": "provider-no-models",
+                "title": "Provider",
+                "models": [],
+            }
+        }
+        result = CatalogResolvedLlms.from_api(payload)
+        assert isinstance(result.data, CatalogResolvedLlmProvider)
+        assert result.data.models == []
+
+    @pytest.mark.parametrize(
+        "scenario, payload, expected_type",
+        [
+            (
+                "endpoint",
+                {"data": {"id": "ep", "title": "EP"}},
+                CatalogResolvedLlmEndpoint,
+            ),
+            (
+                "provider",
+                {"data": {"id": "prov", "title": "Prov", "models": []}},
+                CatalogResolvedLlmProvider,
+            ),
+        ],
+    )
+    def test_from_api_type_dispatch(self, scenario, payload, expected_type):
+        result = CatalogResolvedLlms.from_api(payload)
+        assert isinstance(result.data, expected_type), f"scenario={scenario}"


### PR DESCRIPTION
## Summary

Added SDK wrapper for the new `resolveLlmProviders` GET endpoint (`/api/v1/actions/workspaces/{workspaceId}/ai/resolveLlmProviders`). Created four new model classes (CatalogResolvedLlms, CatalogResolvedLlmEndpoint, CatalogResolvedLlmProvider, CatalogResolvedLlmModelItem) in a new entity_model file, added resolve_llm_providers() service method to CatalogWorkspaceContentService, exported all new classes from gooddata_sdk/__init__.py, and added pure-unit tests covering the polymorphic parsing logic.

**Impact:** new_feature | **Services:** `gooddata-afm-client`

## Files changed

- `packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/entity_model/resolved_llm.py`
- `packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/content_service.py`
- `packages/gooddata-sdk/src/gooddata_sdk/__init__.py`
- `packages/gooddata-sdk/tests/catalog/test_resolved_llm.py`

## Agent decisions

<details><summary>Decisions (4)</summary>

**Service method placement** — Added resolve_llm_providers() to CatalogWorkspaceContentService
  - Alternatives: Add to CatalogWorkspaceService (workspace management), Add to CatalogOrganizationService alongside LLM provider CRUD
  - Why: The endpoint is workspace-scoped (/workspaces/{id}/ai/resolveLlmProviders), matching other workspace content action methods already in this service (compute_valid_objects, get_label_elements, get_dependent_entities_graph).

**Polymorphic oneOf parsing (endpoint vs provider)** — Check for presence of the 'models' key in the raw data dict to dispatch to CatalogResolvedLlmProvider vs CatalogResolvedLlmEndpoint
  - Alternatives: Use a discriminator field (none exists), Merge both subtypes into a single class with optional models field
  - Why: No discriminator field exists in the spec. The only structural difference between the two subtypes is the presence of 'models' in ResolvedLlmProvider. Consistent with how llm_provider.py handles similar type detection.

**client_class() with deferred imports** — Lazy-import generated client classes inside client_class() static methods to avoid circular imports at module load time
  - Alternatives: Top-level imports from gooddata_api_client
  - Why: Matches existing pattern in graph.py and other entity_model files.

**Test type: unit vs integration** — Pure unit tests (no mocks, no cassettes)
  - Alternatives: Integration test with VCR cassette (unnecessary for pure parsing logic)
  - Why: The only non-trivial logic is dict-based type dispatch in CatalogResolvedLlms.from_api(). Unit tests cover all branching paths with zero external dependencies.

</details>

<details><summary>Assumptions to verify (3)</summary>

- The API returns 'models' only for provider-backed configurations and never for endpoint-backed ones, making the 'models' key a reliable discriminator.
- When _check_return_type=False, the actions_api.resolve_llm_providers() return value supports dict-style .get() access (consistent with how other _check_return_type=False calls are consumed in the codebase).
- The 'data' field is absent or null when no LLM is configured, rather than raising an HTTP error.

</details>

<details><summary>Risks (2)</summary>

- If the live backend returns a 404 or non-200 when no LLM is configured (instead of {data: null}), the service method will raise rather than returning CatalogResolvedLlms(data=None).
- If the API response dict uses a key other than 'models' the type-dispatch heuristic would break silently (parsing as endpoint instead of provider).

</details>

<details><summary>Layers touched (3)</summary>

- **entity_model** — New file with CatalogResolvedLlms, CatalogResolvedLlmEndpoint, CatalogResolvedLlmProvider, CatalogResolvedLlmModelItem
  - `packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/entity_model/resolved_llm.py`
- **public_api** — Added resolve_llm_providers() to CatalogWorkspaceContentService; exported 4 new classes from __init__.py
  - `packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/content_service.py`
  - `packages/gooddata-sdk/src/gooddata_sdk/__init__.py`
- **tests** — Unit tests for polymorphic from_api() parsing — no cassettes needed
  - `packages/gooddata-sdk/tests/catalog/test_resolved_llm.py`

</details>

## Source commits (gdc-nas)

- `699c75c` Merge pull request #21420 from hkad98/jkd/resolve-llm-provider

<details><summary>OpenAPI diff</summary>

```diff
diff --git a/microservices/afm-exec-api/src/test/resources/openapi/open-api-spec.json
@@ -3825,20 +3825,38 @@
-      "ResolvedLlmEndpoint" : {
+      "ResolvedLlm" : {
+        "description" : "The resolved LLM configuration, or null if none is configured.",
         "properties" : {
           "id" : { "type" : "string" },
           "title" : { "type" : "string" }
         },
         "required" : [ "id", "title" ],
         "type" : "object"
       },
+      "ResolvedLlmEndpoint" : {
+        "allOf" : [ { "$ref" : "#/components/schemas/ResolvedLlm" }, {
+          "properties" : {
+            "id" : { "description" : "Endpoint Id", "type" : "string" },
+            "title" : { "description" : "Endpoint Title", "type" : "string" }
+          }, "type" : "object"
+        } ],
+        "required" : [ "id", "title" ],
+        "type" : "object"
+      },
+      "ResolvedLlmProvider" : {
+        "allOf" : [ { "$ref" : "#/components/schemas/ResolvedLlm" }, {
+          "properties" : {
+            "id" : { "description" : "Provider Id", "type" : "string" },
+            "models" : { "items" : { "$ref" : "#/components/schemas/LlmModel" }, "maxItems" : 1, "minItems" : 1, "type" : "array" },
+            "title" : { "description" : "Provider Title", "type" : "string" }
+          }, "type" : "object"
+        } ],
+        "required" : [ "id", "models", "title" ],
+        "type" : "object"
+      },
+      "ResolvedLlms" : {
+        "properties" : {
+          "data" : { "oneOf" : [ { "$ref" : "#/components/schemas/ResolvedLlmEndpoint" }, { "$ref" : "#/components/schemas/ResolvedLlmProvider" } ] }
+        },
+        "type" : "object"
+      },
@@ -5987,6 +6044,36 @@
+    "/api/v1/actions/workspaces/{workspaceId}/ai/resolveLlmProviders" : {
+      "get" : {
+        "description" : "Resolves the active LLM configuration for the given workspace.",
+        "operationId" : "resolveLlmProviders",
+        "parameters" : [ { "description" : "Workspace identifier", "in" : "path", "name" : "workspaceId", "required" : true, "schema" : { "pattern" : "^(?!\\.)[.A-Za-z0-9_-]{1,255}$", "type" : "string" } } ],
+        "responses" : { "200" : { "content" : { "application/json" : { "schema" : { "$ref" : "#/components/schemas/ResolvedLlms" } } }, "description" : "OK" } },
+        "summary" : "Get Active LLM configuration for this workspace",
+        "tags" : [ "Smart Functions", "actions" ]
+      }
+    },
```
</details>

## [Workflow run](https://github.com/gooddata/gdc-nas/actions/runs/24638549222)

---
*Generated by SDK OpenAPI Sync workflow*