### PR TITLE
feat(gooddata-sdk): [AUTO] Add organization dataCenter and region diagnostic deployment fields

### DIFF
--- a/packages/gooddata-sdk/src/gooddata_sdk/catalog/organization/entity_model/organization.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/catalog/organization/entity_model/organization.py
@@ -53,6 +53,8 @@ class CatalogOrganization(Base):
             allowed_origins=safeget(ea, ["allowed_origins"]),
             oauth_issuer_location=safeget(ea, ["oauth_issuer_location"]),
             oauth_client_id=safeget(ea, ["oauth_client_id"]),
+            data_center=safeget(ea, ["data_center"]),
+            region=safeget(ea, ["region"]),
         )
 
         identity_provider_id = safeget(er, ["identityProvider", "data", "id"])
@@ -87,7 +89,24 @@ class CatalogOrganizationAttributes(Base):
     allowed_origins: list[str] | None = None
     oauth_issuer_location: str | None = None
     oauth_client_id: str | None = None
+    data_center: str | None = None
+    region: str | None = None
 
     @staticmethod
     def client_class() -> type[JsonApiOrganizationInAttributes]:
         return JsonApiOrganizationInAttributes
+
+    def to_api(self) -> JsonApiOrganizationInAttributes:
+        # data_center and region are read-only diagnostic fields — exclude them from write requests
+        kwargs: dict[str, Any] = {}
+        if self.name is not None:
+            kwargs["name"] = self.name
+        if self.hostname is not None:
+            kwargs["hostname"] = self.hostname
+        if self.allowed_origins is not None:
+            kwargs["allowed_origins"] = self.allowed_origins
+        if self.oauth_issuer_location is not None:
+            kwargs["oauth_issuer_location"] = self.oauth_issuer_location
+        if self.oauth_client_id is not None:
+            kwargs["oauth_client_id"] = self.oauth_client_id
+        return JsonApiOrganizationInAttributes(_check_type=False, **kwargs)

