### PR TITLE
feat(gooddata-sdk): [AUTO] Add parameters include option to analyticalDashboards and visualizations

### DIFF
--- a/packages/gooddata-sdk/tests/catalog/fixtures/workspace_content/test_get_visualizations_with_parameters.yaml
+++ b/packages/gooddata-sdk/tests/catalog/fixtures/workspace_content/test_get_visualizations_with_parameters.yaml
@@ -1,0 +1,1609 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - application/json
+        Accept-Encoding:
+          - br, gzip, deflate
+        X-GDC-VALIDATE-RELATIONS:
+          - 'true'
+        X-Requested-With:
+          - XMLHttpRequest
+      method: GET
+      uri: http://localhost:3000/api/v1/entities/workspaces/demo/visualizationObjects?include=ALL&page=0&size=500
+    response:
+      body:
+        string:
+          data:
+            - attributes:
+                areRelationsValid: true
+                content:
+                  buckets:
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: campaign_spend
+                                    type: metric
+                            localIdentifier: d319bcb2d8c04442a684e3b3cd063381
+                            title: Campaign Spend
+                      localIdentifier: measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: campaign_channels.category
+                                type: label
+                            localIdentifier: 291c085e7df8420db84117ca49f59c49
+                      localIdentifier: view
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: campaign_name
+                                type: label
+                            localIdentifier: d9dd143d647d4d148405a60ec2cf59bc
+                      localIdentifier: segment
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: type
+                            type: label
+                        notIn:
+                          values: []
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: campaign_channels.category
+                            type: label
+                        notIn:
+                          values: []
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: campaign_name
+                            type: label
+                        notIn:
+                          values: []
+                  properties:
+                    controls:
+                      legend:
+                        position: bottom
+                  version: '2'
+                  visualizationUrl: local:treemap
+                createdAt: 2000-01-01 00:00
+                title: Campaign Spend
+              id: campaign_spend
+              links:
+                self: http://localhost:3000/api/v1/entities/workspaces/demo/visualizationObjects/campaign_spend
+              meta:
+                origin:
+                  originId: demo
+                  originType: NATIVE
+              relationships:
+                createdBy:
+                  data:
+                    id: admin
+                    type: userIdentifier
+                labels:
+                  data:
+                    - id: campaign_channels.category
+                      type: label
+                    - id: campaign_name
+                      type: label
+                    - id: type
+                      type: label
+                metrics:
+                  data:
+                    - id: campaign_spend
+                      type: metric
+              type: visualizationObject
+            - attributes:
+                areRelationsValid: true
+                content:
+                  buckets:
+                    - items:
+                        - measure:
+                            alias: Active Customers
+                            definition:
+                              measureDefinition:
+                                computeRatio: false
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: amount_of_active_customers
+                                    type: metric
+                            localIdentifier: 2ba0b87b59ca41a4b1530e81a5c1d081
+                            title: '# of Active Customers'
+                      localIdentifier: measures
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue_per_customer
+                                    type: metric
+                            localIdentifier: ec0606894b9f4897b7beaf1550608928
+                            title: Revenue per Customer
+                      localIdentifier: secondary_measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: date.month
+                                type: label
+                            localIdentifier: 0de7d7f08af7480aa636857a26be72b6
+                      localIdentifier: view
+                  filters:
+                    - relativeDateFilter:
+                        dataSet:
+                          identifier:
+                            id: date
+                            type: dataset
+                        from: -12
+                        granularity: GDC.time.month
+                        to: -1
+                  properties:
+                    controls:
+                      colorMapping:
+                        - color:
+                            type: guid
+                            value: '20'
+                          id: 2ba0b87b59ca41a4b1530e81a5c1d081
+                        - color:
+                            type: guid
+                            value: '4'
+                          id: ec0606894b9f4897b7beaf1550608928
+                      dualAxis: true
+                      legend:
+                        position: bottom
+                      primaryChartType: column
+                      secondaryChartType: line
+                      secondary_yaxis:
+                        measures:
+                          - ec0606894b9f4897b7beaf1550608928
+                      xaxis:
+                        name:
+                          visible: false
+                        rotation: auto
+                  version: '2'
+                  visualizationUrl: local:combo2
+                createdAt: 2000-01-01 00:00
+                title: Customers Trend
+              id: customers_trend
+              links:
+                self: http://localhost:3000/api/v1/entities/workspaces/demo/visualizationObjects/customers_trend
+              meta:
+                origin:
+                  originId: demo
+                  originType: NATIVE
+              relationships:
+                createdBy:
+                  data:
+                    id: admin
+                    type: userIdentifier
+                datasets:
+                  data:
+                    - id: date
+                      type: dataset
+                labels:
+                  data:
+                    - id: date.month
+                      type: label
+                metrics:
+                  data:
+                    - id: amount_of_active_customers
+                      type: metric
+                    - id: revenue_per_customer
+                      type: metric
+              type: visualizationObject
+            - attributes:
+                areRelationsValid: true
+                content:
+                  buckets:
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: percent_revenue_per_product
+                                    type: metric
+                            localIdentifier: 08d8346c1ce7438994b251991c0fbf65
+                            title: '% Revenue per Product'
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue
+                                    type: metric
+                            localIdentifier: b2350c06688b4da9b3833ebcce65527f
+                            title: Revenue
+                      localIdentifier: measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: customer_name
+                                type: label
+                            localIdentifier: 7a4045fd00ac44579f52406df679435f
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: products.category
+                                type: label
+                            localIdentifier: 6a003ffd14994237ba64c4a02c488429
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: product_name
+                                type: label
+                            localIdentifier: 75ea396d0c8b48098e31dccf8b5801d3
+                      localIdentifier: attribute
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: customer_name
+                            type: label
+                        notIn:
+                          values: []
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: products.category
+                            type: label
+                        notIn:
+                          values: []
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: product_name
+                            type: label
+                        notIn:
+                          values: []
+                  properties: {}
+                  sorts:
+                    - attributeSortItem:
+                        attributeIdentifier: 7a4045fd00ac44579f52406df679435f
+                        direction: asc
+                  version: '2'
+                  visualizationUrl: local:table
+                createdAt: 2000-01-01 00:00
+                title: '% Revenue per Product by Customer and Category'
+              id: percent_revenue_per_product_by_customer_and_category
+              links:
+                self: http://localhost:3000/api/v1/entities/workspaces/demo/visualizationObjects/percent_revenue_per_product_by_customer_and_category
+              meta:
+                origin:
+                  originId: demo
+                  originType: NATIVE
+              relationships:
+                createdBy:
+                  data:
+                    id: admin
+                    type: userIdentifier
+                labels:
+                  data:
+                    - id: customer_name
+                      type: label
+                    - id: products.category
+                      type: label
+                    - id: product_name
+                      type: label
+                metrics:
+                  data:
+                    - id: percent_revenue_per_product
+                      type: metric
+                    - id: revenue
+                      type: metric
+              type: visualizationObject
+            - attributes:
+                areRelationsValid: true
+                content:
+                  buckets:
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: amount_of_active_customers
+                                    type: metric
+                            localIdentifier: 1a14cdc1293c46e89a2e25d3e741d235
+                            title: '# of Active Customers'
+                      localIdentifier: measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: date.month
+                                type: label
+                            localIdentifier: c1feca1864244ec2ace7a9b9d7fda231
+                      localIdentifier: view
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: region
+                                type: label
+                            localIdentifier: 530cddbd7ca04d039e73462d81ed44d5
+                      localIdentifier: stack
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: region
+                            type: label
+                        notIn:
+                          values: []
+                    - relativeDateFilter:
+                        dataSet:
+                          identifier:
+                            id: date
+                            type: dataset
+                        from: -11
+                        granularity: GDC.time.month
+                        to: 0
+                  properties:
+                    controls:
+                      legend:
+                        position: bottom
+                      stackMeasuresToPercent: true
+                  version: '2'
+                  visualizationUrl: local:area
+                createdAt: 2000-01-01 00:00
+                title: Percentage of Customers by Region
+              id: percentage_of_customers_by_region
+              links:
+                self: http://localhost:3000/api/v1/entities/workspaces/demo/visualizationObjects/percentage_of_customers_by_region
+              meta:
+                origin:
+                  originId: demo
+                  originType: NATIVE
+              relationships:
+                createdBy:
+                  data:
+                    id: admin
+                    type: userIdentifier
+                datasets:
+                  data:
+                    - id: date
+                      type: dataset
+                labels:
+                  data:
+                    - id: date.month
+                      type: label
+                    - id: region
+                      type: label
+                metrics:
+                  data:
+                    - id: amount_of_active_customers
+                      type: metric
+              type: visualizationObject
+            - attributes:
+                areRelationsValid: true
+                content:
+                  buckets:
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue
+                                    type: metric
+                            localIdentifier: 590d332ef686468b8878ae41b23341c6
+                            title: Revenue
+                      localIdentifier: measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: products.category
+                                type: label
+                            localIdentifier: b166c71091864312a14c7ae8ff886ffe
+                      localIdentifier: view
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: product_name
+                                type: label
+                            localIdentifier: e920a50e0bbb49788df0aac53634c1cd
+                      localIdentifier: segment
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: products.category
+                            type: label
+                        notIn:
+                          values: []
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: product_name
+                            type: label
+                        notIn:
+                          values: []
+                  properties:
+                    controls:
+                      legend:
+                        position: bottom
+                  version: '2'
+                  visualizationUrl: local:treemap
+                createdAt: 2000-01-01 00:00
+                title: Product Breakdown
+              id: product_breakdown
+              links:
+                self: http://localhost:3000/api/v1/entities/workspaces/demo/visualizationObjects/product_breakdown
+              meta:
+                origin:
+                  originId: demo
+                  originType: NATIVE
+              relationships:
+                createdBy:
+                  data:
+                    id: admin
+                    type: userIdentifier
+                labels:
+                  data:
+                    - id: products.category
+                      type: label
+                    - id: product_name
+                      type: label
+                metrics:
+                  data:
+                    - id: revenue
+                      type: metric
+              type: visualizationObject
+            - attributes:
+                areRelationsValid: true
+                content:
+                  buckets:
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                computeRatio: true
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue
+                                    type: metric
+                            format: '#,##0.00%'
+                            localIdentifier: 162b857af49d45769bc12604a5c192b9
+                            title: '% Revenue'
+                      localIdentifier: measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: products.category
+                                type: label
+                            localIdentifier: fe513cef1c6244a5ac21c5f49c56b108
+                      localIdentifier: view
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: product_name
+                            type: label
+                        notIn:
+                          values: []
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: products.category
+                            type: label
+                        notIn:
+                          values: []
+                  properties:
+                    controls:
+                      dataLabels:
+                        visible: auto
+                      legend:
+                        position: bottom
+                  version: '2'
+                  visualizationUrl: local:donut
+                createdAt: 2000-01-01 00:00
+                title: Product Categories Pie Chart
+              id: product_categories_pie_chart
+              links:
+                self: http://localhost:3000/api/v1/entities/workspaces/demo/visualizationObjects/product_categories_pie_chart
+              meta:
+                origin:
+                  originId: demo
+                  originType: NATIVE
+              relationships:
+                createdBy:
+                  data:
+                    id: admin
+                    type: userIdentifier
+                labels:
+                  data:
+                    - id: products.category
+                      type: label
+                    - id: product_name
+                      type: label
+                metrics:
+                  data:
+                    - id: revenue
+                      type: metric
+              type: visualizationObject
+            - attributes:
+                areRelationsValid: true
+                content:
+                  buckets:
+                    - items:
+                        - measure:
+                            alias: Previous Period
+                            definition:
+                              popMeasureDefinition:
+                                measureIdentifier: c82e025fa2db4afea9a600a424591dbe
+                                popAttribute:
+                                  identifier:
+                                    id: date.year
+                                    type: attribute
+                            localIdentifier: c82e025fa2db4afea9a600a424591dbe_pop
+                        - measure:
+                            alias: This Period
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue
+                                    type: metric
+                            localIdentifier: c82e025fa2db4afea9a600a424591dbe
+                            title: Revenue
+                      localIdentifier: measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: products.category
+                                type: label
+                            localIdentifier: c804ef5ba7944a5a9f360c86a9e95e9a
+                      localIdentifier: view
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: product_name
+                            type: label
+                        notIn:
+                          values: []
+                    - relativeDateFilter:
+                        dataSet:
+                          identifier:
+                            id: date
+                            type: dataset
+                        from: -11
+                        granularity: GDC.time.month
+                        to: 0
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: products.category
+                            type: label
+                        notIn:
+                          values: []
+                  properties:
+                    controls:
+                      legend:
+                        position: bottom
+                      stackMeasures: false
+                      xaxis:
+                        name:
+                          visible: false
+                      yaxis:
+                        name:
+                          visible: false
+                  version: '2'
+                  visualizationUrl: local:column
+                createdAt: 2000-01-01 00:00
+                title: Product Revenue Comparison (over previous period)
+              id: product_revenue_comparison-over_previous_period
+              links:
+                self: http://localhost:3000/api/v1/entities/workspaces/demo/visualizationObjects/product_revenue_comparison-over_previous_period
+              meta:
+                origin:
+                  originId: demo
+                  originType: NATIVE
+              relationships:
+                attributes:
+                  data:
+                    - id: date.year
+                      type: attribute
+                createdBy:
+                  data:
+                    id: admin
+                    type: userIdentifier
+                datasets:
+                  data:
+                    - id: date
+                      type: dataset
+                labels:
+                  data:
+                    - id: products.category
+                      type: label
+                    - id: product_name
+                      type: label
+                metrics:
+                  data:
+                    - id: revenue
+                      type: metric
+              type: visualizationObject
+            - attributes:
+                areRelationsValid: true
+                content:
+                  buckets:
+                    - items:
+                        - measure:
+                            alias: Number of Orders
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: amount_of_orders
+                                    type: metric
+                            localIdentifier: aeb5d51a162d4b59aba3bd6ddebcc780
+                            title: '# of Orders'
+                      localIdentifier: measures
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue
+                                    type: metric
+                            localIdentifier: 94b3edd3a73c4a48a4d13bbe9442cc98
+                            title: Revenue
+                      localIdentifier: secondary_measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: product_name
+                                type: label
+                            localIdentifier: d2a991bdd123448eb2be73d79f1180c4
+                      localIdentifier: attribute
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: product_name
+                            type: label
+                        notIn:
+                          values: []
+                  properties:
+                    controls:
+                      dataLabels:
+                        visible: auto
+                      grid:
+                        enabled: true
+                  version: '2'
+                  visualizationUrl: local:scatter
+                createdAt: 2000-01-01 00:00
+                title: Product Saleability
+              id: product_saleability
+              links:
+                self: http://localhost:3000/api/v1/entities/workspaces/demo/visualizationObjects/product_saleability
+              meta:
+                origin:
+                  originId: demo
+                  originType: NATIVE
+              relationships:
+                createdBy:
+                  data:
+                    id: admin
+                    type: userIdentifier
+                labels:
+                  data:
+                    - id: product_name
+                      type: label
+                metrics:
+                  data:
+                    - id: amount_of_orders
+                      type: metric
+                    - id: revenue
+                      type: metric
+              type: visualizationObject
+            - attributes:
+                areRelationsValid: true
+                content:
+                  buckets:
+                    - items:
+                        - measure:
+                            alias: Items Sold
+                            definition:
+                              measureDefinition:
+                                aggregation: sum
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: quantity
+                                    type: fact
+                            format: '#,##0.00'
+                            localIdentifier: 29486504dd0e4a36a18b0b2f792d3a46
+                            title: Sum of Quantity
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                aggregation: avg
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: price
+                                    type: fact
+                            format: '#,##0.00'
+                            localIdentifier: aa6391acccf1452f8011201aef9af492
+                            title: Avg Price
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: percent_revenue_in_category
+                                    type: metric
+                            localIdentifier: 2cd39539d8da46c9883e63caa3ba7cc0
+                            title: '% Revenue in Category'
+                        - measure:
+                            alias: Total Revenue
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue
+                                    type: metric
+                            localIdentifier: 9a0f08331c094c7facf2a0b4f418de0a
+                            title: Revenue
+                      localIdentifier: measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: products.category
+                                type: label
+                            localIdentifier: 06bc6b3b9949466494e4f594c11f1bff
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: product_name
+                                type: label
+                            localIdentifier: 192668bfb6a74e9ab7b5d1ce7cb68ea3
+                      localIdentifier: attribute
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: customer_name
+                            type: label
+                        notIn:
+                          values: []
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: product_name
+                            type: label
+                        notIn:
+                          values: []
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: products.category
+                            type: label
+                        notIn:
+                          values: []
+                  properties: {}
+                  sorts:
+                    - attributeSortItem:
+                        attributeIdentifier: 06bc6b3b9949466494e4f594c11f1bff
+                        direction: asc
+                  version: '2'
+                  visualizationUrl: local:table
+                createdAt: 2000-01-01 00:00
+                title: Revenue and Quantity by Product and Category
+              id: revenue_and_quantity_by_product_and_category
+              links:
+                self: http://localhost:3000/api/v1/entities/workspaces/demo/visualizationObjects/revenue_and_quantity_by_product_and_category
+              meta:
+                origin:
+                  originId: demo
+                  originType: NATIVE
+              relationships:
+                createdBy:
+                  data:
+                    id: admin
+                    type: userIdentifier
+                facts:
+                  data:
+                    - id: quantity
+                      type: fact
+                    - id: price
+                      type: fact
+                labels:
+                  data:
+                    - id: products.category
+                      type: label
+                    - id: product_name
+                      type: label
+                    - id: customer_name
+                      type: label
+                metrics:
+                  data:
+                    - id: percent_revenue_in_category
+                      type: metric
+                    - id: revenue
+                      type: metric
+              type: visualizationObject
+            - attributes:
+                areRelationsValid: true
+                content:
+                  buckets:
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue
+                                    type: metric
+                            localIdentifier: 7df6c34387744d69b23ec92e1a5cf543
+                            title: Revenue
+                      localIdentifier: measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: date.month
+                                type: label
+                            localIdentifier: 4bb4fc1986c546de9ad976e6ec23fed4
+                      localIdentifier: trend
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: products.category
+                                type: label
+                            localIdentifier: 34bddcb1cd024902a82396216b0fa9d8
+                      localIdentifier: segment
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: products.category
+                            type: label
+                        notIn:
+                          values: []
+                    - relativeDateFilter:
+                        dataSet:
+                          identifier:
+                            id: date
+                            type: dataset
+                        granularity: GDC.time.year
+                  properties:
+                    controls:
+                      legend:
+                        position: bottom
+                  version: '2'
+                  visualizationUrl: local:line
+                createdAt: 2000-01-01 00:00
+                title: Revenue by Category Trend
+              id: revenue_by_category_trend
+              links:
+                self: http://localhost:3000/api/v1/entities/workspaces/demo/visualizationObjects/revenue_by_category_trend
+              meta:
+                origin:
+                  originId: demo
+                  originType: NATIVE
+              relationships:
+                createdBy:
+                  data:
+                    id: admin
+                    type: userIdentifier
+                datasets:
+                  data:
+                    - id: date
+                      type: dataset
+                labels:
+                  data:
+                    - id: date.month
+                      type: label
+                    - id: products.category
+                      type: label
+                metrics:
+                  data:
+                    - id: revenue
+                      type: metric
+              type: visualizationObject
+            - attributes:
+                areRelationsValid: true
+                content:
+                  buckets:
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue
+                                    type: metric
+                            localIdentifier: 4ae3401bdbba4938afe983df4ba04e1c
+                            title: Revenue
+                      localIdentifier: measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: product_name
+                                type: label
+                            localIdentifier: 1c8ba72dbfc84ddd913bf81dc355c427
+                      localIdentifier: view
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: product_name
+                            type: label
+                        notIn:
+                          values: []
+                  properties: {}
+                  version: '2'
+                  visualizationUrl: local:bar
+                createdAt: 2000-01-01 00:00
+                title: Revenue by Product
+              id: revenue_by_product
+              links:
+                self: http://localhost:3000/api/v1/entities/workspaces/demo/visualizationObjects/revenue_by_product
+              meta:
+                origin:
+                  originId: demo
+                  originType: NATIVE
+              relationships:
+                createdBy:
+                  data:
+                    id: admin
+                    type: userIdentifier
+                labels:
+                  data:
+                    - id: product_name
+                      type: label
+                metrics:
+                  data:
+                    - id: revenue
+                      type: metric
+              type: visualizationObject
+            - attributes:
+                areRelationsValid: true
+                content:
+                  buckets:
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: campaign_spend
+                                    type: metric
+                            localIdentifier: 13a50d811e474ac6808d8da7f4673b35
+                            title: Campaign Spend
+                      localIdentifier: measures
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue_per_dollar_spent
+                                    type: metric
+                            localIdentifier: a0f15e82e6334280a44dbedc7d086e7c
+                            title: Revenue per Dollar Spent
+                      localIdentifier: secondary_measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: campaign_name
+                                type: label
+                            localIdentifier: 1d9fa968bafb423eb29c938dfb1207ff
+                      localIdentifier: attribute
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: campaign_name
+                            type: label
+                        notIn:
+                          values: []
+                  properties:
+                    controls:
+                      xaxis:
+                        min: '0'
+                      yaxis:
+                        min: '0'
+                  version: '2'
+                  visualizationUrl: local:scatter
+                createdAt: 2000-01-01 00:00
+                title: Revenue per $ vs Spend by Campaign
+              id: revenue_per_usd_vs_spend_by_campaign
+              links:
+                self: http://localhost:3000/api/v1/entities/workspaces/demo/visualizationObjects/revenue_per_usd_vs_spend_by_campaign
+              meta:
+                origin:
+                  originId: demo
+                  originType: NATIVE
+              relationships:
+                createdBy:
+                  data:
+                    id: admin
+                    type: userIdentifier
+                labels:
+                  data:
+                    - id: campaign_name
+                      type: label
+                metrics:
+                  data:
+                    - id: campaign_spend
+                      type: metric
+                    - id: revenue_per_dollar_spent
+                      type: metric
+              type: visualizationObject
+            - attributes:
+                areRelationsValid: true
+                content:
+                  buckets:
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                computeRatio: false
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue
+                                    type: metric
+                            localIdentifier: 60c854969a9c4c278ab596d99c222e92
+                            title: Revenue
+                      localIdentifier: measures
+                    - items:
+                        - measure:
+                            alias: Number of Orders
+                            definition:
+                              measureDefinition:
+                                computeRatio: false
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: amount_of_orders
+                                    type: metric
+                            localIdentifier: c2fa7ef48cc54af99f8c280eb451e051
+                            title: '# of Orders'
+                      localIdentifier: secondary_measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: date.month
+                                type: label
+                            localIdentifier: 413ac374b65648fa96826ca01d47bdda
+                      localIdentifier: view
+                  filters:
+                    - relativeDateFilter:
+                        dataSet:
+                          identifier:
+                            id: date
+                            type: dataset
+                        from: -3
+                        granularity: GDC.time.quarter
+                        to: 0
+                  properties:
+                    controls:
+                      dualAxis: true
+                      legend:
+                        position: bottom
+                      primaryChartType: column
+                      secondaryChartType: line
+                      secondary_yaxis:
+                        measures:
+                          - c2fa7ef48cc54af99f8c280eb451e051
+                      xaxis:
+                        name:
+                          visible: false
+                        rotation: auto
+                  version: '2'
+                  visualizationUrl: local:combo2
+                createdAt: 2000-01-01 00:00
+                title: Revenue Trend
+              id: revenue_trend
+              links:
+                self: http://localhost:3000/api/v1/entities/workspaces/demo/visualizationObjects/revenue_trend
+              meta:
+                origin:
+                  originId: demo
+                  originType: NATIVE
+              relationships:
+                createdBy:
+                  data:
+                    id: admin
+                    type: userIdentifier
+                datasets:
+                  data:
+                    - id: date
+                      type: dataset
+                labels:
+                  data:
+                    - id: date.month
+                      type: label
+                metrics:
+                  data:
+                    - id: revenue
+                      type: metric
+                    - id: amount_of_orders
+                      type: metric
+              type: visualizationObject
+            - attributes:
+                areRelationsValid: true
+                content:
+                  buckets:
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue_top_10
+                                    type: metric
+                            localIdentifier: 3f127ccfe57a40399e23f9ae2a4ad810
+                            title: Revenue / Top 10
+                      localIdentifier: measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: customer_name
+                                type: label
+                            localIdentifier: f4e39e24f11e4827a191c30d65c89d2c
+                      localIdentifier: view
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: state
+                                type: label
+                            localIdentifier: bbccd430176d428caed54c99afc9589e
+                      localIdentifier: stack
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: customer_name
+                            type: label
+                        notIn:
+                          values: []
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: state
+                            type: label
+                        notIn:
+                          values: []
+                  properties:
+                    controls:
+                      legend:
+                        position: bottom
+                  version: '2'
+                  visualizationUrl: local:bar
+                createdAt: 2000-01-01 00:00
+                title: Top 10 Customers
+              id: top_10_customers
+              links:
+                self: http://localhost:3000/api/v1/entities/workspaces/demo/visualizationObjects/top_10_customers
+              meta:
+                origin:
+                  originId: demo
+                  originType: NATIVE
+              relationships:
+                createdBy:
+                  data:
+                    id: admin
+                    type: userIdentifier
+                labels:
+                  data:
+                    - id: customer_name
+                      type: label
+                    - id: state
+                      type: label
+                metrics:
+                  data:
+                    - id: revenue_top_10
+                      type: metric
+              type: visualizationObject
+            - attributes:
+                areRelationsValid: true
+                content:
+                  buckets:
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue_top_10
+                                    type: metric
+                            localIdentifier: 77dc71bbac92412bac5f94284a5919df
+                            title: Revenue / Top 10
+                      localIdentifier: measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: product_name
+                                type: label
+                            localIdentifier: 781952e728204dcf923142910cc22ae2
+                      localIdentifier: view
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: products.category
+                                type: label
+                            localIdentifier: fe513cef1c6244a5ac21c5f49c56b108
+                      localIdentifier: stack
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: product_name
+                            type: label
+                        notIn:
+                          values: []
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: products.category
+                            type: label
+                        notIn:
+                          values: []
+                  properties:
+                    controls:
+                      legend:
+                        position: bottom
+                  version: '2'
+                  visualizationUrl: local:bar
+                createdAt: 2000-01-01 00:00
+                title: Top 10 Products
+              id: top_10_products
+              links:
+                self: http://localhost:3000/api/v1/entities/workspaces/demo/visualizationObjects/top_10_products
+              meta:
+                origin:
+                  originId: demo
+                  originType: NATIVE
+              relationships:
+                createdBy:
+                  data:
+                    id: admin
+                    type: userIdentifier
+                labels:
+                  data:
+                    - id: product_name
+                      type: label
+                    - id: products.category
+                      type: label
+                metrics:
+                  data:
+                    - id: revenue_top_10
+                      type: metric
+              type: visualizationObject
+          included:
+            - attributes:
+                content:
+                  format: '#,##0'
+                  maql: SELECT COUNT({attribute/order_id})
+                createdAt: 2000-01-01 00:00
+                title: '# of Orders'
+              id: amount_of_orders
+              links:
+                self: http://localhost:3000/api/v1/entities/workspaces/demo/metrics/amount_of_orders
+              type: metric
+            - attributes:
+                content:
+                  format: $#,##0
+                  maql: SELECT {metric/order_amount} WHERE NOT ({label/order_status}
+                    IN ("Returned", "Canceled"))
+                createdAt: 2000-01-01 00:00
+                description: ''
+                title: Revenue
+              id: revenue
+              links:
+                self: http://localhost:3000/api/v1/entities/workspaces/demo/metrics/revenue
+              type: metric
+            - attributes:
+                description: Price
+                isNullable: true
+                sourceColumn: price
+                sourceColumnDataType: NUMERIC
+                tags:
+                  - Order lines
+                title: Price
+              id: price
+              links:
+                self: http://localhost:3000/api/v1/entities/workspaces/demo/facts/price
+              type: fact
+            - attributes:
+                description: Product name
+                isNullable: true
+                primary: true
+                sourceColumn: product_name
+                sourceColumnDataType: STRING
+                tags:
+                  - Products
+                title: Product name
+                valueType: TEXT
+              id: product_name
+              links:
+                self: http://localhost:3000/api/v1/entities/workspaces/demo/labels/product_name
+              type: label
+            - attributes:
+                description: Year
+                granularity: YEAR
+                tags:
+                  - Date
+                title: Date - Year
+              id: date.year
+              links:
+                self: http://localhost:3000/api/v1/entities/workspaces/demo/attributes/date.year
+              type: attribute
+            - attributes:
+                description: Campaign name
+                isNullable: true
+                primary: true
+                sourceColumn: campaign_name
+                sourceColumnDataType: STRING
+                tags:
+                  - Campaigns
+                title: Campaign name
+                valueType: TEXT
+              id: campaign_name
+              links:
+                self: http://localhost:3000/api/v1/entities/workspaces/demo/labels/campaign_name
+              type: label
+            - attributes:
+                content:
+                  format: '#,##0.0%'
+                  maql: SELECT {metric/revenue} / (SELECT {metric/revenue} BY {attribute/products.category},
+                    ALL OTHER)
+                createdAt: 2000-01-01 00:00
+                title: '% Revenue in Category'
+              id: percent_revenue_in_category
+              links:
+                self: http://localhost:3000/api/v1/entities/workspaces/demo/metrics/percent_revenue_in_category
+              type: metric
+            - attributes:
+                content:
+                  format: $#,##0.0
+                  maql: SELECT AVG(SELECT {metric/revenue} BY {attribute/customer_id})
+                createdAt: 2000-01-01 00:00
+                title: Revenue per Customer
+              id: revenue_per_customer
+              links:
+                self: http://localhost:3000/api/v1/entities/workspaces/demo/metrics/revenue_per_customer
+              type: metric
+            - attributes:
+                content:
+                  format: $#,##0
+                  maql: SELECT {metric/revenue} WHERE TOP(10) OF ({metric/revenue})
+                createdAt: 2000-01-01 00:00
+                title: Revenue / Top 10
+              id: revenue_top_10
+              links:
+                self: http://localhost:3000/api/v1/entities/workspaces/demo/metrics/revenue_top_10
+              type: metric
+            - attributes:
+                description: Month and Year (12/2020)
+                primary: true
+                sourceColumn: ''
+                tags:
+                  - Date
+                title: Date - Month/Year
+              id: date.month
+              links:
+                self: http://localhost:3000/api/v1/entities/workspaces/demo/labels/date.month
+              type: label
+            - attributes:
+                content:
+                  format: '#,##0.0%'
+                  maql: SELECT {metric/revenue} / (SELECT {metric/revenue} BY ALL
+                    {attribute/product_id})
+                createdAt: 2000-01-01 00:00
+                title: '% Revenue per Product'
+              id: percent_revenue_per_product
+              links:
+                self: http://localhost:3000/api/v1/entities/workspaces/demo/metrics/percent_revenue_per_product
+              type: metric
+            - attributes:
+                description: Quantity
+                isNullable: true
+                sourceColumn: quantity
+                sourceColumnDataType: NUMERIC
+                tags:
+                  - Order lines
+                title: Quantity
+              id: quantity
+              links:
+                self: http://localhost:3000/api/v1/entities/workspaces/demo/facts/quantity
+              type: fact
+            - attributes: {}
+              id: admin
+              links:
+                self: http://localhost:3000/api/v1/entities/workspaces/demo/userIdentifiers/admin
+              type: userIdentifier
+            - attributes:
+                description: ''
+                tags:
+                  - Date
+                title: Date
+                type: DATE
+              id: date
+              links:
+                self: http://localhost:3000/api/v1/entities/workspaces/demo/datasets/date
+              type: dataset
+            - attributes:
+                description: Category
+                isNullable: true
+                primary: true
+                sourceColumn: category
+                sourceColumnDataType: STRING
+                tags:
+                  - Campaign channels
+                title: Category
+                valueType: TEXT
+              id: campaign_channels.category
+              links:
+                self: http://localhost:3000/api/v1/entities/workspaces/demo/labels/campaign_channels.category
+              type: label
+            - attributes:
+                description: Customer name
+                isNullable: true
+                primary: true
+                sourceColumn: customer_name
+                sourceColumnDataType: STRING
+                tags:
+                  - Customers
+                title: Customer name
+                valueType: TEXT
+              id: customer_name
+              links:
+                self: http://localhost:3000/api/v1/entities/workspaces/demo/labels/customer_name
+              type: label
+            - attributes:
+                description: Type
+                isNullable: true
+                primary: true
+                sourceColumn: type
+                sourceColumnDataType: STRING
+                tags:
+                  - Campaign channels
+                title: Type
+                valueType: TEXT
+              id: type
+              links:
+                self: http://localhost:3000/api/v1/entities/workspaces/demo/labels/type
+              type: label
+            - attributes:
+                description: Region
+                isNullable: true
+                primary: true
+                sourceColumn: region
+                sourceColumnDataType: STRING
+                tags:
+                  - Customers
+                title: Region
+                valueType: TEXT
+              id: region
+              links:
+                self: http://localhost:3000/api/v1/entities/workspaces/demo/labels/region
+              type: label
+            - attributes:
+                description: State
+                isNullable: true
+                primary: true
+                sourceColumn: state
+                sourceColumnDataType: STRING
+                tags:
+                  - Customers
+                title: State
+                valueType: TEXT
+              id: state
+              links:
+                self: http://localhost:3000/api/v1/entities/workspaces/demo/labels/state
+              type: label
+            - attributes:
+                content:
+                  format: '#,##0'
+                  maql: SELECT COUNT({attribute/customer_id},{attribute/order_line_id})
+                createdAt: 2000-01-01 00:00
+                title: '# of Active Customers'
+              id: amount_of_active_customers
+              links:
+                self: http://localhost:3000/api/v1/entities/workspaces/demo/metrics/amount_of_active_customers
+              type: metric
+            - attributes:
+                description: Category
+                isNullable: true
+                primary: true
+                sourceColumn: category
+                sourceColumnDataType: STRING
+                tags:
+                  - Products
+                title: Category
+                valueType: TEXT
+              id: products.category
+              links:
+                self: http://localhost:3000/api/v1/entities/workspaces/demo/labels/products.category
+              type: label
+            - attributes:
+                content:
+                  format: $#,##0
+                  maql: SELECT SUM({fact/spend})
+                createdAt: 2000-01-01 00:00
+                title: Campaign Spend
+              id: campaign_spend
+              links:
+                self: http://localhost:3000/api/v1/entities/workspaces/demo/metrics/campaign_spend
+              type: metric
+            - attributes:
+                content:
+                  format: $#,##0.0
+                  maql: SELECT {metric/revenue} / {metric/campaign_spend}
+                createdAt: 2000-01-01 00:00
+                title: Revenue per Dollar Spent
+              id: revenue_per_dollar_spent
+              links:
+                self: http://localhost:3000/api/v1/entities/workspaces/demo/metrics/revenue_per_dollar_spent
+              type: metric
+          links:
+            next: http://localhost:3000/api/v1/entities/workspaces/demo/visualizationObjects?include=ALL&page=1&size=500
+            self: http://localhost:3000/api/v1/entities/workspaces/demo/visualizationObjects?include=ALL&page=0&size=500
+      headers:
+        Content-Type:
+          - application/json
+        DATE: &id001
+          - PLACEHOLDER
+        Expires:
+          - '0'
+        Pragma:
+          - no-cache
+        X-Content-Type-Options:
+          - nosniff
+        X-GDC-TRACE-ID: *id001
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/packages/gooddata-sdk/tests/catalog/test_catalog_workspace_content.py
+++ b/packages/gooddata-sdk/tests/catalog/test_catalog_workspace_content.py
@@ -23,6 +23,7 @@ from gooddata_sdk import (
     DataSourceValidator,
     GoodDataSdk,
     ObjId,
+    Visualization,
 )
 from gooddata_sdk.compute.model.filter import AbsoluteDateFilter, RelativeDateFilter
 from gooddata_sdk.utils import recreate_directory
