### PR TITLE
feat(ci): add /fix slash command and widen review-relay filter

### DIFF
--- a/.github/workflows/sdk-review-relay.yml
+++ b/.github/workflows/sdk-review-relay.yml
@@ -23,7 +23,7 @@ jobs:
       (github.event.review.state == 'changes_requested'
         || (github.event.review.state == 'commented' && github.event.review.body))
       && github.event.pull_request.user.login == 'yenkins-admin'
-      && startsWith(github.event.pull_request.head.ref, 'feature/auto-P')
+      && startsWith(github.event.pull_request.head.ref, 'auto/openapi-sync-')
       && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
     timeout-minutes: 2

--- a/.github/workflows/sdk-slash-commands.yaml
+++ b/.github/workflows/sdk-slash-commands.yaml
@@ -1,0 +1,193 @@
+# =============================================================================
+# SDK Slash Commands
+#
+# Minimal relay that forwards `/fix` PR comments to gdc-nas's review-fix
+# pipeline, using the same repository_dispatch payload as sdk-review-relay.
+#
+# SECURITY
+# --------
+# A PR comment can be authored by anyone (public repo), so access is gated by
+# whether the commenter is a collaborator on gooddata/gdc-nas. The check is
+# performed via the GitHub API using TOKEN_GITHUB_YENKINS_ADMIN (which already
+# has access to gdc-nas); no new secret is introduced.
+#
+# SCOPE
+# -----
+# Only reacts to comments on open PRs authored by yenkins-admin whose head
+# branch starts with `auto/openapi-sync-` (the sync pipeline's auto-branches).
+# Anything else is a silent no-op.
+#
+# CONCURRENCY NOTES
+# -----------------
+# - A second `/fix` on the same PR dispatches a second event. The receiver
+#   (gdc-nas `sdk-py-review-fix.yml`) uses `cancel-in-progress: true` keyed
+#   on PR number, so an earlier in-progress review-fix run will be cancelled
+#   by a newer one. Acceptable at expected volume (single-digit/day).
+# - If a formal review (via sdk-review-relay.yml) and a `/fix` comment arrive
+#   within the receiver's concurrency window, the receiver picks one and
+#   cancels the other. Same mechanism.
+# =============================================================================
+name: SDK Slash Commands
+
+on:
+  issue_comment:
+    types: [created]
+
+# Default-deny for the whole workflow. Jobs must opt in to any scope they
+# actually need. Keeps future additions locked down by default.
+permissions: {}
+
+concurrency:
+  group: sdk-slash-fix-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  fix:
+    name: "/fix — forward to gdc-nas"
+    # Cheap gates first — anything that can be evaluated without an API call.
+    # Job-level match is coarse (`startsWith(body, '/fix')`); the strict
+    # "exact `/fix` token" check lives in the "Validate /fix syntax" step so
+    # we can express the full regex.
+    if: >-
+      github.event.issue.pull_request != null
+      && github.event.issue.state == 'open'
+      && github.event.issue.user.login == 'yenkins-admin'
+      && startsWith(github.event.comment.body, '/fix')
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      # Only GITHUB_TOKEN use is `gh api repos/.../pulls/$PR_NUMBER` to read
+      # head.ref. Reactions and dispatch both go through the PAT.
+      pull-requests: read
+    steps:
+      - name: Validate /fix syntax
+        id: cmd
+        env:
+          BODY: ${{ github.event.comment.body }}
+        run: |
+          # Strict: first line must be exactly `/fix` or `/fix` + whitespace.
+          # Rejects `/fixme`, `/fix-review 42`, etc. Expanding the vocabulary
+          # is an explicit non-goal (see plan §3).
+          FIRST_LINE=$(printf '%s' "$BODY" | head -n1 | tr -d '\r')
+          if [[ "$FIRST_LINE" =~ ^/fix([[:space:]].*)?$ ]]; then
+            echo "matched=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "First line '$FIRST_LINE' is not an exact /fix command — ignoring."
+            echo "matched=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve PR head branch
+        id: pr
+        if: steps.cmd.outputs.matched == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          HEAD_REF=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER" \
+            --jq '.head.ref')
+          if [[ "$HEAD_REF" != auto/openapi-sync-* ]]; then
+            echo "Branch '$HEAD_REF' is not an auto/openapi-sync-* branch — ignoring."
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "head_ref=$HEAD_REF" >> "$GITHUB_OUTPUT"
+            echo "eligible=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify commenter has gdc-nas access
+        id: auth
+        if: steps.pr.outputs.eligible == 'true'
+        env:
+          # PAT scoped to read gdc-nas collaborator membership.
+          GH_TOKEN: ${{ secrets.TOKEN_GITHUB_YENKINS_ADMIN }}
+          USER: ${{ github.event.comment.user.login }}
+        run: |
+          if ! gh api "repos/gooddata/gdc-nas/collaborators/$USER" --silent 2>/dev/null; then
+            # Silent reject: no reply, no reaction, and run stays green so the
+            # public Actions tab does not leak who was denied.
+            echo "::warning::User '$USER' is not a gdc-nas collaborator — /fix denied."
+            echo "authorized=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "User '$USER' verified as gdc-nas collaborator."
+          echo "authorized=true" >> "$GITHUB_OUTPUT"
+
+      - name: Parse /fix arguments
+        id: parse
+        if: steps.pr.outputs.eligible == 'true' && steps.auth.outputs.authorized == 'true'
+        env:
+          BODY: ${{ github.event.comment.body }}
+        run: |
+          # Take only the first line, strip CRLF, strip leading `/fix` +
+          # whitespace, strip trailing whitespace. Remainder is review_body.
+          FIRST_LINE=$(printf '%s' "$BODY" | head -n1 | tr -d '\r')
+          ARGS=$(printf '%s' "$FIRST_LINE" | sed -E 's#^/fix[[:space:]]*##; s#[[:space:]]+$##')
+          {
+            echo "args<<EOF"
+            printf '%s\n' "$ARGS"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch to gdc-nas
+        id: dispatch
+        if: steps.pr.outputs.eligible == 'true' && steps.auth.outputs.authorized == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.TOKEN_GITHUB_YENKINS_ADMIN }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          HEAD_REF: ${{ steps.pr.outputs.head_ref }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+          REVIEW_BODY: ${{ steps.parse.outputs.args }}
+        run: |
+          jq -nc \
+            --arg pr_number "$PR_NUMBER" \
+            --arg pr_branch "$HEAD_REF" \
+            --arg pr_author "yenkins-admin" \
+            --arg reviewer "$COMMENTER" \
+            --arg review_id "" \
+            --arg review_state "commented" \
+            --arg review_body "$REVIEW_BODY" \
+            '{
+              event_type: "sdk-review-submitted",
+              client_payload: {
+                pr_number: $pr_number,
+                pr_branch: $pr_branch,
+                pr_author: $pr_author,
+                reviewer: $reviewer,
+                review_id: $review_id,
+                review_state: $review_state,
+                review_body: $review_body
+              }
+            }' | gh api "repos/gooddata/gdc-nas/dispatches" \
+              --method POST \
+              --input -
+
+          {
+            echo "## /fix dispatched"
+            echo "- PR: #$PR_NUMBER"
+            echo "- Branch: \`$HEAD_REF\`"
+            echo "- Commenter: @$COMMENTER"
+            echo "- Review body: \`$REVIEW_BODY\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Add rocket reaction (ack on successful dispatch)
+        if: success() && steps.dispatch.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.TOKEN_GITHUB_YENKINS_ADMIN }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "repos/${{ github.repository }}/issues/comments/$COMMENT_ID/reactions" \
+            -f content=rocket > /dev/null
+
+      - name: Add confused reaction (dispatch failed)
+        if: failure() && steps.dispatch.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.TOKEN_GITHUB_YENKINS_ADMIN }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "repos/${{ github.repository }}/issues/comments/$COMMENT_ID/reactions" \
+            -f content=confused > /dev/null || true


