### PR TITLE
feat(gooddata-sdk): [AUTO] Add WidgetDescriptor, DashboardContext, UIContext schemas; extend UserContext

### DIFF
--- a/packages/gooddata-sdk/src/gooddata_sdk/__init__.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/__init__.py
@@ -316,6 +316,18 @@ from gooddata_sdk.compute.model.metric import (
     PopDatesetMetric,
     SimpleMetric,
 )
+from gooddata_sdk.compute.model.user_context import (
+    CatalogActiveObjectIdentification,
+    CatalogDashboardContext,
+    CatalogInsightWidgetDescriptor,
+    CatalogObjectReference,
+    CatalogObjectReferenceGroup,
+    CatalogRichTextWidgetDescriptor,
+    CatalogUIContext,
+    CatalogUserContext,
+    CatalogVisualizationSwitcherWidgetDescriptor,
+    CatalogWidgetDescriptor,
+)
 from gooddata_sdk.compute.service import ComputeService
 from gooddata_sdk.sdk import GoodDataSdk
 from gooddata_sdk.table import ExecutionTable, TableService

--- a/packages/gooddata-sdk/src/gooddata_sdk/compute/model/user_context.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/compute/model/user_context.py
@@ -1,0 +1,178 @@
+# (C) 2026 GoodData Corporation
+from __future__ import annotations
+
+from typing import Any, Union
+
+import attrs
+from gooddata_api_client.model.active_object_identification import ActiveObjectIdentification
+from gooddata_api_client.model.dashboard_context import DashboardContext
+from gooddata_api_client.model.insight_widget_descriptor import InsightWidgetDescriptor
+from gooddata_api_client.model.object_reference import ObjectReference
+from gooddata_api_client.model.object_reference_group import ObjectReferenceGroup
+from gooddata_api_client.model.rich_text_widget_descriptor import RichTextWidgetDescriptor
+from gooddata_api_client.model.ui_context import UIContext
+from gooddata_api_client.model.user_context import UserContext
+from gooddata_api_client.model.visualization_switcher_widget_descriptor import VisualizationSwitcherWidgetDescriptor
+
+
+@attrs.define(kw_only=True)
+class CatalogActiveObjectIdentification:
+    """Identifies the currently active object in the user's UI."""
+
+    id: str
+    type: str
+    workspace_id: str
+
+    def as_api_model(self) -> ActiveObjectIdentification:
+        return ActiveObjectIdentification(
+            id=self.id,
+            type=self.type,
+            workspace_id=self.workspace_id,
+            _check_type=False,
+        )
+
+
+@attrs.define(kw_only=True)
+class CatalogObjectReference:
+    """Reference to a GoodData object (widget, metric, attribute, or dashboard)."""
+
+    id: str
+    type: str  # WIDGET, METRIC, ATTRIBUTE, DASHBOARD
+
+    def as_api_model(self) -> ObjectReference:
+        return ObjectReference(id=self.id, type=self.type, _check_type=False)
+
+
+@attrs.define(kw_only=True)
+class CatalogObjectReferenceGroup:
+    """A group of explicitly referenced objects, optionally scoped by a context."""
+
+    objects: list[CatalogObjectReference] = attrs.field(factory=list)
+    context: CatalogObjectReference | None = None
+
+    def as_api_model(self) -> ObjectReferenceGroup:
+        kwargs: dict[str, Any] = {}
+        if self.context is not None:
+            kwargs["context"] = self.context.as_api_model()
+        return ObjectReferenceGroup(
+            objects=[o.as_api_model() for o in self.objects],
+            _check_type=False,
+            **kwargs,
+        )
+
+
+@attrs.define(kw_only=True)
+class CatalogInsightWidgetDescriptor:
+    """Insight widget visible on a dashboard."""
+
+    title: str
+    widget_id: str
+    visualization_id: str
+    result_id: str | None = None
+
+    def as_api_model(self) -> InsightWidgetDescriptor:
+        kwargs: dict[str, Any] = {}
+        if self.result_id is not None:
+            kwargs["result_id"] = self.result_id
+        return InsightWidgetDescriptor(
+            title=self.title,
+            visualization_id=self.visualization_id,
+            widget_id=self.widget_id,
+            _check_type=False,
+            **kwargs,
+        )
+
+
+@attrs.define(kw_only=True)
+class CatalogRichTextWidgetDescriptor:
+    """Rich text widget visible on a dashboard."""
+
+    title: str
+    widget_id: str
+
+    def as_api_model(self) -> RichTextWidgetDescriptor:
+        return RichTextWidgetDescriptor(title=self.title, widget_id=self.widget_id, _check_type=False)
+
+
+@attrs.define(kw_only=True)
+class CatalogVisualizationSwitcherWidgetDescriptor:
+    """Visualization switcher widget visible on a dashboard."""
+
+    title: str
+    widget_id: str
+    active_visualization_id: str
+    visualization_ids: list[str] = attrs.field(factory=list)
+    result_id: str | None = None
+
+    def as_api_model(self) -> VisualizationSwitcherWidgetDescriptor:
+        kwargs: dict[str, Any] = {}
+        if self.result_id is not None:
+            kwargs["result_id"] = self.result_id
+        return VisualizationSwitcherWidgetDescriptor(
+            active_visualization_id=self.active_visualization_id,
+            title=self.title,
+            visualization_ids=self.visualization_ids,
+            widget_id=self.widget_id,
+            _check_type=False,
+            **kwargs,
+        )
+
+
+# Union of all concrete widget descriptor types.
+CatalogWidgetDescriptor = Union[
+    CatalogInsightWidgetDescriptor,
+    CatalogRichTextWidgetDescriptor,
+    CatalogVisualizationSwitcherWidgetDescriptor,
+]
+
+
+@attrs.define(kw_only=True)
+class CatalogDashboardContext:
+    """Dashboard the user is currently viewing."""
+
+    id: str
+    widgets: list[CatalogWidgetDescriptor] = attrs.field(factory=list)
+
+    def as_api_model(self) -> DashboardContext:
+        return DashboardContext(
+            id=self.id,
+            widgets=[w.as_api_model() for w in self.widgets],
+            _check_type=False,
+        )
+
+
+@attrs.define(kw_only=True)
+class CatalogUIContext:
+    """Ambient UI state describing what the user currently sees."""
+
+    dashboard: CatalogDashboardContext | None = None
+
+    def as_api_model(self) -> UIContext:
+        kwargs: dict[str, Any] = {}
+        if self.dashboard is not None:
+            kwargs["dashboard"] = self.dashboard.as_api_model()
+        return UIContext(_check_type=False, **kwargs)
+
+
+@attrs.define(kw_only=True)
+class CatalogUserContext:
+    """User context that can influence AI feature behavior.
+
+    Provides ambient UI state (``view``) and explicitly referenced objects
+    (``referenced_objects``) in addition to the optionally active object
+    (``active_object``).
+    """
+
+    active_object: CatalogActiveObjectIdentification | None = None
+    referenced_objects: list[CatalogObjectReferenceGroup] = attrs.field(factory=list)
+    view: CatalogUIContext | None = None
+
+    def as_api_model(self) -> UserContext:
+        kwargs: dict[str, Any] = {}
+        if self.active_object is not None:
+            kwargs["active_object"] = self.active_object.as_api_model()
+        if self.referenced_objects:
+            kwargs["referenced_objects"] = [ro.as_api_model() for ro in self.referenced_objects]
+        if self.view is not None:
+            kwargs["view"] = self.view.as_api_model()
+        return UserContext(_check_type=False, **kwargs)

