### PR TITLE
feat(gooddata-sdk): [AUTO] Add LlmProvider entity (Bedrock/Azure/OpenAI) and deprecate LlmEndpoint

### DIFF
--- a/packages/gooddata-sdk/src/gooddata_sdk/__init__.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/__init__.py
@@ -115,6 +115,7 @@ from gooddata_sdk.catalog.organization.entity_model.llm_provider import (
     CatalogAzureFoundryApiKeyAuth,
     CatalogAzureFoundryProviderConfig,
     CatalogBedrockAccessKeyAuth,
+    CatalogListLlmProviderModelsResponse,
     CatalogLlmProvider,
     CatalogLlmProviderDocument,
     CatalogLlmProviderModel,
@@ -122,6 +123,7 @@ from gooddata_sdk.catalog.organization.entity_model.llm_provider import (
     CatalogLlmProviderPatchDocument,
     CatalogOpenAiApiKeyAuth,
     CatalogOpenAiProviderConfig,
+    CatalogResolvedLlm,
 )
 from gooddata_sdk.catalog.organization.entity_model.organization import CatalogOrganization
 from gooddata_sdk.catalog.organization.entity_model.setting import CatalogOrganizationSetting

--- a/packages/gooddata-sdk/src/gooddata_sdk/catalog/organization/entity_model/llm_provider.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/catalog/organization/entity_model/llm_provider.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from typing import Any, Union
 
+import attrs
 from attr import define
 from gooddata_api_client.model.aws_bedrock_provider_config import AwsBedrockProviderConfig
 from gooddata_api_client.model.azure_foundry_provider_auth import AzureFoundryProviderAuth
@@ -337,3 +338,54 @@ class CatalogLlmProviderPatchAttributes(Base):
     @staticmethod
     def client_class() -> type[JsonApiLlmProviderInAttributes]:
         return JsonApiLlmProviderInAttributes
+
+
+# --- Resolved LLM response types (read-only, from action API) ---
+
+
+@attrs.define(kw_only=True)
+class CatalogResolvedLlm:
+    """Represents a resolved LLM configuration (provider or legacy endpoint) for a workspace."""
+
+    id: str
+    title: str
+    models: list[CatalogLlmProviderModel] = attrs.field(factory=list)
+
+    @classmethod
+    def from_api(cls, entity: Any) -> CatalogResolvedLlm:
+        raw_models = safeget(entity, ["models"]) or []
+        return cls(
+            id=safeget(entity, ["id"]) or "",
+            title=safeget(entity, ["title"]) or "",
+            models=[
+                CatalogLlmProviderModel(
+                    id=safeget(m, ["id"]) or "",
+                    family=safeget(m, ["family"]) or "",
+                )
+                for m in raw_models
+            ],
+        )
+
+
+@attrs.define(kw_only=True)
+class CatalogListLlmProviderModelsResponse:
+    """Response from listing available models for an LLM provider."""
+
+    success: bool
+    message: str
+    models: list[CatalogLlmProviderModel] = attrs.field(factory=list)
+
+    @classmethod
+    def from_api(cls, entity: Any) -> CatalogListLlmProviderModelsResponse:
+        raw_models = safeget(entity, ["models"]) or []
+        return cls(
+            success=safeget(entity, ["success"]) or False,
+            message=safeget(entity, ["message"]) or "",
+            models=[
+                CatalogLlmProviderModel(
+                    id=safeget(m, ["id"]) or "",
+                    family=safeget(m, ["family"]) or "",
+                )
+                for m in raw_models
+            ],
+        )

--- a/packages/gooddata-sdk/src/gooddata_sdk/catalog/organization/service.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/catalog/organization/service.py
@@ -24,6 +24,7 @@ from gooddata_sdk.catalog.organization.entity_model.directive import CatalogCspD
 from gooddata_sdk.catalog.organization.entity_model.identity_provider import CatalogIdentityProvider
 from gooddata_sdk.catalog.organization.entity_model.jwk import CatalogJwk, CatalogJwkDocument
 from gooddata_sdk.catalog.organization.entity_model.llm_provider import (
+    CatalogListLlmProviderModelsResponse,
     CatalogLlmProvider,
     CatalogLlmProviderDocument,
     CatalogLlmProviderPatch,
@@ -583,6 +584,19 @@ class CatalogOrganizationService(CatalogServiceBase):
             id: LLM provider identifier
         """
         self._entities_api.delete_entity_llm_providers(id, _check_return_type=False)
+
+    def list_llm_provider_models_by_id(self, llm_provider_id: str) -> CatalogListLlmProviderModelsResponse:
+        """List available models for an existing LLM provider by its ID.
+
+        Args:
+            llm_provider_id: LLM provider identifier
+
+        Returns:
+            CatalogListLlmProviderModelsResponse: Response containing available models
+                and a success flag.
+        """
+        response = self._actions_api.list_llm_provider_models_by_id(llm_provider_id, _check_return_type=False)
+        return CatalogListLlmProviderModelsResponse.from_api(response)
 
     # Layout APIs
 

--- a/packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/content_service.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/content_service.py
@@ -13,6 +13,7 @@ from gooddata_sdk.catalog.catalog_service_base import CatalogServiceBase
 from gooddata_sdk.catalog.data_source.validation.data_source import DataSourceValidator
 from gooddata_sdk.catalog.depends_on import CatalogDependsOn, CatalogDependsOnDateFilter
 from gooddata_sdk.catalog.filter_by import CatalogFilterBy
+from gooddata_sdk.catalog.organization.entity_model.llm_provider import CatalogResolvedLlm
 from gooddata_sdk.catalog.types import ValidObjects
 from gooddata_sdk.catalog.validate_by_item import CatalogValidateByItem
 from gooddata_sdk.catalog.workspace.declarative_model.workspace.analytics_model.analytics_model import (
@@ -685,3 +686,26 @@ class CatalogWorkspaceContentService(CatalogServiceBase):
             workspace_id, request, _check_return_type=False, **paging_params
         )
         return [v["title"] for v in values["elements"]]
+
+    def resolve_llm_providers(self, workspace_id: str) -> CatalogResolvedLlm | None:
+        """Resolve the active LLM configuration for a workspace.
+
+        When the ENABLE_LLM_ENDPOINT_REPLACEMENT feature flag is enabled, returns
+        the active LLM provider with its associated models. Otherwise, falls back
+        to the legacy LLM endpoint response format.
+
+        Args:
+            workspace_id (str):
+                Workspace identification string e.g. "demo".
+
+        Returns:
+            CatalogResolvedLlm | None:
+                Resolved LLM configuration, or None if no active configuration exists.
+        """
+        response = self._actions_api.resolve_llm_providers(workspace_id, _check_return_type=False)
+        if response is None:
+            return None
+        data = response.data if hasattr(response, "data") else None
+        if data is None:
+            return None
+        return CatalogResolvedLlm.from_api(data)

--- a/packages/gooddata-sdk/tests/catalog/fixtures/organization/list_llm_provider_models_by_id.yaml
+++ b/packages/gooddata-sdk/tests/catalog/fixtures/organization/list_llm_provider_models_by_id.yaml
@@ -1,0 +1,37 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - application/json
+        Accept-Encoding:
+          - br, gzip, deflate
+        X-GDC-VALIDATE-RELATIONS:
+          - 'true'
+        X-Requested-With:
+          - XMLHttpRequest
+      method: GET
+      uri: http://localhost:3000/api/v1/entities/llmProviders
+    response:
+      body:
+        string:
+          data: []
+          links:
+            next: http://localhost:3000/api/v1/entities/llmProviders?page=1&size=20
+            self: http://localhost:3000/api/v1/entities/llmProviders?page=0&size=20
+      headers:
+        Content-Type:
+          - application/json
+        DATE: &id001
+          - PLACEHOLDER
+        Expires:
+          - '0'
+        Pragma:
+          - no-cache
+        X-Content-Type-Options:
+          - nosniff
+        X-GDC-TRACE-ID: *id001
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/packages/gooddata-sdk/tests/catalog/test_catalog_organization.py
+++ b/packages/gooddata-sdk/tests/catalog/test_catalog_organization.py
@@ -3,13 +3,16 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from gooddata_api_client.exceptions import NotFoundException
 from gooddata_sdk import (
     CatalogCspDirective,
     CatalogDeclarativeNotificationChannel,
     CatalogJwk,
+    CatalogListLlmProviderModelsResponse,
     CatalogOrganization,
     CatalogOrganizationSetting,
+    CatalogResolvedLlm,
     CatalogRsaSpecification,
     CatalogWebhook,
     GoodDataSdk,
@@ -563,3 +566,85 @@ def test_layout_notification_channels(test_config, snapshot_notification_channel
 #         sdk.catalog_organization.put_declarative_identity_providers([])
 #         idps = sdk.catalog_organization.get_declarative_identity_providers()
 #         assert len(idps) == 0
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for LLM provider response model classes (no cassettes needed)
+# ---------------------------------------------------------------------------
+
+
+def test_catalog_resolved_llm_from_api():
+    """CatalogResolvedLlm.from_api deserializes a plain dict correctly."""
+    data = {
+        "id": "my-provider",
+        "title": "My LLM Provider",
+        "models": [
+            {"id": "gpt-4o", "family": "OPENAI"},
+            {"id": "gpt-4-turbo", "family": "OPENAI"},
+        ],
+    }
+    result = CatalogResolvedLlm.from_api(data)
+    assert result.id == "my-provider"
+    assert result.title == "My LLM Provider"
+    assert len(result.models) == 2
+    assert result.models[0].id == "gpt-4o"
+    assert result.models[0].family == "OPENAI"
+    assert result.models[1].id == "gpt-4-turbo"
+
+
+def test_catalog_resolved_llm_from_api_empty_models():
+    """CatalogResolvedLlm.from_api handles missing models gracefully."""
+    data = {"id": "provider-no-models", "title": "Provider"}
+    result = CatalogResolvedLlm.from_api(data)
+    assert result.id == "provider-no-models"
+    assert result.title == "Provider"
+    assert result.models == []
+
+
+def test_catalog_list_llm_provider_models_response_from_api():
+    """CatalogListLlmProviderModelsResponse.from_api deserializes correctly."""
+    data = {
+        "success": True,
+        "message": "Models listed successfully.",
+        "models": [
+            {"id": "claude-3-5-sonnet-20241022", "family": "ANTHROPIC"},
+        ],
+    }
+    result = CatalogListLlmProviderModelsResponse.from_api(data)
+    assert result.success is True
+    assert result.message == "Models listed successfully."
+    assert len(result.models) == 1
+    assert result.models[0].id == "claude-3-5-sonnet-20241022"
+    assert result.models[0].family == "ANTHROPIC"
+
+
+def test_catalog_list_llm_provider_models_response_failure():
+    """CatalogListLlmProviderModelsResponse.from_api handles failure response."""
+    data = {
+        "success": False,
+        "message": "Authentication failed.",
+        "models": [],
+    }
+    result = CatalogListLlmProviderModelsResponse.from_api(data)
+    assert result.success is False
+    assert result.message == "Authentication failed."
+    assert result.models == []
+
+
+# ---------------------------------------------------------------------------
+# Integration tests for LLM provider CRUD and action methods
+# (cassettes to be recorded against a live server)
+# ---------------------------------------------------------------------------
+
+
+@gd_vcr.use_cassette(str(_fixtures_dir / "list_llm_provider_models_by_id.yaml"))
+def test_list_llm_provider_models_by_id(test_config):
+    sdk = GoodDataSdk.create(host_=test_config["host"], token_=test_config["token"])
+    providers = sdk.catalog_organization.list_llm_providers()
+    if not providers:
+        pytest.skip("No LLM providers configured — cannot test list_llm_provider_models_by_id")
+    provider_id = providers[0].id
+    response = sdk.catalog_organization.list_llm_provider_models_by_id(provider_id)
+    assert isinstance(response, CatalogListLlmProviderModelsResponse)
+    assert isinstance(response.success, bool)
+    assert isinstance(response.message, str)


### PR DESCRIPTION
## Summary

Added CatalogResolvedLlm and CatalogListLlmProviderModelsResponse response model classes; added resolve_llm_providers() to CatalogWorkspaceContentService and list_llm_provider_models_by_id() to CatalogOrganizationService; exported both new classes from the public __init__.py; wrote 4 unit tests (no cassettes) and 1 integration test stub. The LlmProvider entity CRUD (get/list/create/update/delete) was already fully implemented; no LlmEndpoint SDK wrappers existed to deprecate.

**Impact:** deprecation | **Services:** `gooddata-metadata-client`

## Files changed

- `packages/gooddata-sdk/src/gooddata_sdk/catalog/organization/entity_model/llm_provider.py`
- `packages/gooddata-sdk/src/gooddata_sdk/catalog/organization/service.py`
- `packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/content_service.py`
- `packages/gooddata-sdk/src/gooddata_sdk/__init__.py`
- `packages/gooddata-sdk/tests/catalog/test_catalog_organization.py`

## Agent decisions

<details><summary>Decisions (4)</summary>

**resolve_llm_providers placement** — Added to CatalogWorkspaceContentService (workspace-scoped)
  - Alternatives: Add to CatalogOrganizationService, Create a separate AI/LLM service
  - Why: The API endpoint /api/v1/actions/workspaces/{workspaceId}/ai/resolveLlmProviders is workspace-scoped, matching the responsibility boundary of CatalogWorkspaceContentService.

**list_llm_provider_models_by_id placement** — Added to CatalogOrganizationService (org-scoped)
  - Alternatives: Add to workspace content service
  - Why: The API endpoint /api/v1/actions/ai/llmProvider/{llmProviderId}/listModels has no workspace scope, matching the responsibility of CatalogOrganizationService which already owns LlmProvider CRUD.

**Response class inheritance** — CatalogResolvedLlm and CatalogListLlmProviderModelsResponse do NOT extend Base
  - Alternatives: Extend Base and implement client_class() returning NotImplemented
  - Why: These are pure read-only response objects never sent to the API. They don't need client_class(), to_api(), or from_dict() from Base.

**LlmEndpoint deprecation handling** — No SDK changes for LlmEndpoint deprecation
  - Alternatives: Add deprecation warnings to the generated client (not allowed — auto-generated)
  - Why: The SDK never had LlmEndpoint CRUD wrappers, so there is nothing in the SDK to mark deprecated. The API-level deprecation on /api/v1/entities/llmEndpoints does not require SDK action.

</details>

<details><summary>Assumptions to verify (4)</summary>

- The response.data attribute from resolve_llm_providers() exposes id, title, models fields accessible via safeget (both dict and OpenApiModel are supported by safeget).
- list_llm_provider_models_by_id() returns an object where success, message, models are accessible by safeget.
- The LlmProvider entity CRUD already implemented prior to this cluster is correct and complete.
- The ResolvedLlmsData oneOf (endpoint or provider) always returns id, title, models fields, so CatalogResolvedLlm covers both shapes.

</details>

<details><summary>Risks (2)</summary>

- test_list_llm_provider_models_by_id will be skipped if the test environment has no LLM providers configured.
- resolve_llm_providers returns different shape depending on ENABLE_LLM_ENDPOINT_REPLACEMENT feature flag; CatalogResolvedLlm assumes both shapes share id/title/models.

</details>

<details><summary>Layers touched (3)</summary>

- **entity_model** — Added CatalogResolvedLlm and CatalogListLlmProviderModelsResponse read-only response classes
  - `packages/gooddata-sdk/src/gooddata_sdk/catalog/organization/entity_model/llm_provider.py`
- **public_api** — Added list_llm_provider_models_by_id() to org service, resolve_llm_providers() to workspace content service, exported new public classes
  - `packages/gooddata-sdk/src/gooddata_sdk/catalog/organization/service.py`
  - `packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/content_service.py`
  - `packages/gooddata-sdk/src/gooddata_sdk/__init__.py`
- **tests** — 4 unit tests for model deserialization + 1 integration test stub needing cassette
  - `packages/gooddata-sdk/tests/catalog/test_catalog_organization.py`

</details>

## Source commits (gdc-nas)

- `31290c9` Merge pull request #21147 from hkad98/jkd/llm-endpoint-to-provider-phase1
- `f15a954` Merge pull request #21038 from hkad98/jkd/llm-provider
- `a19eb19` Merge pull request #21393 from hkad98/jkd/llm-endpoint-deprecation
- `699c75c` Merge pull request #21420 from hkad98/jkd/resolve-llm-provider
- `456d25a` Merge pull request #21526 from gooddata/jkd/llm-provider-sync-default-on
- `c84a24a` Merge pull request #21232 from hkad98/jkd/llm-provider-setting
- `6fe3b97` Merge pull request #20938 from hkad98/jkd/llm-provider-model-listing
- `151ac81` Merge pull request #21566 from gooddata/rkis/phase4-pr9b-remaining-org-model
- `e06d415` Merge pull request #21533 from gooddata/rkis/phase4-pr9a-org-model-controllers
- `6d6b21f` Merge pull request #21127 from gooddata/rkis/entity-controllers-phase2
- `e822d57` Merge pull request #21064 from gooddata/rkis/entity-controllers-phase1

<details><summary>OpenAPI diff</summary>

```diff
+      "JsonApiLlmProviderIn": { ... },
+      "JsonApiLlmProviderOut": { ... },
+      "AwsBedrockProviderConfig": {
+        "properties": {
+          "accessKeyId": { "type": "string" },
+          "secretAccessKey": { "type": "string" },
+          "region": { "type": "string" }
+        }
+      },
+      "AzureOpenAiProviderConfig": { ... },
+      "OpenAIProviderConfig": { ... },
+    paths:
+      "/api/v1/entities/llmProviders": { "get": {...}, "post": {...} },
+      "/api/v1/entities/llmProviders/{id}": { "get": {...}, "patch": {...}, "delete": {...} },
     paths:
       "/api/v1/entities/llmEndpoints": {
+        "deprecated": true,
+        "description": "Will be soon removed and replaced by LlmProvider."
       }
```
</details>

## [Workflow run](https://github.com/gooddata/gdc-nas/actions/runs/24666182171)

---
*Generated by SDK OpenAPI Sync workflow*