@@ -502,3 +503,18 @@ def test_export_definition_analytics_layout(test_config):
         assert deep_eq(analytics_o.analytics.export_definitions, analytics_e.analytics.export_definitions)
     finally:
         safe_delete(_refresh_workspaces, sdk)
+
+
+@gd_vcr.use_cassette(str(_fixtures_dir / "test_get_visualizations_with_parameters.yaml"))
+def test_get_visualizations_with_parameters(test_config):
+    """Verify that visualization objects entity endpoint works correctly after
+    the parameters relationship was added to JsonApiVisualizationObjectOut.
+    The included array type changed from JsonApiVisualizationObjectOutIncludes
+    to JsonApiMetricOutIncludes which now includes JsonApiParameterOutWithLinks.
+    """
+    sdk = GoodDataSdk.create(host_=test_config["host"], token_=test_config["token"])
+    visualizations = sdk.visualizations.get_visualizations(test_config["workspace"])
+    assert len(visualizations) > 0
+    for vis in visualizations:
+        assert isinstance(vis, Visualization)
+        assert vis.id is not None


### PR DESCRIPTION
## Summary

Added integration test for the visualization objects entity endpoint to cover the API change that added a 'parameters' relationship to JsonApiVisualizationObjectOut and changed the 'included' array type from JsonApiVisualizationObjectOutIncludes to JsonApiMetricOutIncludes (which now includes JsonApiParameterOutWithLinks). The existing SDK wrapper code (VisualizationService) required no changes because it already uses _check_return_type=False and SideLoads handles any type of included object. Similarly the AnalyticalDashboard entity response change (added parameters relationship + included) requires no SDK wrapper changes since no SDK method wraps that entity endpoint directly.