--- a/packages/gooddata-sdk/src/gooddata_sdk/compute/service.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/compute/service.py
@@ -23,6 +23,7 @@ from gooddata_sdk.compute.model.execution import (
     ResultCacheMetadata,
     TableDimension,
 )
+from gooddata_sdk.compute.model.user_context import CatalogUserContext
 from gooddata_sdk.compute.visualization_to_sdk_converter import VisualizationToSdkConverter
 
 logger = logging.getLogger(__name__)
@@ -135,17 +136,27 @@ class ComputeService:
             is_cancellable=is_cancellable,
         )
 
-    def ai_chat(self, workspace_id: str, question: str) -> ChatResult:
+    def ai_chat(
+        self,
+        workspace_id: str,
+        question: str,
+        user_context: CatalogUserContext | None = None,
+    ) -> ChatResult:
         """
         Chat with AI in GoodData workspace.
 
         Args:
             workspace_id (str): workspace identifier
             question (str): question for the AI
+            user_context (CatalogUserContext | None): optional user context providing ambient UI
+                state and explicitly referenced objects to influence the AI response.
         Returns:
             ChatResult: Chat response
         """
-        chat_request = ChatRequest(question=question)
+        kwargs: dict[str, Any] = {}
+        if user_context is not None:
+            kwargs["user_context"] = user_context.as_api_model()
+        chat_request = ChatRequest(question=question, **kwargs)
         response = self._actions_api.ai_chat(workspace_id, chat_request, _check_return_type=False)
         return response
 
