### PR TITLE
feat(gooddata-sdk): [AUTO] Add retrieveResultBinary endpoint; remove Arrow formats from retrieveResult

### DIFF
--- a/packages/gooddata-sdk/src/gooddata_sdk/compute/model/execution.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/compute/model/execution.py
@@ -504,6 +504,15 @@ class Execution:
     ) -> ExecutionResult:
         return self.bare_exec_response.read_result(limit, offset, timeout)
 
+    def read_result_arrow(self) -> pyarrow.Table:
+        """
+        Reads the full execution result as a pyarrow Table via the binary endpoint.
+
+        The binary endpoint returns the complete result in one shot (no paging).
+        Requires pyarrow to be installed (pip install gooddata-sdk[arrow]).
+        """
+        return self.bare_exec_response.read_result_arrow()
+
     def cancel(self) -> None:
         """
         Cancels the execution.

--- a/packages/gooddata-sdk/tests/compute/test_bare_execution_response.py
+++ b/packages/gooddata-sdk/tests/compute/test_bare_execution_response.py
@@ -42,6 +42,31 @@ class _FakeResponse(io.RawIOBase):
         return n
 
 
+def _make_execution(ipc_bytes: bytes):
+    """Return an Execution backed by a mock API client."""
+    from gooddata_sdk.compute.model.execution import Execution
+
+    mock_api_client = MagicMock()
+    mock_response = _FakeResponse(ipc_bytes)
+    mock_api_client.actions_api.api_client.call_api.return_value = mock_response
+
+    afm_exec_response = {
+        "execution_response": {
+            "links": {"executionResult": "result-id-123"},
+            "dimensions": [],
+        }
+    }
+    mock_exec_def = MagicMock()
+
+    execution = Execution(
+        api_client=mock_api_client,
+        workspace_id="ws-id",
+        exec_def=mock_exec_def,
+        response=afm_exec_response,
+    )
+    return execution, mock_response
+
+
 def _make_bare(ipc_bytes: bytes):
     """Return a BareExecutionResponse backed by a mock API client."""
     from gooddata_sdk.compute.model.execution import BareExecutionResponse
@@ -108,3 +133,33 @@ def test_read_result_arrow_no_pyarrow_raises() -> None:
 
     with patch.object(_exec_mod, "_ipc", None), pytest.raises(ImportError, match="pyarrow is required"):
         bare.read_result_arrow()
+
+
+# ---------------------------------------------------------------------------
+# Execution.read_result_arrow – delegates to BareExecutionResponse
+# ---------------------------------------------------------------------------
+
+
+def test_execution_read_result_arrow_returns_table() -> None:
+    """Execution.read_result_arrow() delegates to BareExecutionResponse and returns a pa.Table."""
+    import pyarrow as pa
+
+    ipc_bytes = _make_ipc_stream_bytes()
+    execution, mock_response = _make_execution(ipc_bytes)
+
+    result = execution.read_result_arrow()
+
+    assert isinstance(result, pa.Table)
+    mock_response.release_conn.assert_called_once()
+
+
+def test_execution_read_result_arrow_calls_binary_endpoint() -> None:
+    """Execution.read_result_arrow() hits the /binary endpoint with the correct Accept header."""
+    ipc_bytes = _make_ipc_stream_bytes()
+    execution, _ = _make_execution(ipc_bytes)
+
+    execution.read_result_arrow()
+
+    call_kwargs = execution.bare_exec_response._actions_api.api_client.call_api.call_args.kwargs
+    assert call_kwargs["header_params"]["Accept"] == "application/vnd.apache.arrow.stream"
+    assert "/binary" in call_kwargs["resource_path"]


### PR DESCRIPTION
## Summary

Added `Execution.read_result_arrow()` method to the SDK's `Execution` class, delegating to the already-implemented `BareExecutionResponse.read_result_arrow()`. Also added two new unit tests that exercise the delegation path through `Execution`. No other layers needed changes: the API client already had `retrieve_result_binary`, `BareExecutionResponse.read_result_arrow()` was already implemented and tested, and all relevant classes were already exported from `gooddata_sdk/__init__.py`.

**Impact:** new_feature | **Services:** `gooddata-afm-client`

## Files changed

- `packages/gooddata-sdk/src/gooddata_sdk/compute/model/execution.py`
- `packages/gooddata-sdk/tests/compute/test_bare_execution_response.py`

## Agent decisions

<details><summary>Decisions (3)</summary>

**where to expose read_result_arrow()** — Add read_result_arrow() to Execution as a thin delegation to bare_exec_response.read_result_arrow()
  - Alternatives: Add a service-level method on ComputeService, Leave it only on BareExecutionResponse and document the accessor
  - Why: Execution already delegates read_result() and cancel() to BareExecutionResponse the same way. The gooddata-pandas package accesses it via execution.bare_exec_response.read_result_arrow() which is not a clean public API. Adding it directly on Execution matches the existing pattern and lets callers use execution.read_result_arrow() consistently.

**not adding a new service method on ComputeService** — No ComputeService change; the binary read is per-execution, not a standalone service call
  - Alternatives: Add ComputeService.retrieve_result_binary(workspace_id, result_id)
  - Why: ComputeService.for_exec_def() returns an Execution. Result reading is modeled as a method on the Execution/BareExecutionResponse, not on the service. retrieve_result_cache_metadata() is an exception because it takes a result_id independently; read_result_arrow() always follows an Execution.

**not modifying __init__.py** — No changes to public exports
  - Why: Execution and BareExecutionResponse are already exported. The new method is just an addition to an already-exported class.

</details>

<details><summary>Assumptions to verify (3)</summary>

- The pre-existing BareExecutionResponse.read_result_arrow() implementation (using call_api with /binary path and application/vnd.apache.arrow.stream Accept header) is correct for the new retrieveResultBinary endpoint.
- The type-check errors from ty check are all pre-existing environment issues (missing cattrs, requests, pyarrow site-packages) and not introduced by this change.
- gooddata-pandas callers that use execution.bare_exec_response.read_result_arrow() remain fully backward-compatible; the new Execution.read_result_arrow() is additive.

</details>

<details><summary>Risks (2)</summary>

- No integration tests added (the feature involves binary Arrow data over HTTP which requires a live server cassette); the existing unit tests on BareExecutionResponse.read_result_arrow() are sufficient coverage for the pure delegation.
- If the API server still returns arrow data on the old /result endpoint (before the OpenAPI change is deployed), callers using read_result_arrow() on the new binary endpoint may get errors — this is a server-side concern, not an SDK concern.

</details>

<details><summary>Layers touched (2)</summary>

- **entity_model** — Added read_result_arrow() delegation method to Execution class
  - `packages/gooddata-sdk/src/gooddata_sdk/compute/model/execution.py`
- **tests** — Added _make_execution() factory and two test functions for Execution.read_result_arrow()
  - `packages/gooddata-sdk/tests/compute/test_bare_execution_response.py`

</details>

## Source commits (gdc-nas)

- `81eb97a` Merge pull request #21382 from gooddata/dho/cq-104-arrow-api-2

<details><summary>OpenAPI diff</summary>

```diff
diff --git a/microservices/afm-exec-api/src/test/resources/openapi/open-api-spec.json
@@ retrieveResult response: remove Arrow media types @@
@@ -6314,9 +6314,7 @@
                 "schema" : { "$ref" : "#/components/schemas/ExecutionResult" }
-              },
-              "application/vnd.apache.arrow.file" : { },
-              "application/vnd.apache.arrow.stream" : { }
+              }
@@ +new endpoint: retrieveResultBinary @@
+    "/api/v1/actions/workspaces/{workspaceId}/execution/afm/execute/result/{resultId}/binary" : {
+      "get" : {
+        "description" : "(BETA) Gets a single execution result as an Apache Arrow IPC File or Stream format.",
+        "operationId" : "retrieveResultBinary",
+        "parameters" : [ { workspaceId path }, { resultId path }, { "in" : "header", "name" : "X-GDC-CANCEL-TOKEN", "required" : false, "schema" : { "type" : "string" } } ],
+        "responses" : {
+          "200" : { "content" : {
+            "application/vnd.apache.arrow.file" : { "schema" : { "format" : "binary", "type" : "string" } },
+            "application/vnd.apache.arrow.stream" : { "schema" : { "format" : "binary", "type" : "string" } }
+          }, "description" : "Execution result was found and returned." }
+        },
+        "summary" : "(BETA) Get a single execution result in Apache Arrow File or Stream format",
+        "tags" : [ "Computation", "actions" ],
+        "x-gdc-security-info" : { "permissions" : [ "VIEW" ] }
+      }
+    },
```
</details>

## [Workflow run](https://github.com/gooddata/gdc-nas/actions/runs/24638549222)

---
*Generated by SDK OpenAPI Sync workflow*