**Impact:** modification | **Services:** `gooddata-metadata-client`

## Files changed

- `packages/gooddata-sdk/tests/catalog/test_catalog_workspace_content.py`

## Agent decisions

<details><summary>Decisions (4)</summary>

**No SDK model changes** — Left SDK wrapper code (VisualizationService, SideLoads) unchanged
  - Alternatives: Add explicit parameter handling to VisualizationService, Add a property on Visualization to expose parameter side loads
  - Why: The API change adds parameters to existing response shapes. The VisualizationService already uses _check_return_type=False for all API calls, so it accepts any response shape. SideLoads stores all included objects by type/id key and does not type-check individual entries. The new JsonApiParameterOutWithLinks objects will be automatically included in side loads if present.

**No AnalyticalDashboard entity test** — Only added test for VisualizationService, not for analytical dashboard entity endpoint
  - Alternatives: Add a new SDK method for analytical dashboard entity reads, Test via raw entities_api client call
  - Why: The SDK has no direct wrapper for the analytical dashboard entity endpoint. Dashboard operations in the SDK go through the layout API (declarative model). Adding a test would require either a new SDK method or calling the raw API client directly, which is out of scope for this change.

**Integration test placement** — Added test to test_catalog_workspace_content.py
  - Alternatives: Create a new test file tests/visualization/test_visualization_service_integration.py
  - Why: The VisualizationService is related to workspace content, and all other workspace content integration tests live in this file. No separate visualization service integration test file exists.