@@ -160,17 +171,27 @@ class ComputeService:
                     except json.JSONDecodeError:
                         continue
 
-    def ai_chat_stream(self, workspace_id: str, question: str) -> Iterator[Any]:
+    def ai_chat_stream(
+        self,
+        workspace_id: str,
+        question: str,
+        user_context: CatalogUserContext | None = None,
+    ) -> Iterator[Any]:
         """
         Chat Stream with AI in GoodData workspace.
 
         Args:
             workspace_id (str): workspace identifier
             question (str): question for the AI
+            user_context (CatalogUserContext | None): optional user context providing ambient UI
+                state and explicitly referenced objects to influence the AI response.
         Returns:
             Iterator[Any]: Yields parsed JSON objects from each SSE event's data field
         """
-        chat_request = ChatRequest(question=question)
+        kwargs: dict[str, Any] = {}
+        if user_context is not None:
+            kwargs["user_context"] = user_context.as_api_model()
+        chat_request = ChatRequest(question=question, **kwargs)
         response = self._actions_api.ai_chat_stream(
             workspace_id, chat_request, _check_return_type=False, _preload_content=False
         )

--- a/packages/gooddata-sdk/tests/compute/test_user_context.py
+++ b/packages/gooddata-sdk/tests/compute/test_user_context.py
@@ -1,0 +1,217 @@
+# (C) 2026 GoodData Corporation
+"""Unit tests for CatalogUserContext and related models."""
+
+from __future__ import annotations
+
+import pytest
+from gooddata_sdk.compute.model.user_context import (
+    CatalogActiveObjectIdentification,
+    CatalogDashboardContext,
+    CatalogInsightWidgetDescriptor,
+    CatalogObjectReference,
+    CatalogObjectReferenceGroup,
+    CatalogRichTextWidgetDescriptor,
+    CatalogUIContext,
+    CatalogUserContext,
+    CatalogVisualizationSwitcherWidgetDescriptor,
+)
+
+
+class TestCatalogObjectReference:
+    def test_as_api_model_basic(self):
+        ref = CatalogObjectReference(id="metric-1", type="METRIC")
+        api = ref.as_api_model()
+        assert api["id"] == "metric-1"
+        assert api["type"] == "METRIC"
+
+    @pytest.mark.parametrize("ref_type", ["WIDGET", "METRIC", "ATTRIBUTE", "DASHBOARD"])
+    def test_all_types(self, ref_type: str):
+        ref = CatalogObjectReference(id="obj-id", type=ref_type)
+        api = ref.as_api_model()
+        assert api["type"] == ref_type
+
+
+class TestCatalogObjectReferenceGroup:
+    def test_as_api_model_without_context(self):
+        group = CatalogObjectReferenceGroup(
+            objects=[CatalogObjectReference(id="w1", type="WIDGET")],
+        )
+        api = group.as_api_model()
+        assert len(api["objects"]) == 1
+        assert api["objects"][0]["id"] == "w1"
+
+    def test_as_api_model_with_context(self):
+        group = CatalogObjectReferenceGroup(
+            objects=[CatalogObjectReference(id="m1", type="METRIC")],
+            context=CatalogObjectReference(id="db1", type="DASHBOARD"),
+        )
+        api = group.as_api_model()
+        assert api["context"]["id"] == "db1"
+        assert api["context"]["type"] == "DASHBOARD"
+
+    def test_empty_objects(self):
+        group = CatalogObjectReferenceGroup()
+        api = group.as_api_model()
+        assert api["objects"] == []
+
+
+class TestCatalogInsightWidgetDescriptor:
+    def test_as_api_model_minimal(self):
+        widget = CatalogInsightWidgetDescriptor(
+            title="Revenue Chart",
+            widget_id="w-insight-1",
+            visualization_id="viz-1",
+        )
+        api = widget.as_api_model()
+        assert api["title"] == "Revenue Chart"
+        assert api["widget_id"] == "w-insight-1"
+        assert api["visualization_id"] == "viz-1"
+
+    def test_as_api_model_with_result_id(self):
+        widget = CatalogInsightWidgetDescriptor(
+            title="Revenue Chart",
+            widget_id="w-insight-1",
+            visualization_id="viz-1",
+            result_id="result-abc",
+        )
+        api = widget.as_api_model()
+        assert api["result_id"] == "result-abc"
+
+
+class TestCatalogRichTextWidgetDescriptor:
+    def test_as_api_model(self):
+        widget = CatalogRichTextWidgetDescriptor(title="Header", widget_id="w-rt-1")
+        api = widget.as_api_model()
+        assert api["title"] == "Header"
+        assert api["widget_id"] == "w-rt-1"
+
+
+class TestCatalogVisualizationSwitcherWidgetDescriptor:
+    def test_as_api_model_minimal(self):
+        widget = CatalogVisualizationSwitcherWidgetDescriptor(
+            title="Switcher",
+            widget_id="w-vs-1",
+            active_visualization_id="viz-a",
+            visualization_ids=["viz-a", "viz-b"],
+        )
+        api = widget.as_api_model()
+        assert api["title"] == "Switcher"
+        assert api["active_visualization_id"] == "viz-a"
+        assert api["visualization_ids"] == ["viz-a", "viz-b"]
+
+    def test_as_api_model_with_result_id(self):
+        widget = CatalogVisualizationSwitcherWidgetDescriptor(
+            title="Switcher",
+            widget_id="w-vs-1",
+            active_visualization_id="viz-a",
+            visualization_ids=["viz-a"],
+            result_id="result-xyz",
+        )
+        api = widget.as_api_model()
+        assert api["result_id"] == "result-xyz"
+
+
+class TestCatalogDashboardContext:
+    def test_as_api_model_no_widgets(self):
+        ctx = CatalogDashboardContext(id="db-1")
+        api = ctx.as_api_model()
+        assert api["id"] == "db-1"
+        assert api["widgets"] == []
+
+    def test_as_api_model_mixed_widgets(self):
+        ctx = CatalogDashboardContext(
+            id="db-2",
+            widgets=[
+                CatalogInsightWidgetDescriptor(title="Chart", widget_id="w1", visualization_id="viz-1"),
+                CatalogRichTextWidgetDescriptor(title="Note", widget_id="w2"),
+            ],
+        )
+        api = ctx.as_api_model()
+        assert api["id"] == "db-2"
+        assert len(api["widgets"]) == 2
+
+
+class TestCatalogUIContext:
+    def test_as_api_model_no_dashboard(self):
+        ctx = CatalogUIContext()
+        api = ctx.as_api_model()
+        # dashboard key should not be present when not set
+        assert "dashboard" not in api
+
+    def test_as_api_model_with_dashboard(self):
+        ctx = CatalogUIContext(
+            dashboard=CatalogDashboardContext(id="db-1"),
+        )
+        api = ctx.as_api_model()
+        assert api["dashboard"]["id"] == "db-1"
+
+
+class TestCatalogUserContext:
+    def test_empty_user_context(self):
+        ctx = CatalogUserContext()
+        api = ctx.as_api_model()
+        # None of the optional fields should appear
+        assert "active_object" not in api
+        assert "referenced_objects" not in api
+        assert "view" not in api
+
+    def test_with_active_object(self):
+        ctx = CatalogUserContext(
+            active_object=CatalogActiveObjectIdentification(id="dash-1", type="dashboard", workspace_id="ws-1")
+        )
+        api = ctx.as_api_model()
+        assert api["active_object"]["id"] == "dash-1"
+        assert api["active_object"]["type"] == "dashboard"
+        assert api["active_object"]["workspace_id"] == "ws-1"
+
+    def test_with_referenced_objects(self):
+        ctx = CatalogUserContext(
+            referenced_objects=[
+                CatalogObjectReferenceGroup(
+                    objects=[CatalogObjectReference(id="m1", type="METRIC")],
+                )
+            ]
+        )
+        api = ctx.as_api_model()
+        assert len(api["referenced_objects"]) == 1
+
+    def test_with_view(self):
+        ctx = CatalogUserContext(
+            view=CatalogUIContext(
+                dashboard=CatalogDashboardContext(id="db-1"),
+            )
+        )
+        api = ctx.as_api_model()
+        assert api["view"]["dashboard"]["id"] == "db-1"
+
+    def test_full_context(self):
+        ctx = CatalogUserContext(
+            active_object=CatalogActiveObjectIdentification(id="dash-1", type="dashboard", workspace_id="ws-1"),
+            referenced_objects=[
+                CatalogObjectReferenceGroup(
+                    objects=[
+                        CatalogObjectReference(id="w1", type="WIDGET"),
+                        CatalogObjectReference(id="m1", type="METRIC"),
+                    ],
+                    context=CatalogObjectReference(id="dash-1", type="DASHBOARD"),
+                )
+            ],
+            view=CatalogUIContext(
+                dashboard=CatalogDashboardContext(
+                    id="dash-1",
+                    widgets=[
+                        CatalogInsightWidgetDescriptor(
+                            title="Revenue",
+                            widget_id="w1",
+                            visualization_id="viz-rev",
+                        )
+                    ],
+                )
+            ),
+        )
+        api = ctx.as_api_model()
+        assert api["active_object"]["id"] == "dash-1"
+        assert len(api["referenced_objects"]) == 1
+        assert api["referenced_objects"][0]["context"]["type"] == "DASHBOARD"
+        assert api["view"]["dashboard"]["id"] == "dash-1"
+        assert len(api["view"]["dashboard"]["widgets"]) == 1


