### PR TITLE
feat(gooddata-sdk): [AUTO] Add grandTotalsPosition field to tabular export Settings schema

### DIFF
--- a/packages/gooddata-sdk/src/gooddata_sdk/catalog/export/request.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/catalog/export/request.py
@@ -14,7 +14,7 @@ from gooddata_api_client.model.visual_export_request import VisualExportRequest 
 
 from gooddata_sdk.catalog.base import Base
 
-GrandTotalsPosition = Literal["pinnedBottom", "pinnedTop", "bottom", "top"]
+GrandTotalsPosition = Literal["pinnedBottom", "pinnedTop", "bottom", "top", "TOP", "BOTTOM"]
 
 
 @define(kw_only=True)

--- a/packages/gooddata-sdk/tests/export/test_export_service.py
+++ b/packages/gooddata-sdk/tests/export/test_export_service.py
@@ -95,7 +95,7 @@ def _tabular_by_visualization_id_base(test_config, export_format: str):
 
 @pytest.mark.parametrize(
     "grand_totals_position",
-    ["pinnedBottom", "pinnedTop", "bottom", "top"],
+    ["pinnedBottom", "pinnedTop", "bottom", "top", "TOP", "BOTTOM"],
 )
 def test_export_settings_grand_totals_position(grand_totals_position):
     settings = ExportSettings(merge_headers=True, show_filters=False, grand_totals_position=grand_totals_position)


### PR DESCRIPTION
## Summary

Extended GrandTotalsPosition Literal type in request.py to include uppercase 'TOP' and 'BOTTOM' values added by the OpenAPI diff, and updated the parametrized test to cover the two new enum values.

**Impact:** new_feature | **Services:** `gooddata-export-client`, `gooddata-metadata-client`

## Files changed

- `packages/gooddata-sdk/src/gooddata_sdk/catalog/export/request.py`
- `packages/gooddata-sdk/tests/export/test_export_service.py`

## Agent decisions

<details><summary>Decisions (2)</summary>

**uppercase vs lowercase enum values** — Add 'TOP' and 'BOTTOM' (uppercase) as additional valid values in GrandTotalsPosition Literal alongside existing lowercase values
  - Alternatives: Replace lowercase 'top'/'bottom' with uppercase 'TOP'/'BOTTOM' (breaking change), Set status=no_changes because auto-generated client only shows lowercase values
  - Why: The OpenAPI diff explicitly adds grandTotalsPosition with enum ['TOP','BOTTOM'] (uppercase). The auto-generated client passes _check_type=False so uppercase values can be forwarded to the API. Keeping lowercase values preserves backward compatibility.

**scope of SDK change** — Only update GrandTotalsPosition TypeAlias and corresponding test; no new classes needed
  - Alternatives: Add a wrapper for DashboardExportSettings to expose grandTotalsPosition, Create a new PDF-specific settings class
  - Why: The diff targets the tabular export Settings schema, which is already wrapped by ExportSettings. The only missing piece is the new enum values in GrandTotalsPosition.

</details>

<details><summary>Assumptions to verify (3)</summary>

- The 'TOP' and 'BOTTOM' uppercase values are genuinely new API-accepted enum values for grandTotalsPosition in PDF tabular exports, distinct from the existing lowercase 'top' and 'bottom'.
- The auto-generated gooddata-api-client in this repo was regenerated from a version of the spec that predates this cluster's change; with _check_type=False the uppercase values will still be forwarded correctly to the API server.
- The schemas/ directory represents a snapshot that may not yet include the uppercase enum values; the ground truth for what the server accepts is the cluster diff.

</details>

<details><summary>Risks (2)</summary>

- If the API server does not actually accept uppercase 'TOP'/'BOTTOM' (and they were just a diff representation artifact), tests parametrized with those values will fail against a live server.
- If the auto-generated client has enum validation enabled at the server-response level, responses containing 'TOP'/'BOTTOM' might not deserialize correctly.

</details>

<details><summary>Layers touched (2)</summary>

- **entity_model** — Extended GrandTotalsPosition TypeAlias with 'TOP' and 'BOTTOM' uppercase variants
  - `packages/gooddata-sdk/src/gooddata_sdk/catalog/export/request.py`
- **tests** — Added 'TOP' and 'BOTTOM' to parametrize list of test_export_settings_grand_totals_position
  - `packages/gooddata-sdk/tests/export/test_export_service.py`

</details>

## Source commits (gdc-nas)

- `36a823e` feat(tabular-exporter): respect grand-total-possition in PDFs in AD
- `0f0ac6f` feat(tabular-exporter): respect grand-total-possition in PDFs

<details><summary>OpenAPI diff</summary>

```diff
       "Settings": {
         "properties": {
+          "grandTotalsPosition": {
+            "description": "Position of grand totals in the exported tabular data.",
+            "enum": ["TOP", "BOTTOM"],
+            "type": "string"
+          },
           "mergeHeaders": { "type": "boolean" }
         }
       }
```
</details>

## [Workflow run](https://github.com/gooddata/gdc-nas/actions/runs/24666182171)

---
*Generated by SDK OpenAPI Sync workflow*