**Test assertion style** — Used len > 0 and isinstance checks instead of specific counts
  - Alternatives: Assert specific count (fragile across environments), Assert specific visualization IDs (tightly coupled to demo workspace state)
  - Why: The demo workspace visualization count could vary between environments. The key correctness assertion is that the endpoint returns valid Visualization objects, not a specific count.

</details>

<details><summary>Assumptions to verify (4)</summary>

- The demo test workspace contains at least one visualization object, so len(visualizations) > 0 will be true when the cassette is recorded.
- JsonApiVisualizationObjectOutIncludes was already removed from the generated client (confirmed: no file found at gooddata-api-client/gooddata_api_client/model/json_api_visualization_object_out_includes.py), and no SDK code references it.
- The ty check errors observed (unresolved-import for cattrs, requests, gooddata_code_convertors, etc.) are pre-existing environment setup issues, not introduced by these changes.
- The parameters relationship in analytical dashboards is only relevant to the entity-level API, not the declarative layout API used by CatalogWorkspaceContentService.get_declarative_analytics_model().

</details>

<details><summary>Risks (2)</summary>

- test_get_visualizations_with_parameters will fail if the demo workspace has no visualization objects when the cassette is recorded.
- If the server returns a response where parameters are included in the visualization object included array, the SideLoads class will include them. If any downstream code only expects specific types in side loads, it could break — but inspection shows SideLoads is a generic dict-of-dicts.