### PR DESCRIPTION
## Summary

Added SDK wrapper models for WidgetDescriptor, DashboardContext, UIContext, ObjectReference, ObjectReferenceGroup, and the extended UserContext (with referencedObjects and view). Updated ai_chat/ai_chat_stream to accept optional CatalogUserContext. Exported all new classes from __init__.py. Unit tests added for all new model serialization paths.

**Impact:** new_feature | **Services:** `gooddata-afm-client`
**Tickets:** LX-2141

## Files changed

- `packages/gooddata-sdk/src/gooddata_sdk/compute/model/user_context.py`
- `packages/gooddata-sdk/src/gooddata_sdk/compute/service.py`
- `packages/gooddata-sdk/src/gooddata_sdk/__init__.py`
- `packages/gooddata-sdk/tests/compute/test_user_context.py`

## Agent decisions

<details><summary>Decisions (5)</summary>

**model location** — Placed all new models in packages/gooddata-sdk/src/gooddata_sdk/compute/model/user_context.py
  - Alternatives: Place under catalog/workspace/ (AI context is request-time, not catalog/entity), Place under catalog/organization/ alongside llm_provider.py
  - Why: UserContext is a ChatRequest input model consumed by ComputeService. Co-locating with compute/model/ keeps it alongside the execution-model classes it is used with.