--- a/packages/gooddata-sdk/tests/catalog/test_catalog_organization.py
+++ b/packages/gooddata-sdk/tests/catalog/test_catalog_organization.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from gooddata_api_client.exceptions import NotFoundException
 from gooddata_sdk import (
     CatalogCspDirective,
@@ -14,6 +15,7 @@ from gooddata_sdk import (
     CatalogWebhook,
     GoodDataSdk,
 )
+from gooddata_sdk.catalog.organization.entity_model.organization import CatalogOrganizationAttributes
 from tests_support.vcrpy_utils import get_vcr
 
 from .conftest import safe_delete
@@ -563,3 +565,89 @@ def test_layout_notification_channels(test_config, snapshot_notification_channel
 #         sdk.catalog_organization.put_declarative_identity_providers([])
 #         idps = sdk.catalog_organization.get_declarative_identity_providers()
 #         assert len(idps) == 0
+
+
+# Unit tests for deployment diagnostic fields (no cassettes needed)
+
+
+@pytest.mark.parametrize(
+    "scenario, data_center, region",
+    [
+        ("both_set", "us-east-1", "prod-cluster"),
+        ("only_data_center", "eu-west-1", None),
+        ("only_region", None, "staging"),
+        ("both_none", None, None),
+    ],
+)
+def test_organization_attributes_diagnostic_fields(scenario, data_center, region):
+    """data_center and region are stored on CatalogOrganizationAttributes."""
+    attrs = CatalogOrganizationAttributes(
+        name="TestOrg",
+        hostname="test.gooddata.com",
+        data_center=data_center,
+        region=region,
+    )
+    assert attrs.data_center == data_center
+    assert attrs.region == region
+
+
+@pytest.mark.parametrize(
+    "scenario, data_center, region",
+    [
+        ("both_set", "us-east-1", "prod-cluster"),
+        ("only_data_center", "eu-west-1", None),
+        ("only_region", None, "staging"),
+        ("both_none", None, None),
+    ],
+)
+def test_organization_attributes_to_api_excludes_diagnostic_fields(scenario, data_center, region):
+    """to_api() must not forward read-only diagnostic fields to the write model."""
+    attrs = CatalogOrganizationAttributes(
+        name="TestOrg",
+        hostname="test.gooddata.com",
+        data_center=data_center,
+        region=region,
+    )
+    api_model = attrs.to_api()
+    api_dict = api_model.to_dict()
+    assert "dataCenter" not in api_dict
+    assert "data_center" not in api_dict
+    assert "region" not in api_dict
+
+
+def test_catalog_organization_from_api_reads_diagnostic_fields():
+    """CatalogOrganization.from_api() populates data_center and region from the response.
+
+    The keys use snake_case as exposed by the OpenApiModel __getitem__ accessor
+    (camelCase keys are normalised to snake_case by the generated client).
+    """
+    entity = {
+        "id": "default",
+        "type": "organization",
+        "attributes": {
+            "name": "TestOrg",
+            "hostname": "test.gooddata.com",
+            "data_center": "us-east-1",
+            "region": "prod-cluster",
+        },
+        "relationships": {},
+    }
+    org = CatalogOrganization.from_api(entity)
+    assert org.attributes.data_center == "us-east-1"
+    assert org.attributes.region == "prod-cluster"
+
+
+def test_catalog_organization_from_api_handles_missing_diagnostic_fields():
+    """from_api() gracefully handles responses that lack data_center/region."""
+    entity = {
+        "id": "default",
+        "type": "organization",
+        "attributes": {
+            "name": "TestOrg",
+            "hostname": "test.gooddata.com",
+        },
+        "relationships": {},
+    }
+    org = CatalogOrganization.from_api(entity)
+    assert org.attributes.data_center is None
+    assert org.attributes.region is None


### PR DESCRIPTION
## Summary

Added data_center and region diagnostic deployment fields to CatalogOrganizationAttributes. Both fields are read from the API response (JsonApiOrganizationOutAttributes already contains them in the generated client) but excluded from write requests via a custom to_api() override, since they are absent from JsonApiOrganizationInAttributes. Four unit tests added covering field storage, to_api() exclusion, from_api() population, and graceful handling of absent fields.

**Impact:** new_feature | **Services:** `gooddata-metadata-client`

## Files changed

- `packages/gooddata-sdk/src/gooddata_sdk/catalog/organization/entity_model/organization.py`
- `packages/gooddata-sdk/tests/catalog/test_catalog_organization.py`

## Agent decisions

<details><summary>Decisions (3)</summary>

**placement of data_center and region** — Add to CatalogOrganizationAttributes alongside the other organization attributes
  - Alternatives: Add as top-level fields on CatalogOrganization directly
  - Why: The fields appear in the attributes section of the API response (JsonApiOrganizationOutAttributes), making CatalogOrganizationAttributes the semantically correct home. Users access them consistently via organization.attributes.data_center, matching the pattern for name, hostname, etc.

**excluding read-only fields from write requests** — Override to_api() in CatalogOrganizationAttributes to explicitly construct JsonApiOrganizationInAttributes with only writable fields
  - Alternatives: Rely on None-filtering in _get_snake_dict() — unsafe when fields are non-None, Place fields only on CatalogOrganization to avoid the write-path concern
  - Why: data_center and region are absent from JsonApiOrganizationInAttributes (the write model), so they must not appear in PUT/PATCH bodies. An explicit to_api() override is the safest mechanism, consistent with the as_api_model() kwargs pattern in the architecture guide.

**no __init__.py export change** — Leave CatalogOrganizationAttributes unexported
  - Alternatives: Export CatalogOrganizationAttributes for type-hinting convenience
  - Why: CatalogOrganizationAttributes was not previously exported. The new fields are reachable via organization.attributes.data_center without requiring a new public symbol.

</details>

<details><summary>Assumptions to verify (3)</summary>

- The API server ignores unknown additional properties in write request bodies — consistent with existing code where oauth_issuer_location and oauth_client_id in CatalogOrganizationAttributes are also absent from JsonApiOrganizationInAttributes.
- data_center and region are truly server-generated read-only fields that users should never set explicitly; the OpenAPI diff description ('for diagnostic purposes') supports this.
- safeget(ea, ['data_center']) correctly retrieves the value from a JsonApiOrganizationOutAttributes OpenApiModel via snake_case key lookup, matching how the generated client normalises attribute names.

</details>

<details><summary>Risks (2)</summary>

- The existing VCR cassette organization.yaml already contains dataCenter and region as empty strings in the response body (verified), so test_get_organization should pass without re-recording.
- Unit tests that pass a plain dict to from_api() exercise a slightly different code path than production (which uses a JsonApiOrganizationOut object), but safeget handles both dict and OpenApiModel so the tests remain valid.

</details>

<details><summary>Layers touched (2)</summary>

- **entity_model** — Added data_center and region to CatalogOrganizationAttributes; added to_api() override to exclude them from write requests; updated CatalogOrganization.from_api() to populate them.
  - `packages/gooddata-sdk/src/gooddata_sdk/catalog/organization/entity_model/organization.py`
- **tests** — Added four unit tests (no cassettes): field storage, to_api() exclusion (parametrized), from_api() population, and from_api() absent-field handling.
  - `packages/gooddata-sdk/tests/catalog/test_catalog_organization.py`

</details>

## Source commits (gdc-nas)

- `f0f3783` feat(metadata-api): add deployment info to API
- `2577b31` Merge pull request #21385 from Vojtasii/vto/deployment-info

<details><summary>OpenAPI diff</summary>

```diff
       "JsonApiOrganizationOutAttributes": {
         "properties": {
+          "dataCenter": {
+            "description": "Data center identifier for diagnostic purposes.",
+            "type": "string"
+          },
+          "region": {
+            "description": "Region identifier for diagnostic purposes.",
+            "type": "string"
+          },
           "hostname": { "type": "string" }
         }
       }
```
</details>

## [Workflow run](https://github.com/gooddata/gdc-nas/actions/runs/24666182171)

---
*Generated by SDK OpenAPI Sync workflow*