### PR TITLE
feat(gooddata-sdk): [AUTO] Add WRITE/READ_KNOWLEDGE_DOCUMENTS and BASE_UI_ACCESS permissions

### DIFF
--- a/packages/gooddata-sdk/tests/catalog/test_catalog_permission.py
+++ b/packages/gooddata-sdk/tests/catalog/test_catalog_permission.py
@@ -143,6 +143,10 @@ def test_data_source_permission(test_config):
     _validation_helper(CatalogDeclarativeDataSourcePermission, "name")
 
 
+def test_organization_permission_validation(test_config):
+    _validation_helper(CatalogDeclarativeOrganizationPermission, "name")
+
+
 @gd_vcr.use_cassette(str(_fixtures_dir / "get_declarative_permissions.yaml"))
 def test_get_declarative_permissions(test_config):
     sdk = GoodDataSdk.create(host_=test_config["host"], token_=test_config["token"])


### PR DESCRIPTION
## Summary

Added test_organization_permission_validation to test_catalog_permission.py to cover the new BASE_UI_ACCESS org permission value. No SDK wrapper source changes were needed: the auto-generated gooddata-api-client already carries WRITE_KNOWLEDGE_DOCUMENTS, READ_KNOWLEDGE_DOCUMENTS (WorkspacePermission), and BASE_UI_ACCESS (OrganizationPermission) in its allowed_values dicts, and the SDK wrapper uses the dynamic value_in_allowed validator that reads those dicts at runtime.

**Impact:** enum_addition | **Services:** `gooddata-metadata-client`

## Files changed

- `packages/gooddata-sdk/tests/catalog/test_catalog_permission.py`

## Agent decisions

<details><summary>Decisions (2)</summary>

**no SDK wrapper source changes** — Set status to implemented (test addition only) rather than no_changes
  - Alternatives: Add explicit constants or a TypeAlias for the new enum values, Mark as no_changes since no wrapper source changed
  - Why: The value_in_allowed validator in catalog/base.py reads allowed_values from the client_class() at runtime, so the new enum values propagate automatically from the auto-generated client. A test file change was still appropriate to assert all org permission values (including BASE_UI_ACCESS) are valid.

**test approach for enum addition** — Unit test using existing _validation_helper pattern without cassettes
  - Alternatives: Integration test with cassette, Skip test entirely since auto-generated client already validates
  - Why: The _validation_helper function only instantiates SDK objects; it makes no HTTP calls. No cassette is needed. The three existing workspace/datasource permission validation tests follow the same pattern, and adding the org-permission counterpart keeps the test suite symmetric.

</details>

<details><summary>Assumptions to verify (3)</summary>

- The auto-generated gooddata-api-client in gooddata-api-client/ was already regenerated from the updated OpenAPI spec before this agent ran.
- SELF_SERVICE_ENTITLEMENTS in the diff refers to the old OrganizationPermission that was replaced by SELF_CREATE_TOKEN in the current codebase; no renaming is needed in the SDK wrapper.
- The WorkspacePermission diff only shows ANALYZE and VIEW as existing values for brevity; MANAGE, EXPORT, etc. already existed prior to this cluster.

</details>

<details><summary>Layers touched (1)</summary>

- **tests** — Added test_organization_permission_validation unit test
  - `packages/gooddata-sdk/tests/catalog/test_catalog_permission.py`

</details>

## Source commits (gdc-nas)

- `ba12e35` feat: enforce knowledge document permissions
- `7c52d90` feat(afm-exec-api): gate knowledge APIs with enableAIKnowledge
- `3d58a73` Merge pull request #20450 from peter-plochan/perm/base-ui-access

<details><summary>OpenAPI diff</summary>

```diff
       "WorkspacePermission": {
         "enum": [
           "ANALYZE",
+          "READ_KNOWLEDGE_DOCUMENTS",
+          "WRITE_KNOWLEDGE_DOCUMENTS",
           "VIEW"
         ]
       },
       "OrganizationPermission": {
         "enum": [
+          "BASE_UI_ACCESS",
           "MANAGE",
           "SELF_SERVICE_ENTITLEMENTS"
         ]
       }
```
</details>

## [Workflow run](https://github.com/gooddata/gdc-nas/actions/runs/24666182171)

---
*Generated by SDK OpenAPI Sync workflow*