### PR TITLE
feat(gooddata-sdk): [AUTO] Add HLL data type, APPROXIMATE_COUNT operation, and HYPERLOGLOG label type

### DIFF
--- a/packages/gooddata-dbt/src/gooddata_dbt/dbt/base.py
+++ b/packages/gooddata-dbt/src/gooddata_dbt/dbt/base.py
@@ -23,6 +23,8 @@ class GoodDataLabelType(Enum):
     GEO_LONGITUDE = "GEO_LONGITUDE"
     GEO_AREA = "GEO_AREA"
     GEO_ICON = "GEO_ICON"
+    HYPERLOGLOG = "HYPERLOGLOG"
+    AUXILIARY = "AUXILIARY"
 
 
 class GoodDataSortDirection(Enum):

--- a/packages/gooddata-pipelines/src/gooddata_pipelines/ldm_extension/models/custom_data_object.py
+++ b/packages/gooddata-pipelines/src/gooddata_pipelines/ldm_extension/models/custom_data_object.py
@@ -30,6 +30,7 @@ class ColumnDataType(str, Enum):
     TIMESTAMP = "TIMESTAMP"
     TIMESTAMP_TZ = "TIMESTAMP_TZ"
     BOOLEAN = "BOOLEAN"
+    HLL = "HLL"
 
 
 class CustomFieldDefinition(BaseModel):


### PR DESCRIPTION
## Summary

Added HLL to ColumnDataType enum in gooddata-pipelines, and HYPERLOGLOG + AUXILIARY to GoodDataLabelType enum in gooddata-dbt. APPROXIMATE_COUNT was already present in gooddata-sdk's SIMPLE_METRIC_AGGREGATION and _AGGREGATION_CONVERSION. The gooddata-sdk declarative model fields (source_column_data_type, value_type) are typed as str | None without enum validators, so no SDK-core changes were needed.

**Impact:** enum_addition | **Services:** `gooddata-afm-client`, `gooddata-metadata-client`

## Files changed

- `packages/gooddata-dbt/src/gooddata_dbt/dbt/base.py`
- `packages/gooddata-pipelines/src/gooddata_pipelines/ldm_extension/models/custom_data_object.py`

## Agent decisions

<details><summary>Decisions (3)</summary>

**APPROXIMATE_COUNT already present** — No change to gooddata-sdk metric.py or visualization.py
  - Alternatives: Add duplicate entry (incorrect), Remove and re-add (unnecessary churn)
  - Why: SIMPLE_METRIC_AGGREGATION in compute/model/metric.py already contained 'APPROXIMATE_COUNT' (line 43), and _AGGREGATION_CONVERSION in visualization.py already mapped 'approximate_count' -> 'APPROXIMATE_COUNT'. The API client also already included this value.

**gooddata-sdk core fields need no change** — Left source_column_data_type and value_type fields as str | None without validation
  - Alternatives: Add Literal type annotations, Add value_in_allowed validators
  - Why: The declarative model fields in dataset.py use plain str | None types with no enum-based validators, so new string values pass through automatically without any code change.

**GoodDataLabelType scope** — Added both HYPERLOGLOG and AUXILIARY to GoodDataLabelType in gooddata-dbt
  - Alternatives: Add only AUXILIARY, Leave for dbt team to add separately
  - Why: HYPERLOGLOG was already in the API client's declarative_label.py enum but not in the hand-written dbt GoodDataLabelType. AUXILIARY is brand-new. Both are valid LabelType values per the diff.

</details>

<details><summary>Assumptions to verify (3)</summary>

- The gooddata-api-client auto-generated models will be regenerated separately to include HLL (SourceDataType) and AUXILIARY (LabelType); the hand-written SDK wrapper does not need to enumerate valid values for those fields.
- HYPERLOGLOG was already present in the API client (declarative_label.py line 83) so the backend already supports it; the dbt enum was simply behind.
- HLL is a valid SourceDataType usable as source_column_data_type for attributes, facts, and labels, similar to BOOLEAN or NUMERIC.

</details>

<details><summary>Layers touched (1)</summary>

- **entity_model** — Enum definitions for LabelType (GoodDataLabelType) and SourceDataType (ColumnDataType)
  - `packages/gooddata-dbt/src/gooddata_dbt/dbt/base.py`
  - `packages/gooddata-pipelines/src/gooddata_pipelines/ldm_extension/models/custom_data_object.py`

</details>

## Source commits (gdc-nas)

- `03cb7b6` Merge pull request #21512 from pcerny/pce/cq-2118_hll_sr
- `6faf4e2` Merge pull request #21484 from pcerny/pce/cq-2118_hll_sr
- `e6d7adb` Merge pull request #21592 from pcerny/pce/cq-2118_vertica_scan
- `5ce05e5` Merge pull request #22135 from gooddata/ine-hll-ff
- `7ed4096` Merge pull request #22170 from pcerny/pce/cq-2232_hll_col
- `f24d083` Merge pull request #22147 from pcerny/pce/cq-2227_dataset_auxiliary
- `e35ed4c` Merge pull request #20807 from gooddata/ine-cq-2014

<details><summary>OpenAPI diff</summary>

```diff
+      "HLL": added to SourceDataType enum,
       "SourceDataType": {
         "enum": [
           "BOOLEAN", "DATE", "NUMERIC",
+          "HLL",
           "STRING", "TIMESTAMP"
         ]
       },
       "LabelType": {
         "enum": [
+          "AUXILIARY",
+          "HYPERLOGLOG",
           "ATTRIBUTE", "GEO", ...
         ]
       },
       "MeasureAggregation": {
         "enum": [
+          "APPROXIMATE_COUNT",
           "AVG", "COUNT", ...
         ]
       }
```
</details>

## [Workflow run](https://github.com/gooddata/gdc-nas/actions/runs/24666182171)

---
*Generated by SDK OpenAPI Sync workflow*