**widget descriptor polymorphism** — Three independent @attrs.define classes unified via Union TypeAlias CatalogWidgetDescriptor
  - Alternatives: Single base class with attrs inheritance (fragile field ordering), Single flat class with widget_type discriminator
  - Why: Follows existing llm_provider.py Union-alias pattern (CatalogLlmProviderConfig). Avoids attrs inheritance field-ordering pitfalls.

**Union alias import style** — from typing import Union used for the CatalogWidgetDescriptor alias
  - Alternatives: X | Y | Z runtime syntax (requires Python 3.10+)
  - Why: Module-level | alias fails Python 3.9; Union matches existing llm_provider.py convention.

**as_api_model() vs Base.to_api()** — Explicit as_api_model() on each model without extending Base
  - Alternatives: Extend Base and use to_api() via cattrs
  - Why: These are write-only request models, never deserialized from API. Explicit as_api_model() is simpler and handles polymorphic WidgetDescriptor subtypes cleanly.

**referenced_objects omission when empty** — Omit referenced_objects from UserContext API model when list is empty
  - Alternatives: Always pass empty list
  - Why: Consistent with how active_object and view are gated. An empty list is semantically equivalent to omission.

</details>

<details><summary>Assumptions to verify (3)</summary>

- DashboardContext.widgets accepts InsightWidgetDescriptor/RichText/VisualizationSwitcher subtypes with _check_type=False because JSON serialization is type-agnostic.
- Pre-existing ty check errors in compute/model/filter.py (EmptyValueHandling invalid-return-type) are unrelated to this change.
- unresolved-import: pytest ty errors in test files are an environment-level issue pre-existing across the whole test suite.

</details>

<details><summary>Risks (1)</summary>

- If the backend strictly validates widgetType values, callers must use the exact discriminator values ('insight', 'richText', 'visualizationSwitcher') as shown in the OpenAPI mapping — the SDK wrapper exposes raw string fields and does not enforce these.

</details>

<details><summary>Layers touched (3)</summary>

- **entity_model** — New compute request-model classes: CatalogActiveObjectIdentification, CatalogObjectReference, CatalogObjectReferenceGroup, CatalogInsightWidgetDescriptor, CatalogRichTextWidgetDescriptor, CatalogVisualizationSwitcherWidgetDescriptor, CatalogDashboardContext, CatalogUIContext, CatalogUserContext
  - `packages/gooddata-sdk/src/gooddata_sdk/compute/model/user_context.py`
