### PR TITLE
feat(gooddata-sdk): [AUTO] Add alert trigger ONCE_PER_INTERVAL with interval granularity field

### DIFF
--- a/packages/gooddata-sdk/src/gooddata_sdk/__init__.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/__init__.py
@@ -210,6 +210,7 @@ from gooddata_sdk.catalog.workspace.declarative_model.workspace.analytics_model.
     CatalogDeclarativeExportDefinitionRequestPayload,
 )
 from gooddata_sdk.catalog.workspace.declarative_model.workspace.automation import (
+    CatalogAutomationAlert,
     CatalogAutomationSchedule,
     CatalogDeclarativeAutomation,
 )

--- a/packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/declarative_model/workspace/automation.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/declarative_model/workspace/automation.py
@@ -1,8 +1,11 @@
 # (C) 2024 GoodData Corporation
+from __future__ import annotations
+
 import builtins
 from typing import Any
 
 from attrs import define, field
+from gooddata_api_client.model.automation_alert import AutomationAlert
 from gooddata_api_client.model.automation_schedule import AutomationSchedule
 from gooddata_api_client.model.automation_tabular_export import AutomationTabularExport
 from gooddata_api_client.model.automation_visual_export import AutomationVisualExport
@@ -19,6 +22,30 @@ from gooddata_sdk.catalog.identifier import (
     CatalogUserIdentifier,
 )
 from gooddata_sdk.catalog.workspace.declarative_model.workspace.analytics_model.base import CatalogAnalyticsBaseMeta
+
+
+@define(kw_only=True)
+class CatalogAutomationAlert(Base):
+    """Wraps the alert configuration for an automation.
+
+    The ``trigger`` field controls when the alert fires:
+    - ``ALWAYS`` – fires every time the condition is met.
+    - ``ONCE`` – fires only the first time the condition is met.
+    - ``ONCE_PER_INTERVAL`` – fires when the condition is met, then is suppressed for the
+      duration specified by ``interval``.
+
+    The ``interval`` field is only used when ``trigger`` is ``ONCE_PER_INTERVAL`` and
+    must be one of: ``DAY``, ``WEEK``, ``MONTH``, ``QUARTER``, ``YEAR``.
+    """
+
+    condition: dict[str, Any]
+    execution: dict[str, Any]
+    trigger: str | None = None
+    interval: str | None = None
+
+    @staticmethod
+    def client_class() -> builtins.type[AutomationAlert]:
+        return AutomationAlert
 
 
 @define(kw_only=True)
@@ -65,6 +92,7 @@ class CatalogDeclarativeAutomation(CatalogAnalyticsBaseMeta):
     schedule: CatalogAutomationSchedule | None = None
     tabular_exports: list[CatalogAutomationTabularExport] | None = None
     visual_exports: list[CatalogAutomationVisualExport] | None = None
+    alert: CatalogAutomationAlert | None = None
 
     @staticmethod
     def client_class() -> builtins.type[DeclarativeAutomation]:

