### PR TITLE
feat(gooddata-sdk): [AUTO] Add CustomUserApplicationSetting CRUD endpoints for per-user app settings

### DIFF
--- a/packages/gooddata-sdk/src/gooddata_sdk/__init__.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/__init__.py
@@ -181,6 +181,10 @@ from gooddata_sdk.catalog.user.declarative_model.user_group import (
     CatalogDeclarativeUserGroupPermission,
     CatalogDeclarativeUserGroups,
 )
+from gooddata_sdk.catalog.user.entity_model.custom_user_application_setting import (
+    CatalogCustomUserApplicationSetting,
+    CatalogCustomUserApplicationSettingAttributes,
+)
 from gooddata_sdk.catalog.user.entity_model.user import CatalogUser
 from gooddata_sdk.catalog.user.entity_model.user_group import CatalogUserGroup
 from gooddata_sdk.catalog.user.management_model.management import (

--- a/packages/gooddata-sdk/src/gooddata_sdk/catalog/user/entity_model/custom_user_application_setting.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/catalog/user/entity_model/custom_user_application_setting.py
@@ -1,0 +1,115 @@
+# (C) 2026 GoodData Corporation
+from __future__ import annotations
+
+from typing import Any
+
+import attrs
+from gooddata_api_client.model.json_api_custom_user_application_setting_in import (
+    JsonApiCustomUserApplicationSettingIn,
+)
+from gooddata_api_client.model.json_api_custom_user_application_setting_in_attributes import (
+    JsonApiCustomUserApplicationSettingInAttributes,
+)
+from gooddata_api_client.model.json_api_custom_user_application_setting_in_document import (
+    JsonApiCustomUserApplicationSettingInDocument,
+)
+from gooddata_api_client.model.json_api_custom_user_application_setting_post_optional_id import (
+    JsonApiCustomUserApplicationSettingPostOptionalId,
+)
+from gooddata_api_client.model.json_api_custom_user_application_setting_post_optional_id_document import (
+    JsonApiCustomUserApplicationSettingPostOptionalIdDocument,
+)
+
+from gooddata_sdk.catalog.base import Base
+
+
+@attrs.define(kw_only=True)
+class CatalogCustomUserApplicationSettingAttributes(Base):
+    """Attributes of a custom user application setting."""
+
+    application_name: str
+    content: dict[str, Any]
+    workspace_id: str | None = None
+
+    @staticmethod
+    def client_class() -> type[JsonApiCustomUserApplicationSettingInAttributes]:
+        return JsonApiCustomUserApplicationSettingInAttributes
+
+
+@attrs.define(kw_only=True)
+class CatalogCustomUserApplicationSetting(Base):
+    """Entity representing a per-user application setting."""
+
+    id: str
+    attributes: CatalogCustomUserApplicationSettingAttributes
+
+    @staticmethod
+    def client_class() -> type[JsonApiCustomUserApplicationSettingIn]:
+        return JsonApiCustomUserApplicationSettingIn
+
+    @classmethod
+    def init(
+        cls,
+        setting_id: str,
+        application_name: str,
+        content: dict[str, Any],
+        *,
+        workspace_id: str | None = None,
+    ) -> CatalogCustomUserApplicationSetting:
+        """Convenience factory to create a setting entity without constructing attributes manually."""
+        return cls(
+            id=setting_id,
+            attributes=CatalogCustomUserApplicationSettingAttributes(
+                application_name=application_name,
+                content=content,
+                workspace_id=workspace_id,
+            ),
+        )
+
+    @classmethod
+    def from_api(cls, entity: dict[str, Any]) -> CatalogCustomUserApplicationSetting:
+        ea = entity.get("attributes", {})
+        return cls(
+            id=entity["id"],
+            attributes=CatalogCustomUserApplicationSettingAttributes(
+                application_name=ea["applicationName"],
+                content=ea["content"],
+                workspace_id=ea.get("workspaceId"),
+            ),
+        )
+
+    def as_post_document(self) -> JsonApiCustomUserApplicationSettingPostOptionalIdDocument:
+        """Serialize to the document form used by the POST (create) endpoint."""
+        kwargs: dict[str, Any] = {}
+        if self.attributes.workspace_id is not None:
+            kwargs["workspace_id"] = self.attributes.workspace_id
+        api_attrs = JsonApiCustomUserApplicationSettingInAttributes(
+            application_name=self.attributes.application_name,
+            content=self.attributes.content,
+            _check_type=False,
+            **kwargs,
+        )
+        data = JsonApiCustomUserApplicationSettingPostOptionalId(
+            attributes=api_attrs,
+            id=self.id,
+            _check_type=False,
+        )
+        return JsonApiCustomUserApplicationSettingPostOptionalIdDocument(data=data, _check_type=False)
+
+    def as_patch_document(self) -> JsonApiCustomUserApplicationSettingInDocument:
+        """Serialize to the document form used by the PATCH (update) endpoint."""
+        kwargs: dict[str, Any] = {}
+        if self.attributes.workspace_id is not None:
+            kwargs["workspace_id"] = self.attributes.workspace_id
+        api_attrs = JsonApiCustomUserApplicationSettingInAttributes(
+            application_name=self.attributes.application_name,
+            content=self.attributes.content,
+            _check_type=False,
+            **kwargs,
+        )
+        data = JsonApiCustomUserApplicationSettingIn(
+            attributes=api_attrs,
+            id=self.id,
+            _check_type=False,
+        )
+        return JsonApiCustomUserApplicationSettingInDocument(data=data, _check_type=False)

--- a/packages/gooddata-sdk/src/gooddata_sdk/catalog/user/service.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/catalog/user/service.py
@@ -13,6 +13,9 @@ from gooddata_sdk.catalog.user.declarative_model.user import CatalogDeclarativeU
 from gooddata_sdk.catalog.user.declarative_model.user_and_user_groups import CatalogDeclarativeUsersUserGroups
 from gooddata_sdk.catalog.user.declarative_model.user_group import CatalogDeclarativeUserGroups
 from gooddata_sdk.catalog.user.entity_model.api_token import CatalogApiToken
+from gooddata_sdk.catalog.user.entity_model.custom_user_application_setting import (
+    CatalogCustomUserApplicationSetting,
+)
 from gooddata_sdk.catalog.user.entity_model.user import CatalogUser, CatalogUserDocument
 from gooddata_sdk.catalog.user.entity_model.user_group import CatalogUserGroup, CatalogUserGroupDocument
 from gooddata_sdk.catalog.user.management_model.management import (
@@ -458,3 +461,98 @@ class CatalogUserService(CatalogServiceBase):
 
     def delete_user_api_token(self, user_id: str, api_token_id: str) -> None:
         self._entities_api.delete_entity_api_tokens(user_id, api_token_id)
+
+    # Custom user application settings
+
+    def list_custom_user_application_settings(self, user_id: str) -> list[CatalogCustomUserApplicationSetting]:
+        """List all custom application settings for a user.
+
+        Args:
+            user_id (str):
+                User identification string.
+
+        Returns:
+            list[CatalogCustomUserApplicationSetting]:
+                List of custom user application setting entities.
+        """
+        get_settings = functools.partial(
+            self._entities_api.get_all_entities_custom_user_application_settings,
+            user_id,
+            _check_return_type=False,
+        )
+        settings = load_all_entities(get_settings)
+        return [CatalogCustomUserApplicationSetting.from_api(v) for v in settings.data]
+
+    def get_custom_user_application_setting(self, user_id: str, setting_id: str) -> CatalogCustomUserApplicationSetting:
+        """Get a single custom application setting for a user.
+
+        Args:
+            user_id (str):
+                User identification string.
+            setting_id (str):
+                Setting identification string.
+
+        Returns:
+            CatalogCustomUserApplicationSetting:
+                Custom user application setting entity.
+        """
+        result = self._entities_api.get_entity_custom_user_application_settings(
+            user_id, setting_id, _check_return_type=False
+        )
+        return CatalogCustomUserApplicationSetting.from_api(result.data)
+
+    def create_custom_user_application_setting(
+        self, user_id: str, setting: CatalogCustomUserApplicationSetting
+    ) -> CatalogCustomUserApplicationSetting:
+        """Create a custom application setting for a user.
+
+        Args:
+            user_id (str):
+                User identification string.
+            setting (CatalogCustomUserApplicationSetting):
+                Setting entity to create.
+
+        Returns:
+            CatalogCustomUserApplicationSetting:
+                The newly created custom user application setting entity.
+        """
+        document = setting.as_post_document()
+        result = self._entities_api.create_entity_custom_user_application_settings(
+            user_id, document, _check_return_type=False
+        )
+        return CatalogCustomUserApplicationSetting.from_api(result.data)
+
+    def update_custom_user_application_setting(
+        self, user_id: str, setting: CatalogCustomUserApplicationSetting
+    ) -> CatalogCustomUserApplicationSetting:
+        """Update (patch) a custom application setting for a user.
+
+        Args:
+            user_id (str):
+                User identification string.
+            setting (CatalogCustomUserApplicationSetting):
+                Setting entity with updated values.
+
+        Returns:
+            CatalogCustomUserApplicationSetting:
+                The updated custom user application setting entity.
+        """
+        document = setting.as_patch_document()
+        result = self._entities_api.update_entity_custom_user_application_settings(
+            user_id, setting.id, document, _check_return_type=False
+        )
+        return CatalogCustomUserApplicationSetting.from_api(result.data)
+
+    def delete_custom_user_application_setting(self, user_id: str, setting_id: str) -> None:
+        """Delete a custom application setting for a user.
+
+        Args:
+            user_id (str):
+                User identification string.
+            setting_id (str):
+                Setting identification string.
+
+        Returns:
+            None
+        """
+        self._entities_api.delete_entity_custom_user_application_settings(user_id, setting_id)

--- a/packages/gooddata-sdk/tests/catalog/fixtures/users/test_custom_user_application_settings.yaml
+++ b/packages/gooddata-sdk/tests/catalog/fixtures/users/test_custom_user_application_settings.yaml
@@ -1,0 +1,288 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - application/json
+        Accept-Encoding:
+          - br, gzip, deflate
+        X-GDC-VALIDATE-RELATIONS:
+          - 'true'
+        X-Requested-With:
+          - XMLHttpRequest
+      method: GET
+      uri: http://localhost:3000/api/v1/entities/users/demo/customUserApplicationSettings?page=0&size=500
+    response:
+      body:
+        string:
+          data: []
+          links:
+            next: http://localhost:3000/api/v1/entities/users/demo/customUserApplicationSettings?page=1&size=500
+            self: http://localhost:3000/api/v1/entities/users/demo/customUserApplicationSettings?page=0&size=500
+      headers:
+        Content-Type:
+          - application/json
+        DATE: &id001
+          - PLACEHOLDER
+        Expires:
+          - '0'
+        Pragma:
+          - no-cache
+        X-Content-Type-Options:
+          - nosniff
+        X-GDC-TRACE-ID: *id001
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        data:
+          attributes:
+            applicationName: my-app
+            content:
+              language: en
+              theme: dark
+          id: test-setting-1
+          type: customUserApplicationSetting
+      headers:
+        Accept:
+          - application/json
+        Accept-Encoding:
+          - br, gzip, deflate
+        Content-Type:
+          - application/json
+        X-GDC-VALIDATE-RELATIONS:
+          - 'true'
+        X-Requested-With:
+          - XMLHttpRequest
+      method: POST
+      uri: http://localhost:3000/api/v1/entities/users/demo/customUserApplicationSettings
+    response:
+      body:
+        string:
+          data:
+            attributes:
+              applicationName: my-app
+              content:
+                language: en
+                theme: dark
+            id: test-setting-1
+            type: customUserApplicationSetting
+          links:
+            self: http://localhost:3000/api/v1/entities/users/demo/customUserApplicationSettings/test-setting-1
+      headers:
+        Content-Type:
+          - application/json
+        DATE: *id001
+        Expires:
+          - '0'
+        Pragma:
+          - no-cache
+        X-Content-Type-Options:
+          - nosniff
+        X-GDC-TRACE-ID: *id001
+      status:
+        code: 201
+        message: Created
+  - request:
+      body: null
+      headers:
+        Accept:
+          - application/json
+        Accept-Encoding:
+          - br, gzip, deflate
+        X-GDC-VALIDATE-RELATIONS:
+          - 'true'
+        X-Requested-With:
+          - XMLHttpRequest
+      method: GET
+      uri: http://localhost:3000/api/v1/entities/users/demo/customUserApplicationSettings/test-setting-1
+    response:
+      body:
+        string:
+          data:
+            attributes:
+              applicationName: my-app
+              content:
+                language: en
+                theme: dark
+            id: test-setting-1
+            type: customUserApplicationSetting
+          links:
+            self: http://localhost:3000/api/v1/entities/users/demo/customUserApplicationSettings/test-setting-1
+      headers:
+        Content-Type:
+          - application/json
+        DATE: *id001
+        Expires:
+          - '0'
+        Pragma:
+          - no-cache
+        X-Content-Type-Options:
+          - nosniff
+        X-GDC-TRACE-ID: *id001
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Accept:
+          - application/json
+        Accept-Encoding:
+          - br, gzip, deflate
+        X-GDC-VALIDATE-RELATIONS:
+          - 'true'
+        X-Requested-With:
+          - XMLHttpRequest
+      method: GET
+      uri: http://localhost:3000/api/v1/entities/users/demo/customUserApplicationSettings?page=0&size=500
+    response:
+      body:
+        string:
+          data:
+            - attributes:
+                applicationName: my-app
+                content:
+                  language: en
+                  theme: dark
+              id: test-setting-1
+              links:
+                self: http://localhost:3000/api/v1/entities/users/demo/customUserApplicationSettings/test-setting-1
+              type: customUserApplicationSetting
+          links:
+            next: http://localhost:3000/api/v1/entities/users/demo/customUserApplicationSettings?page=1&size=500
+            self: http://localhost:3000/api/v1/entities/users/demo/customUserApplicationSettings?page=0&size=500
+      headers:
+        Content-Type:
+          - application/json
+        DATE: *id001
+        Expires:
+          - '0'
+        Pragma:
+          - no-cache
+        X-Content-Type-Options:
+          - nosniff
+        X-GDC-TRACE-ID: *id001
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        data:
+          attributes:
+            applicationName: my-app
+            content:
+              language: fr
+              theme: light
+          id: test-setting-1
+          type: customUserApplicationSetting
+      headers:
+        Accept:
+          - application/json
+        Accept-Encoding:
+          - br, gzip, deflate
+        Content-Type:
+          - application/json
+        X-GDC-VALIDATE-RELATIONS:
+          - 'true'
+        X-Requested-With:
+          - XMLHttpRequest
+      method: PUT
+      uri: http://localhost:3000/api/v1/entities/users/demo/customUserApplicationSettings/test-setting-1
+    response:
+      body:
+        string:
+          data:
+            attributes:
+              applicationName: my-app
+              content:
+                language: fr
+                theme: light
+            id: test-setting-1
+            type: customUserApplicationSetting
+          links:
+            self: http://localhost:3000/api/v1/entities/users/demo/customUserApplicationSettings/test-setting-1
+      headers:
+        Content-Type:
+          - application/json
+        DATE: *id001
+        Expires:
+          - '0'
+        Pragma:
+          - no-cache
+        X-Content-Type-Options:
+          - nosniff
+        X-GDC-TRACE-ID: *id001
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Accept:
+          - application/json
+        Accept-Encoding:
+          - br, gzip, deflate
+        X-GDC-VALIDATE-RELATIONS:
+          - 'true'
+        X-Requested-With:
+          - XMLHttpRequest
+      method: GET
+      uri: http://localhost:3000/api/v1/entities/users/demo/customUserApplicationSettings/test-setting-1
+    response:
+      body:
+        string:
+          data:
+            attributes:
+              applicationName: my-app
+              content:
+                language: fr
+                theme: light
+            id: test-setting-1
+            type: customUserApplicationSetting
+          links:
+            self: http://localhost:3000/api/v1/entities/users/demo/customUserApplicationSettings/test-setting-1
+      headers:
+        Content-Type:
+          - application/json
+        DATE: *id001
+        Expires:
+          - '0'
+        Pragma:
+          - no-cache
+        X-Content-Type-Options:
+          - nosniff
+        X-GDC-TRACE-ID: *id001
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Accept-Encoding:
+          - br, gzip, deflate
+        X-GDC-VALIDATE-RELATIONS:
+          - 'true'
+        X-Requested-With:
+          - XMLHttpRequest
+      method: DELETE
+      uri: http://localhost:3000/api/v1/entities/users/demo/customUserApplicationSettings/test-setting-1
+    response:
+      body:
+        string: ''
+      headers:
+        Content-Type:
+          - application/vnd.gooddata.api+json
+        DATE: *id001
+        Expires:
+          - '0'
+        Pragma:
+          - no-cache
+        X-Content-Type-Options:
+          - nosniff
+        X-GDC-TRACE-ID: *id001
+      status:
+        code: 204
+        message: No Content
+version: 1

--- a/packages/gooddata-sdk/tests/catalog/test_catalog_user_service.py
+++ b/packages/gooddata-sdk/tests/catalog/test_catalog_user_service.py
@@ -27,6 +27,7 @@ from pathlib import Path
 import pytest
 from gooddata_sdk import (
     CatalogAssigneeIdentifier,
+    CatalogCustomUserApplicationSetting,
     CatalogDeclarativeUser,
     CatalogDeclarativeUserGroup,
     CatalogDeclarativeUserGroups,
@@ -774,6 +775,63 @@ def test_api_tokens(test_config):
         assert tokens[0].bearer_token is None
     finally:
         safe_delete(sdk.catalog_user.delete_user_api_token, test_config["demo_user"], token_id)
+
+
+# Custom user application settings
+
+
+@gd_vcr.use_cassette(str(_fixtures_dir / "test_custom_user_application_settings.yaml"))
+def test_custom_user_application_settings(test_config):
+    sdk = GoodDataSdk.create(host_=test_config["host"], token_=test_config["token"])
+    user_id = test_config["demo_user"]
+    setting_id = "test-setting-1"
+    application_name = "my-app"
+    content = {"theme": "dark", "language": "en"}
+    updated_content = {"theme": "light", "language": "fr"}
+
+    initial_settings = sdk.catalog_user.list_custom_user_application_settings(user_id)
+    initial_count = len(initial_settings)
+
+    try:
+        # Create
+        setting = CatalogCustomUserApplicationSetting.init(
+            setting_id=setting_id,
+            application_name=application_name,
+            content=content,
+        )
+        created = sdk.catalog_user.create_custom_user_application_setting(user_id, setting)
+        assert created.id == setting_id
+        assert created.attributes.application_name == application_name
+        assert created.attributes.content == content
+        assert created.attributes.workspace_id is None
+
+        # Get
+        fetched = sdk.catalog_user.get_custom_user_application_setting(user_id, setting_id)
+        assert fetched.id == setting_id
+        assert fetched.attributes.application_name == application_name
+        assert fetched.attributes.content == content
+
+        # List
+        all_settings = sdk.catalog_user.list_custom_user_application_settings(user_id)
+        assert len(all_settings) == initial_count + 1
+        assert any(s.id == setting_id for s in all_settings)
+
+        # Update
+        updated_setting = CatalogCustomUserApplicationSetting.init(
+            setting_id=setting_id,
+            application_name=application_name,
+            content=updated_content,
+        )
+        updated = sdk.catalog_user.update_custom_user_application_setting(user_id, updated_setting)
+        assert updated.id == setting_id
+        assert updated.attributes.content == updated_content
+
+        # Verify update
+        re_fetched = sdk.catalog_user.get_custom_user_application_setting(user_id, setting_id)
+        assert re_fetched.attributes.content == updated_content
+
+    finally:
+        safe_delete(sdk.catalog_user.delete_custom_user_application_setting, user_id, setting_id)
 
 
 # Help functions


### PR DESCRIPTION
## Summary

Added full SDK support for the new `CustomUserApplicationSetting` CRUD endpoints. Created the entity model class `CatalogCustomUserApplicationSetting` with helper methods for serializing to the two distinct API document types (POST vs PATCH). Added five service methods to `CatalogUserService` (list, get, create, update, delete). Exported the new classes from the public `__init__.py`. Added an integration test covering the full CRUD lifecycle.

**Impact:** new_feature | **Services:** `gooddata-metadata-client`

## Files changed

- `packages/gooddata-sdk/src/gooddata_sdk/catalog/user/entity_model/custom_user_application_setting.py`
- `packages/gooddata-sdk/src/gooddata_sdk/catalog/user/service.py`
- `packages/gooddata-sdk/src/gooddata_sdk/__init__.py`
- `packages/gooddata-sdk/tests/catalog/test_catalog_user_service.py`

## Agent decisions

<details><summary>Decisions (3)</summary>

**document serialization helpers vs document wrapper classes** — Added as_post_document() and as_patch_document() directly on the entity class rather than separate CatalogXxxDocument / CatalogXxxPatchDocument wrapper classes
  - Alternatives: Create two separate document wrapper classes (CatalogCustomUserApplicationSettingDocument and CatalogCustomUserApplicationSettingInDocument), Construct API objects inline in the service methods (like api_token create does)
  - Why: The create endpoint requires JsonApiCustomUserApplicationSettingPostOptionalIdDocument while update requires JsonApiCustomUserApplicationSettingInDocument — two different types. A single client_class() can only point to one, so the standard 3-class wrapper pattern doesn't cleanly handle this asymmetry. Consolidating both serialization paths on the entity avoids introducing wrapper classes with confusing client_class() pointing.

**camelCase attribute access in from_api** — Use ea['applicationName'] / ea.get('workspaceId') (camelCase) when accessing raw API dict in from_api()
  - Alternatives: snake_case keys — incorrect for raw API dicts
  - Why: When _check_return_type=False the response is a raw dict using camelCase keys (as set by the API). Other from_api overrides in the codebase (e.g. CatalogLlmProvider.from_api) also use camelCase key access.

**workspace_id as optional kwarg** — workspace_id defaults to None in CatalogCustomUserApplicationSettingAttributes and passed to API only when non-None
  - Alternatives: Always send workspace_id even when None
  - Why: The OpenAPI spec marks workspaceId as optional (nullable). Null means user-level scope. The JsonApiCustomUserApplicationSettingInAttributes constructor treats workspace_id as optional, so we gate it with a kwargs dict to avoid sending null explicitly.

</details>

<details><summary>Assumptions to verify (4)</summary>

- I assumed entity attributes are returned in camelCase in the raw API response dict when _check_return_type=False (based on api_token pattern and LLM provider from_api examples)
- I assumed the create operation always supplies an id (our SDK entity requires id), so using PostOptionalId variant with id set is correct
- I assumed the update endpoint (PATCH) is called update_entity_custom_user_application_settings (not patch_entity_...) based on the entities_api grep output showing that operation_id
- I assumed demo_user ('demo' user from gd_test_config.yaml) is a safe user to create/delete test settings on, as it has no pre-existing custom settings based on the existing api_tokens test pattern

</details>

<details><summary>Risks (2)</summary>

- test_custom_user_application_settings will fail on first cassette recording if the demo user already has settings with id 'test-setting-1' from a previous failed test run — the finally block should clean it up
- If the PATCH endpoint returns 204 No Content instead of the updated entity, from_api(result.data) will fail — some PATCH endpoints return empty body; needs verification against real server

</details>

<details><summary>Layers touched (3)</summary>

- **entity_model** — New file — CatalogCustomUserApplicationSetting and CatalogCustomUserApplicationSettingAttributes
  - `packages/gooddata-sdk/src/gooddata_sdk/catalog/user/entity_model/custom_user_application_setting.py`
- **public_api** — Five new CRUD service methods + public exports
  - `packages/gooddata-sdk/src/gooddata_sdk/catalog/user/service.py`
  - `packages/gooddata-sdk/src/gooddata_sdk/__init__.py`
- **tests** — Added test_custom_user_application_settings integration test
  - `packages/gooddata-sdk/tests/catalog/test_catalog_user_service.py`

</details>

## Source commits (gdc-nas)

- `827a35d` feat(metadata-api): add CustomUserApplicationSetting endpoint (#22399)

<details><summary>OpenAPI diff</summary>

```diff
@@ gooddata-metadata-client.json @@
+      "JsonApiCustomUserApplicationSettingIn": { "description": "JSON:API representation of customUserApplicationSetting entity.", "properties": { "applicationName", "content", "workspaceId" } }
+      "JsonApiCustomUserApplicationSettingInDocument": { ... }
+      "JsonApiCustomUserApplicationSettingOut": { ... }
+      "JsonApiCustomUserApplicationSettingOutDocument": { ... }
+      "JsonApiCustomUserApplicationSettingOutList": { ... }
+      "JsonApiCustomUserApplicationSettingOutWithLinks": { ... }
+      "JsonApiCustomUserApplicationSettingPostOptionalId": { ... }
+      "JsonApiCustomUserApplicationSettingPostOptionalIdDocument": { ... }
+    "/api/v1/entities/users/{userId}/customUserApplicationSettings": { "get": { "operationId": "getAllEntities@CustomUserApplicationSettings" }, "post": { "operationId": "createEntity@CustomUserApplicationSettings" } }
+    "/api/v1/entities/users/{userId}/customUserApplicationSettings/{id}": { "get", "patch", "delete" }
```
</details>

## [Workflow run](https://github.com/gooddata/gdc-nas/actions/runs/25718559682)

---
*Generated by SDK OpenAPI Sync workflow*