- **public_api** — Exported 10 new classes; added user_context parameter to ai_chat and ai_chat_stream
  - `packages/gooddata-sdk/src/gooddata_sdk/__init__.py`
  - `packages/gooddata-sdk/src/gooddata_sdk/compute/service.py`
- **tests** — Unit tests covering as_api_model() for all new model classes
  - `packages/gooddata-sdk/tests/compute/test_user_context.py`

</details>

## Source commits (gdc-nas)

- `3f2b607` Merge pull request #21274 from gooddata/smac/LX-2141
- `63dd6bf` feat(gen-ai): refactor widgets polymorphism and enhance OpenAPI spec
- `075d22d` Merge pull request #21389 from gooddata/dho/trivial-fix

<details><summary>OpenAPI diff</summary>

```diff
diff --git a/microservices/afm-exec-api/src/test/resources/openapi/open-api-spec.json
@@ Added schemas: DashboardContext, InsightWidgetDescriptor, RichTextWidgetDescriptor, VisualizationSwitcherWidgetDescriptor, WidgetDescriptor (discriminator), ObjectReference, ObjectReferenceGroup, UIContext @@
+      "DashboardContext" : {
+        "description" : "Dashboard the user is currently viewing.",
+        "properties" : {
+          "id" : { "description" : "Dashboard object ID.", "type" : "string" },
+          "widgets" : { "description" : "Widgets currently visible on the dashboard.", "$ref" : "#/components/schemas/WidgetDescriptor" }
+        },
+        "required" : [ "id", "widgets" ],
+        "type" : "object"
+      },
+      "WidgetDescriptor" : {
+        "description" : "Descriptor for a widget on the dashboard.",
+        "discriminator" : {
+          "mapping" : { "insight" : "#/components/schemas/InsightWidgetDescriptor", "richText" : "#/components/schemas/RichTextWidgetDescriptor", "visualizationSwitcher" : "#/components/schemas/VisualizationSwitcherWidgetDescriptor" },
+          "propertyName" : "widgetType"
+        },
+        "properties" : { "title" : { "type" : "string" }, "widgetId" : { "type" : "string" }, "widgetType" : { "type" : "string" } },
+        "type" : "object"
+      },
+      "InsightWidgetDescriptor" : { "description" : "Insight widget.", "properties" : { "resultId" : ..., "title" : ..., "visualizationId" : ..., "widgetId" : ... }, "required" : [ "title", "visualizationId", "widgetId" ], "type" : "object" },
+      "RichTextWidgetDescriptor" : { "description" : "Rich text widget.", "properties" : { "title" : ..., "widgetId" : ... }, "required" : [ "title", "widgetId" ], "type" : "object" },
+      "VisualizationSwitcherWidgetDescriptor" : { "description" : "Visualization switcher widget.", "required" : [ "activeVisualizationId", "title", "visualizationIds", "widgetId" ], "type" : "object" },
+      "ObjectReference" : { "properties" : { "id" : ..., "type" : { "enum" : [ "WIDGET", "METRIC", "ATTRIBUTE", "DASHBOARD" ] } }, "required" : [ "id", "type" ], "type" : "object" },
+      "ObjectReferenceGroup" : { "properties" : { "context" : { "$ref" : "#/components/schemas/ObjectReference" }, "objects" : { "items" : { "$ref" : "#/components/schemas/ObjectReference" } } }, "required" : [ "objects" ], "type" : "object" },
+      "UIContext" : { "description" : "Ambient UI state.", "properties" : { "dashboard" : { "$ref" : "#/components/schemas/DashboardContext" } }, "type" : "object" },
@@ UserContext extended (required removed by 075d22d5) @@
       "UserContext" : {
-        "description" : "User context, which can affect the behavior of the underlying AI features.",
+        "description" : "User context with ambient UI state (view) and explicitly referenced objects.",
         "properties" : {
           "activeObject" : { "$ref" : "#/components/schemas/ActiveObjectIdentification" },
+          "referencedObjects" : { "description" : "Groups of explicitly referenced objects.", "items" : { "$ref" : "#/components/schemas/ObjectReferenceGroup" }, "type" : "array" },
+          "view" : { "$ref" : "#/components/schemas/UIContext" }
         },
-        "required" : [ "activeObject" ],
         "type" : "object"
       },
```
</details>

## [Workflow run](https://github.com/gooddata/gdc-nas/actions/runs/24638549222)

---
*Generated by SDK OpenAPI Sync workflow*