### PR TITLE
feat(gooddata-sdk): [AUTO] Add ToolCallEventResult schema and toolCallEvents to chat response

### DIFF
--- a/packages/gooddata-sdk/src/gooddata_sdk/__init__.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/__init__.py
@@ -274,6 +274,7 @@ from gooddata_sdk.client import GoodDataApiClient
 from gooddata_sdk.compute.compute_to_sdk_converter import ComputeToSdkConverter
 from gooddata_sdk.compute.model.attribute import Attribute
 from gooddata_sdk.compute.model.base import ExecModelEntity, ObjId
+from gooddata_sdk.compute.model.chat import ToolCallEventResult
 from gooddata_sdk.compute.model.execution import (
     BareExecutionResponse,
     Execution,

--- a/packages/gooddata-sdk/src/gooddata_sdk/compute/model/chat.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/compute/model/chat.py
@@ -1,0 +1,32 @@
+# (C) 2026 GoodData Corporation
+from __future__ import annotations
+
+import attrs
+from gooddata_api_client.model.tool_call_event_result import (
+    ToolCallEventResult as ApiToolCallEventResult,
+)
+
+from gooddata_sdk.catalog.base import Base
+
+
+@attrs.define(kw_only=True)
+class ToolCallEventResult(Base):
+    """Represents a tool call event emitted during the agentic loop.
+
+    Only present in :class:`~gooddata_api_client.model.chat_result.ChatResult`
+    when the ``GEN_AI_YIELD_TOOL_CALL_EVENTS`` feature flag is enabled on the
+    GoodData backend.
+    """
+
+    function_arguments: str
+    """JSON-encoded arguments passed to the tool function."""
+
+    function_name: str
+    """Name of the tool function that was called."""
+
+    result: str
+    """Result returned by the tool function."""
+
+    @staticmethod
+    def client_class() -> type[ApiToolCallEventResult]:
+        return ApiToolCallEventResult

--- a/packages/gooddata-sdk/tests/compute/test_chat_models.py
+++ b/packages/gooddata-sdk/tests/compute/test_chat_models.py
@@ -1,0 +1,70 @@
+# (C) 2026 GoodData Corporation
+from __future__ import annotations
+
+import pytest
+from gooddata_sdk.compute.model.chat import ToolCallEventResult
+
+
+@pytest.mark.parametrize(
+    "scenario, input_data, expected_snake",
+    [
+        (
+            "basic",
+            {
+                "functionArguments": '{"x": 1}',
+                "functionName": "get_revenue",
+                "result": "42",
+            },
+            {
+                "function_arguments": '{"x": 1}',
+                "function_name": "get_revenue",
+                "result": "42",
+            },
+        ),
+        (
+            "empty_strings",
+            {
+                "functionArguments": "",
+                "functionName": "noop",
+                "result": "",
+            },
+            {
+                "function_arguments": "",
+                "function_name": "noop",
+                "result": "",
+            },
+        ),
+    ],
+)
+def test_tool_call_event_result_from_dict(scenario, input_data, expected_snake):
+    """Verify ToolCallEventResult round-trips through from_dict / to_dict."""
+    model = ToolCallEventResult.from_dict(input_data)
+
+    assert model.function_arguments == expected_snake["function_arguments"]
+    assert model.function_name == expected_snake["function_name"]
+    assert model.result == expected_snake["result"]
+
+    # Round-trip back to camelCase dict
+    as_dict = model.to_dict(camel_case=True)
+    assert as_dict["functionArguments"] == expected_snake["function_arguments"]
+    assert as_dict["functionName"] == expected_snake["function_name"]
+    assert as_dict["result"] == expected_snake["result"]
+
+
+def test_tool_call_event_result_construction():
+    """Verify direct construction and attribute access."""
+    evt = ToolCallEventResult(
+        function_arguments='{"threshold": 0.5}',
+        function_name="filter_results",
+        result="filtered",
+    )
+    assert evt.function_arguments == '{"threshold": 0.5}'
+    assert evt.function_name == "filter_results"
+    assert evt.result == "filtered"
+
+
+def test_tool_call_event_result_client_class():
+    """Verify client_class() returns the generated API model class."""
+    from gooddata_api_client.model.tool_call_event_result import ToolCallEventResult as ApiToolCallEventResult
+
+    assert ToolCallEventResult.client_class() is ApiToolCallEventResult


### PR DESCRIPTION
## Summary

Added `ToolCallEventResult` SDK wrapper class for the new `ToolCallEventResult` OpenAPI schema and the `toolCallEvents` array field added to `ChatResult`. The generated API client already contained both changes; the SDK wrapper was added in `compute/model/chat.py` and exported from `gooddata_sdk/__init__.py`. A unit test covering construction, `from_dict`/`to_dict` round-trip, and `client_class()` was added in `tests/compute/test_chat_models.py`.

**Impact:** new_feature | **Services:** `gooddata-afm-client`
**Tickets:** GDAI-1438

## Files changed

- `packages/gooddata-sdk/src/gooddata_sdk/compute/model/chat.py`
- `packages/gooddata-sdk/src/gooddata_sdk/__init__.py`
- `packages/gooddata-sdk/tests/compute/test_chat_models.py`

## Agent decisions

<details><summary>Decisions (3)</summary>

**Class placement** — Placed ToolCallEventResult in compute/model/chat.py (compute module, no Catalog prefix)
  - Alternatives: catalog/<domain>/entity_model/ with Catalog prefix, Inline in compute/service.py
  - Why: The AI chat feature lives in compute/service.py. Existing compute model classes (Attribute, Metric, Filter) use no Catalog prefix. Placing it here keeps the domain consistent.

**Naming to avoid collision with generated client** — Import generated class as ApiToolCallEventResult alias, define SDK class as ToolCallEventResult
  - Alternatives: CatalogToolCallEventResult (Catalog prefix would be inconsistent with compute module), Re-export the generated class directly (no SDK wrapper)
  - Why: Gives users a clean SDK name (ToolCallEventResult) while avoiding confusion; the alias makes the generated-vs-SDK distinction explicit inside the module.

**Wrapper vs. pass-through** — Created a proper attrs wrapper class extending Base
  - Alternatives: Re-export generated ToolCallEventResult directly (no from_dict/to_dict), No wrapper at all
  - Why: Gives users from_dict/to_dict/to_api serialization support and a stable SDK type for type annotations. Other response types (ChatResult, SearchResult) are returned raw from service methods, but ToolCallEventResult is a new leaf schema that benefits from SDK ownership.

</details>

<details><summary>Assumptions to verify (3)</summary>

- The generated API client (gooddata-api-client) already includes ToolCallEventResult and ChatResult.tool_call_events — confirmed by reading the files directly.
- The Base.from_dict / to_dict serialization path works for ToolCallEventResult because the generated ApiToolCallEventResult has from_dict (it inherits from ModelNormal). This was not executable-verified due to missing urllib3 in the test environment.
- All three fields (function_arguments, function_name, result) are non-optional (required in the OpenAPI spec), so they are declared as required positional attrs fields.

</details>

<details><summary>Risks (1)</summary>

- The Base.to_dict() path calls self.client_class().from_dict(snake_case_dict, camel_case=False). If the generated ApiToolCallEventResult.from_dict does not accept camel_case=False cleanly for all three fields, the round-trip test will fail.

</details>

<details><summary>Layers touched (3)</summary>

- **entity_model** — New ToolCallEventResult wrapper class in compute model layer
  - `packages/gooddata-sdk/src/gooddata_sdk/compute/model/chat.py`
- **public_api** — Exported ToolCallEventResult from the public SDK surface
  - `packages/gooddata-sdk/src/gooddata_sdk/__init__.py`
- **tests** — Unit tests for ToolCallEventResult construction, round-trip serialization, and client_class()
  - `packages/gooddata-sdk/tests/compute/test_chat_models.py`

</details>

## Source commits (gdc-nas)

- `0e847c5` Merge pull request #21287 from gooddata/zovi/GDAI-1438-e2e-skill-tests

<details><summary>OpenAPI diff</summary>

```diff
diff --git a/microservices/afm-exec-api/src/test/resources/openapi/open-api-spec.json
@@ -1208,6 +1208,13 @@
           "threadIdSuffix" : { "description" : "Chat History thread suffix.", "type" : "string" },
+          "toolCallEvents" : {
+            "description" : "Tool call events emitted during the agentic loop (only present when GEN_AI_YIELD_TOOL_CALL_EVENTS is enabled).",
+            "items" : { "$ref" : "#/components/schemas/ToolCallEventResult" },
+            "type" : "array"
+          }
@@ -4485,6 +4492,25 @@
+      "ToolCallEventResult" : {
+        "description" : "Tool call events emitted during the agentic loop.",
+        "properties" : {
+          "functionArguments" : { "description" : "JSON-encoded arguments passed to the tool function.", "type" : "string" },
+          "functionName" : { "description" : "Name of the tool function that was called.", "type" : "string" },
+          "result" : { "description" : "Result returned by the tool function.", "type" : "string" }
+        },
+        "required" : [ "functionArguments", "functionName", "result" ],
+        "type" : "object"
+      },
```
</details>

## [Workflow run](https://github.com/gooddata/gdc-nas/actions/runs/24638549222)

---
*Generated by SDK OpenAPI Sync workflow*