</details>

<details><summary>Layers touched (1)</summary>

- **tests** — Added test_get_visualizations_with_parameters integration test and Visualization import
  - `packages/gooddata-sdk/tests/catalog/test_catalog_workspace_content.py`

</details>

## Source commits (gdc-nas)

- `25451ef` feat(metadata-api): add parameters to analyticalDashboards
- `cf3402f` feat(metadata-api): add parameters to visualizations

<details><summary>OpenAPI diff</summary>

```diff
@@ gooddata-metadata-client.json (JsonApiAnalyticalDashboardOutDocument.relationships) @@
+              "parameters": {
+                "properties": { "data": { "$ref": "JsonApiParameterToManyLinkage" } },
+                "required": ["data"]
+              }
@@ gooddata-metadata-client.json (JsonApiAnalyticalDashboardOutList.included) @@
+          { "$ref": "JsonApiParameterOutWithLinks" }
@@ gooddata-metadata-client.json (JsonApiVisualizationObjectOutDocument.relationships) @@
+              "parameters": {
+                "properties": { "data": { "$ref": "JsonApiParameterToManyLinkage" } }
+              }
@@ gooddata-metadata-client.json (JsonApiVisualizationObjectOutDocument.included ref) @@
-              "$ref": "JsonApiVisualizationObjectOutIncludes"
+              "$ref": "JsonApiMetricOutIncludes"
-      "JsonApiVisualizationObjectOutIncludes": { "oneOf": [ Attribute, Dataset, Fact, Label, Metric, UserIdentifier ] }
```
</details>

## [Workflow run](https://github.com/gooddata/gdc-nas/actions/runs/25718559682)

---
*Generated by SDK OpenAPI Sync workflow*