--- a/packages/gooddata-sdk/tests/catalog/test_catalog_workspace.py
+++ b/packages/gooddata-sdk/tests/catalog/test_catalog_workspace.py
@@ -8,6 +8,7 @@ from xml.etree import ElementTree as ET
 import yaml
 from gooddata_sdk import (
     BasicCredentials,
+    CatalogAutomationAlert,
     CatalogAutomationSchedule,
     CatalogDataSourcePostgres,
     CatalogDeclarativeAutomation,
@@ -1032,3 +1033,41 @@ def test_layout_filter_views(test_config):
         assert filter_views_expected == filter_views_o
     finally:
         safe_delete(sdk.catalog_workspace.put_declarative_filter_views, workspace_id, [])
+
+
+def test_catalog_automation_alert_once_per_interval():
+    """Unit test: CatalogAutomationAlert round-trips ONCE_PER_INTERVAL + interval correctly."""
+    condition = {"type": "comparison", "operator": "GREATER_THAN", "right": {"value": 100}}
+    execution = {"measures": [{"localIdentifier": "m1", "definition": {"measure": {"item": {"identifier": {"id": "revenue", "type": "measure"}}}}}]}
+
+    alert = CatalogAutomationAlert(
+        condition=condition,
+        execution=execution,
+        trigger="ONCE_PER_INTERVAL",
+        interval="MONTH",
+    )
+
+    assert alert.trigger == "ONCE_PER_INTERVAL"
+    assert alert.interval == "MONTH"
+
+    # to_api should produce an AutomationAlert with interval and trigger set
+    api_model = alert.to_api()
+    api_dict = api_model.to_dict()
+    assert api_dict.get("trigger") == "ONCE_PER_INTERVAL"
+    assert api_dict.get("interval") == "MONTH"
+
+
+def test_catalog_automation_alert_defaults():
+    """Unit test: CatalogAutomationAlert trigger and interval are optional (None by default)."""
+    condition = {"type": "comparison", "operator": "GREATER_THAN", "right": {"value": 0}}
+    execution = {"measures": []}
+
+    alert = CatalogAutomationAlert(condition=condition, execution=execution)
+
+    assert alert.trigger is None
+    assert alert.interval is None
+
+    api_dict = alert.to_api().to_dict()
+    # trigger/interval should not appear when not set
+    assert "trigger" not in api_dict or api_dict.get("trigger") is None
+    assert "interval" not in api_dict or api_dict.get("interval") is None


### PR DESCRIPTION
## Summary

Added CatalogAutomationAlert SDK wrapper class with new `interval` field and `ONCE_PER_INTERVAL` trigger support. Added `alert` field to CatalogDeclarativeAutomation. Exported CatalogAutomationAlert from the public API surface. Two unit tests added (no cassettes required).

**Impact:** new_feature | **Services:** `gooddata-automation-client`, `gooddata-metadata-client`

## Files changed

- `packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/declarative_model/workspace/automation.py`
- `packages/gooddata-sdk/src/gooddata_sdk/__init__.py`
- `packages/gooddata-sdk/tests/catalog/test_catalog_workspace.py`

## Agent decisions

<details><summary>Decisions (4)</summary>

**condition and execution field types** — Use dict[str, Any] for condition and execution in CatalogAutomationAlert
  - Alternatives: Create full CatalogAutomationAlertCondition and CatalogAlertAfm wrapper classes, Use Any type
  - Why: AutomationAlertCondition is a complex discriminated union; AlertAfm is a complex AFM object. The SDK already uses dict for comparably complex nested fields (e.g., metadata: dict | None in CatalogDeclarativeAutomation). Using dict avoids a large scope expansion while still allowing full round-trip serialization via AutomationAlert.from_dict.

**where to add CatalogAutomationAlert** — Add CatalogAutomationAlert to existing automation.py alongside the other CatalogAutomation* classes
  - Alternatives: Create a separate alert.py file
  - Why: All automation-related wrapper classes live in automation.py; keeping CatalogAutomationAlert there maintains cohesion.

**alert field previously absent from CatalogDeclarativeAutomation** — Add alert: CatalogAutomationAlert | None = None to CatalogDeclarativeAutomation
  - Alternatives: Leave alert field absent and only update the API client
  - Why: The OpenAPI diff sdk_impact is 'new_feature'. Without exposing alert in the SDK, users cannot set trigger=ONCE_PER_INTERVAL or interval on their alerts. The alert field was silently dropped on round-trip before this change.

**from __future__ import annotations** — Added to automation.py (was missing before)
  - Why: Required by SDK coding standards; also needed for the forward reference to CatalogAutomationAlert inside CatalogDeclarativeAutomation.

</details>

<details><summary>Assumptions to verify (2)</summary>

- AutomationAlert.from_dict() accepts plain Python dicts for condition and execution — consistent with how DeclarativeAutomation handles metadata: dict, but not confirmed by running tests due to environment restrictions.
- The alert field in DeclarativeAutomation was intentionally omitted in the SDK previously (not a pre-existing bug).

</details>

<details><summary>Risks (2)</summary>

- If AutomationAlert.from_dict() strictly type-checks condition as AutomationAlertCondition and rejects plain dicts, test_catalog_automation_alert_once_per_interval will fail at to_api(). Fix: override to_api() to pass _check_type=False to AutomationAlert constructor.
- The existing test_layout_automations cassette does not include an alert field; re-recording would be needed for a full alert round-trip integration test.

</details>

<details><summary>Layers touched (3)</summary>

- **declarative_model** — Added CatalogAutomationAlert class; added alert field to CatalogDeclarativeAutomation
  - `packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/declarative_model/workspace/automation.py`
- **public_api** — Exported CatalogAutomationAlert
  - `packages/gooddata-sdk/src/gooddata_sdk/__init__.py`
- **tests** — Added two unit tests for CatalogAutomationAlert (no cassette needed)
  - `packages/gooddata-sdk/tests/catalog/test_catalog_workspace.py`

</details>

## Source commits (gdc-nas)

- `fd55e3f` Merge pull request #22089 from Tjev/cq-2090

<details><summary>OpenAPI diff</summary>

```diff
+                  "interval": {
+                    "description": "Date granularity for the interval of ONCE_PER_INTERVAL trigger. Supported granularities: DAY, WEEK, MONTH, QUARTER, YEAR.",
+                    "enum": [
+                      "DAY",
+                      "WEEK",
+                      "MONTH",
+                      "QUARTER",
+                      "YEAR"
+                    ],
+                    "type": "string"
+                  },
                   "trigger": {
                     "default": "ALWAYS",
-                    "description": "Trigger behavior for the alert.\nALWAYS...\nONCE...",
+                    "description": "Trigger behavior for the alert.\nALWAYS...\nONCE...\nONCE_PER_INTERVAL - alert is triggered when the condition is met, then suppressed for the interval.",
                     "enum": [
                       "ALWAYS",
-                      "ONCE"
+                      "ONCE",
+                      "ONCE_PER_INTERVAL"
                     ]
```
</details>

## [Workflow run](https://github.com/gooddata/gdc-nas/actions/runs/24666182171)

---
*Generated by SDK OpenAPI Sync workflow*