### PR TITLE
feat(gooddata-sdk): [AUTO] Add certification fields and setCertification endpoint for analytics

### DIFF
--- a/packages/gooddata-sdk/src/gooddata_sdk/__init__.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/__init__.py
@@ -249,6 +249,7 @@ from gooddata_sdk.catalog.workspace.declarative_model.workspace.workspace import
     CatalogDeclarativeWorkspaceModel,
     CatalogDeclarativeWorkspaces,
 )
+from gooddata_sdk.catalog.workspace.entity_model.certification import CatalogSetCertificationRequest
 from gooddata_sdk.catalog.workspace.entity_model.content_objects.dataset import (
     CatalogAttribute,
     CatalogDataset,

--- a/packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/content_service.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/content_service.py
@@ -20,6 +20,7 @@ from gooddata_sdk.catalog.workspace.declarative_model.workspace.analytics_model.
 )
 from gooddata_sdk.catalog.workspace.declarative_model.workspace.logical_model.ldm import CatalogDeclarativeModel
 from gooddata_sdk.catalog.workspace.declarative_model.workspace.workspace import LAYOUT_WORKSPACES_DIR
+from gooddata_sdk.catalog.workspace.entity_model.certification import CatalogSetCertificationRequest
 from gooddata_sdk.catalog.workspace.entity_model.content_objects.dataset import (
     CatalogAggregatedFact,
     CatalogAttribute,
@@ -175,6 +176,42 @@ class CatalogWorkspaceContentService(CatalogServiceBase):
         metrics = load_all_entities(get_metrics)
         catalog_metrics = [CatalogMetric.from_api(metric) for metric in metrics.data]
         return catalog_metrics
+
+    def set_metric_certification(
+        self,
+        workspace_id: str,
+        metric_id: str,
+        *,
+        message: str | None = None,
+        status: str | None = "CERTIFIED",
+    ) -> None:
+        """Set or clear the certification status of a metric.
+
+        Args:
+            workspace_id (str):
+                Workspace identification string e.g. "demo"
+            metric_id (str):
+                ID of the metric to certify or decertify.
+            message (str | None):
+                Optional message to associate with the certification.
+            status (str | None):
+                Certification status. Use ``"CERTIFIED"`` (default) to certify,
+                or ``None`` to remove an existing certification.
+
+        Returns:
+            None
+        """
+        request = CatalogSetCertificationRequest(
+            id=metric_id,
+            type="metric",
+            message=message,
+            status=status,
+        )
+        self._actions_api.set_certification(
+            workspace_id=workspace_id,
+            set_certification_request=request.as_api_model(),
+            _check_return_type=False,
+        )
 
     def get_facts_catalog(self, workspace_id: str) -> list[CatalogFact]:
         """Retrieve all facts in a given workspace.

--- a/packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/entity_model/certification.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/entity_model/certification.py
@@ -1,0 +1,43 @@
+# (C) 2024 GoodData Corporation
+from __future__ import annotations
+
+from typing import Any, Literal
+
+import attrs
+from gooddata_api_client.model.set_certification_request import SetCertificationRequest
+
+from gooddata_sdk.catalog.base import Base
+
+CertificationStatus = Literal["CERTIFIED"]
+
+
+@attrs.define(kw_only=True)
+class CatalogSetCertificationRequest(Base):
+    """Request to set or clear the certification status of an analytics object.
+
+    Pass ``status=None`` to remove the certification from the object.
+    Pass ``status="CERTIFIED"`` (the default) to certify it.
+    """
+
+    id: str
+    type: str
+    message: str | None = None
+    status: str | None = "CERTIFIED"
+
+    @staticmethod
+    def client_class() -> type[SetCertificationRequest]:
+        return SetCertificationRequest
+
+    def as_api_model(self) -> SetCertificationRequest:
+        kwargs: dict[str, Any] = {}
+        if self.message is not None:
+            kwargs["message"] = self.message
+        # status=None means "clear certification" — always forward it so the
+        # caller can explicitly remove a previously set status.
+        kwargs["status"] = self.status
+        return SetCertificationRequest(
+            id=self.id,
+            type=self.type,
+            _check_type=False,
+            **kwargs,
+        )

--- a/packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/entity_model/content_objects/metric.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/entity_model/content_objects/metric.py
@@ -25,5 +25,20 @@ class CatalogMetric(AttrCatalogEntity):
     def is_hidden(self) -> bool | None:
         return safeget(self.json_api_attributes, ["isHidden"])
 
+    @property
+    def certification(self) -> str | None:
+        """Certification status of the metric (e.g. 'CERTIFIED'), or None if not certified."""
+        return safeget(self.json_api_attributes, ["certification"])
+
+    @property
+    def certification_message(self) -> str | None:
+        """Optional message associated with the certification."""
+        return safeget(self.json_api_attributes, ["certificationMessage"])
+
+    @property
+    def certified_at(self) -> str | None:
+        """ISO-8601 datetime string of when the certification was set, or None."""
+        return safeget(self.json_api_attributes, ["certifiedAt"])
+
     def as_computable(self) -> Metric:
         return SimpleMetric(local_id=self.id, item=self.obj_id)

--- a/packages/gooddata-sdk/tests/catalog/test_catalog_workspace_content.py
+++ b/packages/gooddata-sdk/tests/catalog/test_catalog_workspace_content.py
@@ -18,6 +18,7 @@ from gooddata_sdk import (
     CatalogDependsOn,
     CatalogDependsOnDateFilter,
     CatalogEntityIdentifier,
+    CatalogSetCertificationRequest,
     CatalogValidateByItem,
     CatalogWorkspace,
     DataSourceValidator,
@@ -502,3 +503,62 @@ def test_export_definition_analytics_layout(test_config):
         assert deep_eq(analytics_o.analytics.export_definitions, analytics_e.analytics.export_definitions)
     finally:
         safe_delete(_refresh_workspaces, sdk)
+
+
+# --- Certification unit tests ---
+
+
+def test_set_certification_request_as_api_model_certified():
+    """CatalogSetCertificationRequest serialises correctly for a CERTIFIED request."""
+    req = CatalogSetCertificationRequest(id="my-metric", type="metric", message="Approved", status="CERTIFIED")
+    api_model = req.as_api_model()
+    assert api_model.id == "my-metric"
+    assert api_model.type == "metric"
+    assert api_model.message == "Approved"
+    assert api_model.status == "CERTIFIED"
+
+
+def test_set_certification_request_as_api_model_clear():
+    """CatalogSetCertificationRequest serialises correctly when clearing certification (status=None)."""
+    req = CatalogSetCertificationRequest(id="my-metric", type="metric", status=None)
+    api_model = req.as_api_model()
+    assert api_model.id == "my-metric"
+    assert api_model.type == "metric"
+    assert api_model.status is None
+
+
+def test_set_certification_request_defaults():
+    """Default status is 'CERTIFIED' and message defaults to None."""
+    req = CatalogSetCertificationRequest(id="m1", type="metric")
+    assert req.status == "CERTIFIED"
+    assert req.message is None
+
+
+def test_set_metric_certification_calls_api():
+    """set_metric_certification forwards the correct request to the actions API."""
+    from unittest.mock import MagicMock
+
+    from gooddata_sdk.catalog.workspace.content_service import CatalogWorkspaceContentService
+
+    mock_api_client = MagicMock()
+    mock_api_client.entities_api = MagicMock()
+    mock_api_client.layout_api = MagicMock()
+    mock_api_client.actions_api = MagicMock()
+    mock_api_client.user_management_api = MagicMock()
+
+    service = CatalogWorkspaceContentService(mock_api_client)
+    service.set_metric_certification(
+        workspace_id="demo",
+        metric_id="total-revenue",
+        message="Verified by data team",
+        status="CERTIFIED",
+    )
+
+    mock_api_client.actions_api.set_certification.assert_called_once()
+    call_kwargs = mock_api_client.actions_api.set_certification.call_args
+    assert call_kwargs.kwargs["workspace_id"] == "demo"
+    api_req = call_kwargs.kwargs["set_certification_request"]
+    assert api_req.id == "total-revenue"
+    assert api_req.type == "metric"
+    assert api_req.message == "Verified by data team"
+    assert api_req.status == "CERTIFIED"


### PR DESCRIPTION
## Summary

Added certification fields to CatalogMetric, created CatalogSetCertificationRequest model, and added set_metric_certification() service method to CatalogWorkspaceContentService. CatalogSetCertificationRequest is exported from gooddata_sdk.

**Impact:** new_feature | **Services:** `gooddata-metadata-client`

## Files changed

- `packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/entity_model/content_objects/metric.py`
- `packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/entity_model/certification.py`
- `packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/content_service.py`
- `packages/gooddata-sdk/src/gooddata_sdk/__init__.py`
- `packages/gooddata-sdk/tests/catalog/test_catalog_workspace_content.py`

## Agent decisions

<details><summary>Decisions (4)</summary>

**use existing generic setCertification endpoint** — Use ActionsApi.set_certification (workspace-level endpoint) with type='metric'
  - Alternatives: Implement the new metric-specific /metrics/{objectId}/setCertification path via _do_post_request
  - Why: The metric-specific endpoint from the diff is NOT present in the generated API client; the existing workspace-level endpoint already accepts type='metric' and achieves the same result. Using the generated client avoids raw HTTP plumbing.

**certification field type in CatalogMetric** — str | None (not bool)
  - Alternatives: bool | None (matching the diff's 'type: boolean')
  - Why: The generated JsonApiMetricOutAttributes model defines certification as str with allowed_values={'CERTIFIED': 'CERTIFIED'}, not as boolean. The diff is a rough approximation; the generated code is authoritative.

**where to place CatalogSetCertificationRequest** — New file catalog/workspace/entity_model/certification.py
  - Alternatives: Inline in content_objects/metric.py, In catalog/workspace/action_model/
  - Why: Certification applies to multiple entity types (metric, visualizationObject, analyticalDashboard), so a separate file avoids coupling it to the metric module.

**status=None handling in as_api_model** — Always forward status (including None) to the API model
  - Alternatives: Omit status from kwargs when None
  - Why: The API's SetCertificationRequest allowed_values includes None as a valid status to clear certification; callers must be able to pass None explicitly.

</details>

<details><summary>Assumptions to verify (3)</summary>

- The certified_at field in json_api_attributes arrives as an ISO-8601 string (not a datetime object) since _check_return_type=False is used; exposed as str | None.
- The certified_by relationship is delivered via include=certifiedBy side-load mechanism, not as a direct attribute; omitted from CatalogMetric properties.
- ActionsApi.set_certification with type='metric' is functionally equivalent to the new /metrics/{objectId}/setCertification endpoint for the metric certification use-case.

</details>

<details><summary>Layers touched (3)</summary>

- **entity_model** — Added certification/certification_message/certified_at read-only properties to CatalogMetric; new CatalogSetCertificationRequest action-request model
  - `packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/entity_model/content_objects/metric.py`
  - `packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/entity_model/certification.py`
- **public_api** — Exported CatalogSetCertificationRequest; added set_metric_certification() to CatalogWorkspaceContentService
  - `packages/gooddata-sdk/src/gooddata_sdk/__init__.py`
  - `packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/content_service.py`
- **tests** — Four new unit tests covering model serialisation and service method forwarding
  - `packages/gooddata-sdk/tests/catalog/test_catalog_workspace_content.py`

</details>

## Source commits (gdc-nas)

- `a6f9082` Merge pull request #20581 from hkad98/jkd/certification
- `0c3c662` Merge pull request #20578 from hkad98/jkd/certification

<details><summary>OpenAPI diff</summary>

```diff
+      "SetCertificationRequest": {
+        "properties": {
+          "certificationMessage": { "type": "string" }
+        }
+      },
       "JsonApiMetricAttributes": {
         "properties": {
+          "certification": { "type": "boolean" },
+          "certificationMessage": { "type": "string" },
+          "certifiedAt": { "format": "date-time", "type": "string" },
+          "certifiedBy": { "type": "string" },
           "content": { ... }
         }
       },
+    paths:
+      "/api/v1/actions/workspaces/{workspaceId}/metrics/{objectId}/setCertification": { "post": {...} }
```
</details>

## [Workflow run](https://github.com/gooddata/gdc-nas/actions/runs/24666182171)

---
*Generated by SDK OpenAPI Sync workflow*