### PR DESCRIPTION
## What this changes

Two fixes to the PR-review automation between `gooddata-python-sdk` and `gdc-nas`.

**1. Relay missed the new auto-PR branch naming.**
The sync pipeline used to name PRs `feature/auto-P...`. It now names them `auto/openapi-sync-C<cluster>-<date>-r<run>`. The relay's `if:` filter hadn't been updated, so reviews on every new auto-PR were silently dropped and never reached `gdc-nas`. The filter now matches the current naming. The `feature/auto-P*` prefix is retired — last produced 2026-03-18, no open PRs carry it today.

```diff
  if: >-
    (github.event.review.state == 'changes_requested'
      || (github.event.review.state == 'commented' && github.event.review.body))
    && github.event.pull_request.user.login == 'yenkins-admin'
-   && startsWith(github.event.pull_request.head.ref, 'feature/auto-P')
+   && startsWith(github.event.pull_request.head.ref, 'auto/openapi-sync-')
    && github.event.pull_request.head.repo.full_name == ...
```

**2. No lightweight way to re-kick the pipeline.**
Until now the only trigger was a formal "Request changes" review. For small follow-ups — or re-kicking after a missed relay event — that's heavier than needed. A PR comment of `/fix` (optionally `/fix short note`) now dispatches the same event as a formal review.

> [!IMPORTANT]
> GitHub activates `issue_comment` / `pull_request_review` workflow changes only from the default branch. Full end-to-end verification can only happen **after this PR is merged**.

> [!NOTE]
> No changes are required in `gdc-nas`. The new workflow emits the exact same `repository_dispatch: sdk-review-submitted` payload that the existing relay does.

## How it works

### Topology

```mermaid
flowchart LR
    A["Reviewer submits<br/>formal review"] --> R
    B["User comments<br/>/fix [note]"] --> S

    subgraph SDK["gooddata-python-sdk (public)"]
      R["sdk-review-relay.yml<br/><i>pull_request_review</i>"]
      S["sdk-slash-commands.yaml<br/><i>issue_comment</i>"]
      G{"Gates"}
      R --> G
      S --> G
    end

    G -->|"repository_dispatch<br/>sdk-review-submitted"| N

    subgraph NAS["gdc-nas (private)"]
      N["sdk-py-review-fix.yml<br/><i>unchanged</i>"]
    end

    style R fill:#d4edda,stroke:#28a745,color:#000
    style S fill:#d4edda,stroke:#28a745,color:#000
    style N fill:#cce5ff,stroke:#004085,color:#000
    style G fill:#fff3cd,stroke:#856404,color:#000
```

### `/fix` decision flow

```mermaid
flowchart TD
    Start(["User comments<br/><b>/fix [note]</b>"])
    Syntax{"Valid <b>/fix</b> syntax?<br/><i>(not /fixme, /fix-review, …)</i>"}
    Context{"PR open, open auto-PR,<br/>authored by yenkins-admin?"}
    Branch{"head.ref starts with<br/><b>auto/openapi-sync-</b>?"}
    Auth{"Commenter is a<br/><b>gdc-nas</b> collaborator?"}
    Dispatch["POST repository_dispatch<br/><b>sdk-review-submitted</b>"]
    Ack["🚀 reaction on comment"]
    Silent(["Silent exit<br/><i>green run, no reply</i>"])
    Done(["<b>gdc-nas</b> runs<br/>sdk-py-review-fix.yml"])

    Start --> Syntax
    Syntax -->|no| Silent
    Syntax -->|yes| Context
    Context -->|no| Silent
    Context -->|yes| Branch
    Branch -->|no| Silent
    Branch -->|yes| Auth
    Auth -->|no| Silent
    Auth -->|yes| Dispatch
    Dispatch --> Ack
    Dispatch --> Done

    style Start fill:#e7f3ff,stroke:#004085,color:#000
    style Dispatch fill:#d4edda,stroke:#28a745,color:#000,font-weight:bold
    style Ack fill:#d4edda,stroke:#28a745,color:#000
    style Done fill:#d4edda,stroke:#28a745,color:#000
    style Silent fill:#f8d7da,stroke:#721c24,color:#000
```

## `/fix` security model

<details>
<summary><b>Gate ladder</b> — cheap checks first, API calls last (click to expand)</summary>

| # | Gate | Blocks |
|---|---|---|
| 1 | `issue.pull_request != null` | ❌ comments on plain issues |
| 2 | `issue.state == 'open'` | ❌ closed/merged PRs |
| 3 | `startsWith(body, '/fix')` + strict regex `^/fix([[:space:]].*)?$` | ❌ `/fixme`, `/fix-review`, etc. |
| 4 | `issue.user.login == 'yenkins-admin'` | ❌ comments on non-auto PRs |
| 5 | `head.ref` starts with `auto/openapi-sync-` | ❌ legacy/non-auto branches |
| 6 | commenter is a collaborator on `gooddata/gdc-nas` | ❌ everyone outside the private-repo ACL |

Gates 1–4 are free (job `if:`). Gate 5 is one API call to resolve the PR's `head.ref`. Gate 6 is the auth check.

</details>

> [!CAUTION]
> Denied commenters get a **silent green run** — no reply, no reaction. This is intentional: it avoids leaking authorization state (who is / isn't on the gdc-nas ACL) from the public Actions tab.

## Cost to the repo

- ✅ **No new secrets.** Reuses the existing `TOKEN_GITHUB_YENKINS_ADMIN` PAT.
- ✅ **No changes in `gdc-nas`.** Payload is byte-identical to what the receiver already consumes.
- ✅ **Narrow token scope.** Workflow's `GITHUB_TOKEN` is restricted to `pull-requests: read`; every write uses the PAT.

<details>
<summary><b>Payload compatibility</b> — which fields the receiver reads (click to expand)</summary>

All seven fields match `gdc-nas/.github/workflows/sdk-py-review-fix.yml`:

| field | source (slash command) | source (formal review) |
|---|---|---|
| `pr_number` | `github.event.issue.number` | `github.event.pull_request.number` |
| `pr_branch` | resolved via `gh api .../pulls/N` | `github.event.pull_request.head.ref` |
| `pr_author` | literal `"yenkins-admin"` | `github.event.pull_request.user.login` |
| `reviewer` | `github.event.comment.user.login` | `github.event.review.user.login` |
| `review_id` | `""` (empty) | `github.event.review.id` |
| `review_state` | literal `"commented"` | `github.event.review.state` |
| `review_body` | `/fix` arg (first line, trimmed) | `github.event.review.body` |

Empty `review_id` is guarded on the receiver side — it falls back to a GraphQL unresolved-threads query, so no 404.

</details>
