### PR TITLE
feat(gooddata-sdk): [AUTO] Add DashboardMeasureValueFilter with comparison and range conditions

### DIFF
--- a/packages/gooddata-sdk/src/gooddata_sdk/__init__.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/__init__.py
@@ -215,6 +215,13 @@ from gooddata_sdk.catalog.workspace.declarative_model.workspace.analytics_model.
     CatalogDeclarativeMemoryItem,
     CatalogDeclarativeMetric,
 )
+from gooddata_sdk.catalog.workspace.declarative_model.workspace.analytics_model.dashboard_filters import (
+    CatalogDashboardCompoundComparisonCondition,
+    CatalogDashboardCompoundConditionItem,
+    CatalogDashboardCompoundRangeCondition,
+    CatalogDashboardMeasureValueFilter,
+    CatalogDashboardMeasureValueFilterBody,
+)
 from gooddata_sdk.catalog.workspace.declarative_model.workspace.analytics_model.export_definition import (
     CatalogDeclarativeExportDefinition,
     CatalogDeclarativeExportDefinitionRequestPayload,

--- a/packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/declarative_model/workspace/analytics_model/dashboard_filters.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/declarative_model/workspace/analytics_model/dashboard_filters.py
@@ -1,0 +1,227 @@
+# (C) 2026 GoodData Corporation
+from __future__ import annotations
+
+from typing import Any, Literal, Union
+
+import attrs
+from cattrs import global_converter, structure
+from gooddata_api_client.model.dashboard_compound_comparison_condition import DashboardCompoundComparisonCondition
+from gooddata_api_client.model.dashboard_compound_range_condition import DashboardCompoundRangeCondition
+from gooddata_api_client.model.dashboard_measure_value_filter import DashboardMeasureValueFilter
+from gooddata_api_client.model.dashboard_measure_value_filter_measure_value_filter import (
+    DashboardMeasureValueFilterMeasureValueFilter,
+)
+
+from gooddata_sdk.catalog.base import Base
+
+ComparisonOperator = Literal[
+    "GREATER_THAN",
+    "GREATER_THAN_OR_EQUAL_TO",
+    "LESS_THAN",
+    "LESS_THAN_OR_EQUAL_TO",
+    "EQUAL_TO",
+    "NOT_EQUAL_TO",
+]
+
+RangeOperator = Literal["BETWEEN", "NOT_BETWEEN"]
+
+
+@attrs.define(kw_only=True)
+class CatalogDashboardCompoundComparisonCondition(Base):
+    """Comparison condition for a dashboard measure value filter.
+
+    Filters dashboard data where the measure satisfies a comparison
+    relation (e.g. greater than, equal to) against a single value.
+    """
+
+    operator: str
+    value: float
+
+    @staticmethod
+    def client_class() -> type[DashboardCompoundComparisonCondition]:
+        return DashboardCompoundComparisonCondition
+
+    def to_api(self) -> DashboardCompoundComparisonCondition:
+        return DashboardCompoundComparisonCondition(
+            operator=self.operator,
+            value=self.value,
+            _check_type=False,
+        )
+
+    @classmethod
+    def from_api(cls, entity: dict[str, Any]) -> CatalogDashboardCompoundComparisonCondition:
+        return cls(
+            operator=entity["operator"],
+            value=float(entity["value"]),
+        )
+
+
+@attrs.define(kw_only=True)
+class CatalogDashboardCompoundRangeCondition(Base):
+    """Range condition for a dashboard measure value filter.
+
+    Filters dashboard data where the measure falls within (or outside)
+    a numeric range defined by ``from_value`` and ``to``.
+    """
+
+    from_value: float
+    operator: str
+    to: float
+
+    @staticmethod
+    def client_class() -> type[DashboardCompoundRangeCondition]:
+        return DashboardCompoundRangeCondition
+
+    def to_api(self) -> DashboardCompoundRangeCondition:
+        return DashboardCompoundRangeCondition(
+            _from=self.from_value,
+            operator=self.operator,
+            to=self.to,
+            _check_type=False,
+        )
+
+    @classmethod
+    def from_api(cls, entity: dict[str, Any]) -> CatalogDashboardCompoundRangeCondition:
+        # The JSON key is "from"; the API client Python attribute is "_from";
+        # after to_dict() it appears as "from" (camelCase=True) or "_from" (camelCase=False).
+        from_val = entity.get("from_value") or entity.get("from") or entity.get("_from")
+        return cls(
+            from_value=float(from_val),
+            operator=entity["operator"],
+            to=float(entity["to"]),
+        )
+
+
+# Union type alias used as the element type for ``conditions``.
+CatalogDashboardCompoundConditionItem = Union[
+    CatalogDashboardCompoundComparisonCondition,
+    CatalogDashboardCompoundRangeCondition,
+]
+
+
+def _structure_condition_item(v: dict[str, Any], _: Any) -> CatalogDashboardCompoundConditionItem:
+    """Discriminate between comparison and range conditions.
+
+    Comparison conditions carry a ``value`` key; range conditions carry
+    ``from`` / ``_from`` / ``from_value`` instead.
+    """
+    if "value" in v:
+        return structure(v, CatalogDashboardCompoundComparisonCondition)
+    return structure(v, CatalogDashboardCompoundRangeCondition)
+
+
+global_converter.register_structure_hook(
+    CatalogDashboardCompoundConditionItem,  # type: ignore[arg-type]
+    _structure_condition_item,
+)
+
+
+@attrs.define(kw_only=True)
+class CatalogDashboardMeasureValueFilterBody(Base):
+    """Inner body of a :class:`CatalogDashboardMeasureValueFilter`.
+
+    Attributes:
+        conditions: One or more compound conditions (comparison or range).
+            Multiple conditions are combined with OR logic.
+        measure: IdentifierRef dict pointing to the measure to filter on,
+            e.g. ``{"identifier": {"id": "metric/revenue", "type": "metric"}}``.
+        local_identifier: Optional local identifier for the filter within
+            a dashboard layout.
+        title: Optional human-readable label for the filter.
+    """
+
+    conditions: list[CatalogDashboardCompoundConditionItem]
+    measure: dict[str, Any]
+    local_identifier: str | None = None
+    title: str | None = None
+
+    @staticmethod
+    def client_class() -> type[DashboardMeasureValueFilterMeasureValueFilter]:
+        return DashboardMeasureValueFilterMeasureValueFilter
+
+    def to_api(self) -> DashboardMeasureValueFilterMeasureValueFilter:
+        kwargs: dict[str, Any] = {}
+        if self.local_identifier is not None:
+            kwargs["local_identifier"] = self.local_identifier
+        if self.title is not None:
+            kwargs["title"] = self.title
+        return DashboardMeasureValueFilterMeasureValueFilter(
+            conditions=[c.to_api() for c in self.conditions],
+            measure=self.measure,
+            _check_type=False,
+            **kwargs,
+        )
+
+    @classmethod
+    def from_api(cls, entity: dict[str, Any]) -> CatalogDashboardMeasureValueFilterBody:
+        local_id = entity.get("local_identifier") or entity.get("localIdentifier")
+        return cls(
+            conditions=[_condition_item_from_dict(c) for c in entity.get("conditions", [])],
+            measure=entity["measure"],
+            local_identifier=local_id,
+            title=entity.get("title"),
+        )
+
+
+def _condition_item_from_dict(v: dict[str, Any]) -> CatalogDashboardCompoundConditionItem:
+    """Construct the correct condition subtype from a plain dict."""
+    if "value" in v:
+        return CatalogDashboardCompoundComparisonCondition(
+            operator=v["operator"],
+            value=float(v["value"]),
+        )
+    from_val = v.get("from_value") or v.get("from") or v.get("_from")
+    return CatalogDashboardCompoundRangeCondition(
+        from_value=float(from_val),
+        operator=v["operator"],
+        to=float(v["to"]),
+    )
+
+
+@attrs.define(kw_only=True)
+class CatalogDashboardMeasureValueFilter(Base):
+    """Dashboard filter that restricts visible data by a measure's value.
+
+    This filter type can appear as an element of
+    ``DashboardFilter.oneOf`` and may be used in dashboard filter
+    contexts or as a filter override in tabular dashboard exports.
+
+    Example::
+
+        from gooddata_sdk import (
+            CatalogDashboardCompoundComparisonCondition,
+            CatalogDashboardMeasureValueFilter,
+            CatalogDashboardMeasureValueFilterBody,
+        )
+
+        mvf = CatalogDashboardMeasureValueFilter(
+            measure_value_filter=CatalogDashboardMeasureValueFilterBody(
+                conditions=[
+                    CatalogDashboardCompoundComparisonCondition(
+                        operator="GREATER_THAN",
+                        value=1000.0,
+                    )
+                ],
+                measure={"identifier": {"id": "metric/revenue", "type": "metric"}},
+                title="Revenue > 1 000",
+            )
+        )
+    """
+
+    measure_value_filter: CatalogDashboardMeasureValueFilterBody
+
+    @staticmethod
+    def client_class() -> type[DashboardMeasureValueFilter]:
+        return DashboardMeasureValueFilter
+
+    def to_api(self) -> DashboardMeasureValueFilter:
+        return DashboardMeasureValueFilter(
+            measure_value_filter=self.measure_value_filter.to_api(),
+            _check_type=False,
+        )
+
+    @classmethod
+    def from_api(cls, entity: dict[str, Any]) -> CatalogDashboardMeasureValueFilter:
+        # Accept both camelCase (from live API) and snake_case (from to_dict round-trip).
+        raw_body = entity.get("measure_value_filter") or entity.get("measureValueFilter")
+        return cls(measure_value_filter=CatalogDashboardMeasureValueFilterBody.from_api(raw_body))

--- a/packages/gooddata-sdk/tests/catalog/fixtures/workspace_content/test_dashboard_measure_value_filter.yaml
+++ b/packages/gooddata-sdk/tests/catalog/fixtures/workspace_content/test_dashboard_measure_value_filter.yaml
@@ -1,0 +1,5439 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - application/json
+        Accept-Encoding:
+          - br, gzip, deflate
+        X-GDC-VALIDATE-RELATIONS:
+          - 'true'
+        X-Requested-With:
+          - XMLHttpRequest
+      method: GET
+      uri: http://localhost:3000/api/v1/layout/workspaces/demo/analyticsModel?exclude=ACTIVITY_INFO
+    response:
+      body:
+        string:
+          analytics:
+            analyticalDashboardExtensions: []
+            analyticalDashboards:
+              - content:
+                  filterContextRef:
+                    identifier:
+                      id: campaign_name_filter
+                      type: filterContext
+                  layout:
+                    sections:
+                      - header:
+                          description: The first insight shows a breakdown of spend
+                            by category and campaign. The second shows revenue per
+                            $ spend, for each campaign, to demonstrate, how campaigns
+                            are successful.
+                          title: Spend breakdown and Revenue
+                        items:
+                          - size:
+                              xl:
+                                gridWidth: 6
+                            type: IDashboardLayoutItem
+                            widget:
+                              description: ''
+                              drills: []
+                              ignoreDashboardFilters: []
+                              insight:
+                                identifier:
+                                  id: campaign_spend
+                                  type: visualizationObject
+                              properties: {}
+                              title: Campaign Spend
+                              type: insight
+                          - size:
+                              xl:
+                                gridWidth: 6
+                            type: IDashboardLayoutItem
+                            widget:
+                              description: ''
+                              drills: []
+                              ignoreDashboardFilters: []
+                              insight:
+                                identifier:
+                                  id: revenue_per_usd_vs_spend_by_campaign
+                                  type: visualizationObject
+                              properties: {}
+                              title: Revenue per $ vs Spend by Campaign
+                              type: insight
+                        type: IDashboardLayoutSection
+                    type: IDashboardLayout
+                  version: '2'
+                description: ''
+                id: campaign
+                permissions:
+                  - assigneeRule:
+                      type: allWorkspaceUsers
+                    name: VIEW
+                title: Campaign
+              - content:
+                  filterContextRef:
+                    identifier:
+                      id: campaign_name_filter
+                      type: filterContext
+                  layout:
+                    sections:
+                      - items:
+                          - size:
+                              xl:
+                                gridWidth: 12
+                            type: IDashboardLayoutItem
+                            widget:
+                              description: ''
+                              drills: []
+                              ignoreDashboardFilters: []
+                              insight:
+                                identifier:
+                                  id: top_10_products
+                                  type: visualizationObject
+                              properties: {}
+                              title: DHO simple
+                              type: insight
+                        type: IDashboardLayoutSection
+                    type: IDashboardLayout
+                  plugins:
+                    - plugin:
+                        identifier:
+                          id: dashboard_plugin_1
+                          type: dashboardPlugin
+                      version: '2'
+                  version: '2'
+                id: dashboard_plugin
+                title: Dashboard plugin
+              - content:
+                  filterContextRef:
+                    identifier:
+                      id: region_filter
+                      type: filterContext
+                  layout:
+                    sections:
+                      - items:
+                          - size:
+                              xl:
+                                gridWidth: 6
+                            type: IDashboardLayoutItem
+                            widget:
+                              dateDataSet:
+                                identifier:
+                                  id: date
+                                  type: dataset
+                              description: ''
+                              drills: []
+                              ignoreDashboardFilters: []
+                              insight:
+                                identifier:
+                                  id: top_10_products
+                                  type: visualizationObject
+                              properties: {}
+                              title: Top 10 Products
+                              type: insight
+                          - size:
+                              xl:
+                                gridWidth: 6
+                            type: IDashboardLayoutItem
+                            widget:
+                              dateDataSet:
+                                identifier:
+                                  id: date
+                                  type: dataset
+                              description: ''
+                              drills: []
+                              ignoreDashboardFilters: []
+                              insight:
+                                identifier:
+                                  id: revenue_trend
+                                  type: visualizationObject
+                              properties: {}
+                              title: Revenue Trend
+                              type: insight
+                          - size:
+                              xl:
+                                gridWidth: 6
+                            type: IDashboardLayoutItem
+                            widget:
+                              dateDataSet:
+                                identifier:
+                                  id: date
+                                  type: dataset
+                              description: ''
+                              drills: []
+                              ignoreDashboardFilters: []
+                              insight:
+                                identifier:
+                                  id: customers_trend
+                                  type: visualizationObject
+                              properties: {}
+                              title: Customers Trend
+                              type: insight
+                          - size:
+                              xl:
+                                gridWidth: 6
+                            type: IDashboardLayoutItem
+                            widget:
+                              dateDataSet:
+                                identifier:
+                                  id: date
+                                  type: dataset
+                              description: ''
+                              drills: []
+                              ignoreDashboardFilters: []
+                              insight:
+                                identifier:
+                                  id: product_categories_pie_chart
+                                  type: visualizationObject
+                              properties: {}
+                              title: Product Categories Pie Chart
+                              type: insight
+                          - size:
+                              xl:
+                                gridWidth: 6
+                            type: IDashboardLayoutItem
+                            widget:
+                              dateDataSet:
+                                identifier:
+                                  id: date
+                                  type: dataset
+                              description: ''
+                              drills: []
+                              ignoreDashboardFilters: []
+                              insight:
+                                identifier:
+                                  id: product_breakdown
+                                  type: visualizationObject
+                              properties: {}
+                              title: Product Breakdown
+                              type: insight
+                          - size:
+                              xl:
+                                gridWidth: 6
+                            type: IDashboardLayoutItem
+                            widget:
+                              dateDataSet:
+                                identifier:
+                                  id: date
+                                  type: dataset
+                              description: ''
+                              drills: []
+                              ignoreDashboardFilters: []
+                              insight:
+                                identifier:
+                                  id: product_saleability
+                                  type: visualizationObject
+                              properties: {}
+                              title: Product Saleability
+                              type: insight
+                          - size:
+                              xl:
+                                gridWidth: 12
+                            type: IDashboardLayoutItem
+                            widget:
+                              dateDataSet:
+                                identifier:
+                                  id: date
+                                  type: dataset
+                              description: ''
+                              drills: []
+                              ignoreDashboardFilters: []
+                              insight:
+                                identifier:
+                                  id: percent_revenue_per_product_by_customer_and_category
+                                  type: visualizationObject
+                              properties: {}
+                              title: '% Revenue per Product by Customer and Category'
+                              type: insight
+                        type: IDashboardLayoutSection
+                    type: IDashboardLayout
+                  version: '2'
+                description: ''
+                id: product_and_category
+                title: Product & Category
+            attributeHierarchies: []
+            dashboardPlugins:
+              - content:
+                  url: https://www.example.com
+                  version: '2'
+                description: Testing record dashboard_plugin_1
+                id: dashboard_plugin_1
+                title: dashboard_plugin_1
+              - content:
+                  url: https://www.example.com
+                  version: '2'
+                description: Testing record dashboard_plugin_2
+                id: dashboard_plugin_2
+                title: dashboard_plugin_2
+            exportDefinitions: []
+            filterContexts:
+              - content:
+                  filters:
+                    - dateFilter:
+                        from: '0'
+                        granularity: GDC.time.month
+                        to: '0'
+                        type: relative
+                    - attributeFilter:
+                        attributeElements:
+                          uris: []
+                        displayForm:
+                          identifier:
+                            id: campaign_name
+                            type: label
+                        filterElementsBy: []
+                        localIdentifier: 14b0807447ef4bc28f43e4fc5c337d1d
+                        negativeSelection: true
+                  version: '2'
+                description: ''
+                id: campaign_name_filter
+                title: filterContext
+              - content:
+                  filters:
+                    - attributeFilter:
+                        attributeElements:
+                          uris: []
+                        displayForm:
+                          identifier:
+                            id: region
+                            type: label
+                        filterElementsBy: []
+                        localIdentifier: 2d5ef8df82444f6ba27b45f0990ee6af
+                        negativeSelection: true
+                  version: '2'
+                description: ''
+                id: region_filter
+                title: filterContext
+            memoryItems: []
+            metrics:
+              - content:
+                  format: '#,##0'
+                  maql: SELECT COUNT({attribute/customer_id},{attribute/order_line_id})
+                id: amount_of_active_customers
+                title: '# of Active Customers'
+              - content:
+                  format: '#,##0'
+                  maql: SELECT COUNT({attribute/order_id})
+                id: amount_of_orders
+                title: '# of Orders'
+              - content:
+                  format: '#,##0'
+                  maql: 'SELECT {metric/amount_of_active_customers} WHERE (SELECT
+                    {metric/revenue} BY {attribute/customer_id}) >  10000 '
+                id: amount_of_top_customers
+                title: '# of Top Customers'
+              - content:
+                  format: '#,##0.00'
+                  maql: SELECT {metric/amount_of_orders} WHERE NOT ({label/order_status}
+                    IN ("Returned", "Canceled"))
+                description: ''
+                id: amount_of_valid_orders
+                title: '# of Valid Orders'
+              - content:
+                  format: $#,##0
+                  maql: SELECT SUM({fact/spend})
+                id: campaign_spend
+                title: Campaign Spend
+              - content:
+                  format: $#,##0
+                  maql: SELECT SUM({fact/price}*{fact/quantity})
+                id: order_amount
+                title: Order Amount
+              - content:
+                  format: '#,##0.0%'
+                  maql: SELECT {metric/revenue} / {metric/total_revenue}
+                id: percent_revenue
+                title: '% Revenue'
+              - content:
+                  format: '#,##0.0%'
+                  maql: "SELECT\n (SELECT {metric/revenue} WHERE (SELECT {metric/revenue_top_10}\
+                    \ BY {attribute/customer_id}) > 0)\n  /\n {metric/revenue}"
+                id: percent_revenue_from_top_10_customers
+                title: '% Revenue from Top 10 Customers'
+              - content:
+                  format: '#,##0.0%'
+                  maql: "SELECT\n (SELECT {metric/revenue} WHERE (SELECT {metric/revenue_top_10_percent}\
+                    \ BY {attribute/customer_id}) > 0)\n  /\n {metric/revenue}"
+                id: percent_revenue_from_top_10_percent_customers
+                title: '% Revenue from Top 10% Customers'
+              - content:
+                  format: '#,##0.0%'
+                  maql: "SELECT\n (SELECT {metric/revenue} WHERE (SELECT {metric/revenue_top_10_percent}\
+                    \ BY {attribute/product_id}) > 0)\n  /\n {metric/revenue}"
+                id: percent_revenue_from_top_10_percent_products
+                title: '% Revenue from Top 10% Products'
+              - content:
+                  format: '#,##0.0%'
+                  maql: "SELECT\n (SELECT {metric/revenue} WHERE (SELECT {metric/revenue_top_10}\
+                    \ BY {attribute/product_id}) > 0)\n  /\n {metric/revenue}"
+                id: percent_revenue_from_top_10_products
+                title: '% Revenue from Top 10 Products'
+              - content:
+                  format: '#,##0.0%'
+                  maql: SELECT {metric/revenue} / (SELECT {metric/revenue} BY {attribute/products.category},
+                    ALL OTHER)
+                id: percent_revenue_in_category
+                title: '% Revenue in Category'
+              - content:
+                  format: '#,##0.0%'
+                  maql: SELECT {metric/revenue} / (SELECT {metric/revenue} BY ALL
+                    {attribute/product_id})
+                id: percent_revenue_per_product
+                title: '% Revenue per Product'
+              - content:
+                  format: $#,##0
+                  maql: SELECT {metric/order_amount} WHERE NOT ({label/order_status}
+                    IN ("Returned", "Canceled"))
+                description: ''
+                id: revenue
+                title: Revenue
+              - content:
+                  format: $#,##0
+                  maql: SELECT {metric/revenue} WHERE {label/products.category} IN
+                    ("Clothing")
+                id: revenue-clothing
+                title: Revenue (Clothing)
+              - content:
+                  format: $#,##0
+                  maql: SELECT {metric/revenue} WHERE {label/products.category} IN
+                    ( "Electronics")
+                id: revenue-electronic
+                title: Revenue (Electronic)
+              - content:
+                  format: $#,##0
+                  maql: SELECT {metric/revenue} WHERE {label/products.category} IN
+                    ("Home")
+                id: revenue-home
+                title: Revenue (Home)
+              - content:
+                  format: $#,##0
+                  maql: SELECT {metric/revenue} WHERE {label/products.category} IN
+                    ("Outdoor")
+                id: revenue-outdoor
+                title: Revenue (Outdoor)
+              - content:
+                  format: $#,##0.0
+                  maql: SELECT AVG(SELECT {metric/revenue} BY {attribute/customer_id})
+                id: revenue_per_customer
+                title: Revenue per Customer
+              - content:
+                  format: $#,##0.0
+                  maql: SELECT {metric/revenue} / {metric/campaign_spend}
+                id: revenue_per_dollar_spent
+                title: Revenue per Dollar Spent
+              - content:
+                  format: $#,##0
+                  maql: SELECT {metric/revenue} WHERE TOP(10) OF ({metric/revenue})
+                id: revenue_top_10
+                title: Revenue / Top 10
+              - content:
+                  format: $#,##0
+                  maql: SELECT {metric/revenue} WHERE TOP(10%) OF ({metric/revenue})
+                id: revenue_top_10_percent
+                title: Revenue / Top 10%
+              - content:
+                  format: $#,##0
+                  maql: SELECT {metric/revenue} BY ALL OTHER
+                id: total_revenue
+                title: Total Revenue
+              - content:
+                  format: $#,##0
+                  maql: SELECT {metric/total_revenue} WITHOUT PARENT FILTER
+                id: total_revenue-no_filters
+                title: Total Revenue (No Filters)
+            parameters: []
+            visualizationObjects:
+              - content:
+                  buckets:
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: campaign_spend
+                                    type: metric
+                            localIdentifier: d319bcb2d8c04442a684e3b3cd063381
+                            title: Campaign Spend
+                      localIdentifier: measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: campaign_channels.category
+                                type: label
+                            localIdentifier: 291c085e7df8420db84117ca49f59c49
+                      localIdentifier: view
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: campaign_name
+                                type: label
+                            localIdentifier: d9dd143d647d4d148405a60ec2cf59bc
+                      localIdentifier: segment
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: type
+                            type: label
+                        notIn:
+                          values: []
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: campaign_channels.category
+                            type: label
+                        notIn:
+                          values: []
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: campaign_name
+                            type: label
+                        notIn:
+                          values: []
+                  properties:
+                    controls:
+                      legend:
+                        position: bottom
+                  version: '2'
+                  visualizationUrl: local:treemap
+                id: campaign_spend
+                title: Campaign Spend
+              - content:
+                  buckets:
+                    - items:
+                        - measure:
+                            alias: Active Customers
+                            definition:
+                              measureDefinition:
+                                computeRatio: false
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: amount_of_active_customers
+                                    type: metric
+                            localIdentifier: 2ba0b87b59ca41a4b1530e81a5c1d081
+                            title: '# of Active Customers'
+                      localIdentifier: measures
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue_per_customer
+                                    type: metric
+                            localIdentifier: ec0606894b9f4897b7beaf1550608928
+                            title: Revenue per Customer
+                      localIdentifier: secondary_measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: date.month
+                                type: label
+                            localIdentifier: 0de7d7f08af7480aa636857a26be72b6
+                      localIdentifier: view
+                  filters:
+                    - relativeDateFilter:
+                        dataSet:
+                          identifier:
+                            id: date
+                            type: dataset
+                        from: -12
+                        granularity: GDC.time.month
+                        to: -1
+                  properties:
+                    controls:
+                      colorMapping:
+                        - color:
+                            type: guid
+                            value: '20'
+                          id: 2ba0b87b59ca41a4b1530e81a5c1d081
+                        - color:
+                            type: guid
+                            value: '4'
+                          id: ec0606894b9f4897b7beaf1550608928
+                      dualAxis: true
+                      legend:
+                        position: bottom
+                      primaryChartType: column
+                      secondaryChartType: line
+                      secondary_yaxis:
+                        measures:
+                          - ec0606894b9f4897b7beaf1550608928
+                      xaxis:
+                        name:
+                          visible: false
+                        rotation: auto
+                  version: '2'
+                  visualizationUrl: local:combo2
+                id: customers_trend
+                title: Customers Trend
+              - content:
+                  buckets:
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: percent_revenue_per_product
+                                    type: metric
+                            localIdentifier: 08d8346c1ce7438994b251991c0fbf65
+                            title: '% Revenue per Product'
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue
+                                    type: metric
+                            localIdentifier: b2350c06688b4da9b3833ebcce65527f
+                            title: Revenue
+                      localIdentifier: measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: customer_name
+                                type: label
+                            localIdentifier: 7a4045fd00ac44579f52406df679435f
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: products.category
+                                type: label
+                            localIdentifier: 6a003ffd14994237ba64c4a02c488429
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: product_name
+                                type: label
+                            localIdentifier: 75ea396d0c8b48098e31dccf8b5801d3
+                      localIdentifier: attribute
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: customer_name
+                            type: label
+                        notIn:
+                          values: []
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: products.category
+                            type: label
+                        notIn:
+                          values: []
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: product_name
+                            type: label
+                        notIn:
+                          values: []
+                  properties: {}
+                  sorts:
+                    - attributeSortItem:
+                        attributeIdentifier: 7a4045fd00ac44579f52406df679435f
+                        direction: asc
+                  version: '2'
+                  visualizationUrl: local:table
+                id: percent_revenue_per_product_by_customer_and_category
+                title: '% Revenue per Product by Customer and Category'
+              - content:
+                  buckets:
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: amount_of_active_customers
+                                    type: metric
+                            localIdentifier: 1a14cdc1293c46e89a2e25d3e741d235
+                            title: '# of Active Customers'
+                      localIdentifier: measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: date.month
+                                type: label
+                            localIdentifier: c1feca1864244ec2ace7a9b9d7fda231
+                      localIdentifier: view
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: region
+                                type: label
+                            localIdentifier: 530cddbd7ca04d039e73462d81ed44d5
+                      localIdentifier: stack
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: region
+                            type: label
+                        notIn:
+                          values: []
+                    - relativeDateFilter:
+                        dataSet:
+                          identifier:
+                            id: date
+                            type: dataset
+                        from: -11
+                        granularity: GDC.time.month
+                        to: 0
+                  properties:
+                    controls:
+                      legend:
+                        position: bottom
+                      stackMeasuresToPercent: true
+                  version: '2'
+                  visualizationUrl: local:area
+                id: percentage_of_customers_by_region
+                title: Percentage of Customers by Region
+              - content:
+                  buckets:
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue
+                                    type: metric
+                            localIdentifier: 590d332ef686468b8878ae41b23341c6
+                            title: Revenue
+                      localIdentifier: measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: products.category
+                                type: label
+                            localIdentifier: b166c71091864312a14c7ae8ff886ffe
+                      localIdentifier: view
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: product_name
+                                type: label
+                            localIdentifier: e920a50e0bbb49788df0aac53634c1cd
+                      localIdentifier: segment
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: products.category
+                            type: label
+                        notIn:
+                          values: []
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: product_name
+                            type: label
+                        notIn:
+                          values: []
+                  properties:
+                    controls:
+                      legend:
+                        position: bottom
+                  version: '2'
+                  visualizationUrl: local:treemap
+                id: product_breakdown
+                title: Product Breakdown
+              - content:
+                  buckets:
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                computeRatio: true
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue
+                                    type: metric
+                            format: '#,##0.00%'
+                            localIdentifier: 162b857af49d45769bc12604a5c192b9
+                            title: '% Revenue'
+                      localIdentifier: measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: products.category
+                                type: label
+                            localIdentifier: fe513cef1c6244a5ac21c5f49c56b108
+                      localIdentifier: view
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: product_name
+                            type: label
+                        notIn:
+                          values: []
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: products.category
+                            type: label
+                        notIn:
+                          values: []
+                  properties:
+                    controls:
+                      dataLabels:
+                        visible: auto
+                      legend:
+                        position: bottom
+                  version: '2'
+                  visualizationUrl: local:donut
+                id: product_categories_pie_chart
+                title: Product Categories Pie Chart
+              - content:
+                  buckets:
+                    - items:
+                        - measure:
+                            alias: Previous Period
+                            definition:
+                              popMeasureDefinition:
+                                measureIdentifier: c82e025fa2db4afea9a600a424591dbe
+                                popAttribute:
+                                  identifier:
+                                    id: date.year
+                                    type: attribute
+                            localIdentifier: c82e025fa2db4afea9a600a424591dbe_pop
+                        - measure:
+                            alias: This Period
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue
+                                    type: metric
+                            localIdentifier: c82e025fa2db4afea9a600a424591dbe
+                            title: Revenue
+                      localIdentifier: measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: products.category
+                                type: label
+                            localIdentifier: c804ef5ba7944a5a9f360c86a9e95e9a
+                      localIdentifier: view
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: product_name
+                            type: label
+                        notIn:
+                          values: []
+                    - relativeDateFilter:
+                        dataSet:
+                          identifier:
+                            id: date
+                            type: dataset
+                        from: -11
+                        granularity: GDC.time.month
+                        to: 0
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: products.category
+                            type: label
+                        notIn:
+                          values: []
+                  properties:
+                    controls:
+                      legend:
+                        position: bottom
+                      stackMeasures: false
+                      xaxis:
+                        name:
+                          visible: false
+                      yaxis:
+                        name:
+                          visible: false
+                  version: '2'
+                  visualizationUrl: local:column
+                id: product_revenue_comparison-over_previous_period
+                title: Product Revenue Comparison (over previous period)
+              - content:
+                  buckets:
+                    - items:
+                        - measure:
+                            alias: Number of Orders
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: amount_of_orders
+                                    type: metric
+                            localIdentifier: aeb5d51a162d4b59aba3bd6ddebcc780
+                            title: '# of Orders'
+                      localIdentifier: measures
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue
+                                    type: metric
+                            localIdentifier: 94b3edd3a73c4a48a4d13bbe9442cc98
+                            title: Revenue
+                      localIdentifier: secondary_measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: product_name
+                                type: label
+                            localIdentifier: d2a991bdd123448eb2be73d79f1180c4
+                      localIdentifier: attribute
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: product_name
+                            type: label
+                        notIn:
+                          values: []
+                  properties:
+                    controls:
+                      dataLabels:
+                        visible: auto
+                      grid:
+                        enabled: true
+                  version: '2'
+                  visualizationUrl: local:scatter
+                id: product_saleability
+                title: Product Saleability
+              - content:
+                  buckets:
+                    - items:
+                        - measure:
+                            alias: Items Sold
+                            definition:
+                              measureDefinition:
+                                aggregation: sum
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: quantity
+                                    type: fact
+                            format: '#,##0.00'
+                            localIdentifier: 29486504dd0e4a36a18b0b2f792d3a46
+                            title: Sum of Quantity
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                aggregation: avg
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: price
+                                    type: fact
+                            format: '#,##0.00'
+                            localIdentifier: aa6391acccf1452f8011201aef9af492
+                            title: Avg Price
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: percent_revenue_in_category
+                                    type: metric
+                            localIdentifier: 2cd39539d8da46c9883e63caa3ba7cc0
+                            title: '% Revenue in Category'
+                        - measure:
+                            alias: Total Revenue
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue
+                                    type: metric
+                            localIdentifier: 9a0f08331c094c7facf2a0b4f418de0a
+                            title: Revenue
+                      localIdentifier: measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: products.category
+                                type: label
+                            localIdentifier: 06bc6b3b9949466494e4f594c11f1bff
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: product_name
+                                type: label
+                            localIdentifier: 192668bfb6a74e9ab7b5d1ce7cb68ea3
+                      localIdentifier: attribute
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: customer_name
+                            type: label
+                        notIn:
+                          values: []
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: product_name
+                            type: label
+                        notIn:
+                          values: []
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: products.category
+                            type: label
+                        notIn:
+                          values: []
+                  properties: {}
+                  sorts:
+                    - attributeSortItem:
+                        attributeIdentifier: 06bc6b3b9949466494e4f594c11f1bff
+                        direction: asc
+                  version: '2'
+                  visualizationUrl: local:table
+                id: revenue_and_quantity_by_product_and_category
+                title: Revenue and Quantity by Product and Category
+              - content:
+                  buckets:
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue
+                                    type: metric
+                            localIdentifier: 7df6c34387744d69b23ec92e1a5cf543
+                            title: Revenue
+                      localIdentifier: measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: date.month
+                                type: label
+                            localIdentifier: 4bb4fc1986c546de9ad976e6ec23fed4
+                      localIdentifier: trend
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: products.category
+                                type: label
+                            localIdentifier: 34bddcb1cd024902a82396216b0fa9d8
+                      localIdentifier: segment
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: products.category
+                            type: label
+                        notIn:
+                          values: []
+                    - relativeDateFilter:
+                        dataSet:
+                          identifier:
+                            id: date
+                            type: dataset
+                        granularity: GDC.time.year
+                  properties:
+                    controls:
+                      legend:
+                        position: bottom
+                  version: '2'
+                  visualizationUrl: local:line
+                id: revenue_by_category_trend
+                title: Revenue by Category Trend
+              - content:
+                  buckets:
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue
+                                    type: metric
+                            localIdentifier: 4ae3401bdbba4938afe983df4ba04e1c
+                            title: Revenue
+                      localIdentifier: measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: product_name
+                                type: label
+                            localIdentifier: 1c8ba72dbfc84ddd913bf81dc355c427
+                      localIdentifier: view
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: product_name
+                            type: label
+                        notIn:
+                          values: []
+                  properties: {}
+                  version: '2'
+                  visualizationUrl: local:bar
+                id: revenue_by_product
+                title: Revenue by Product
+              - content:
+                  buckets:
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: campaign_spend
+                                    type: metric
+                            localIdentifier: 13a50d811e474ac6808d8da7f4673b35
+                            title: Campaign Spend
+                      localIdentifier: measures
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue_per_dollar_spent
+                                    type: metric
+                            localIdentifier: a0f15e82e6334280a44dbedc7d086e7c
+                            title: Revenue per Dollar Spent
+                      localIdentifier: secondary_measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: campaign_name
+                                type: label
+                            localIdentifier: 1d9fa968bafb423eb29c938dfb1207ff
+                      localIdentifier: attribute
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: campaign_name
+                            type: label
+                        notIn:
+                          values: []
+                  properties:
+                    controls:
+                      xaxis:
+                        min: '0'
+                      yaxis:
+                        min: '0'
+                  version: '2'
+                  visualizationUrl: local:scatter
+                id: revenue_per_usd_vs_spend_by_campaign
+                title: Revenue per $ vs Spend by Campaign
+              - content:
+                  buckets:
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                computeRatio: false
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue
+                                    type: metric
+                            localIdentifier: 60c854969a9c4c278ab596d99c222e92
+                            title: Revenue
+                      localIdentifier: measures
+                    - items:
+                        - measure:
+                            alias: Number of Orders
+                            definition:
+                              measureDefinition:
+                                computeRatio: false
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: amount_of_orders
+                                    type: metric
+                            localIdentifier: c2fa7ef48cc54af99f8c280eb451e051
+                            title: '# of Orders'
+                      localIdentifier: secondary_measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: date.month
+                                type: label
+                            localIdentifier: 413ac374b65648fa96826ca01d47bdda
+                      localIdentifier: view
+                  filters:
+                    - relativeDateFilter:
+                        dataSet:
+                          identifier:
+                            id: date
+                            type: dataset
+                        from: -3
+                        granularity: GDC.time.quarter
+                        to: 0
+                  properties:
+                    controls:
+                      dualAxis: true
+                      legend:
+                        position: bottom
+                      primaryChartType: column
+                      secondaryChartType: line
+                      secondary_yaxis:
+                        measures:
+                          - c2fa7ef48cc54af99f8c280eb451e051
+                      xaxis:
+                        name:
+                          visible: false
+                        rotation: auto
+                  version: '2'
+                  visualizationUrl: local:combo2
+                id: revenue_trend
+                title: Revenue Trend
+              - content:
+                  buckets:
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue_top_10
+                                    type: metric
+                            localIdentifier: 3f127ccfe57a40399e23f9ae2a4ad810
+                            title: Revenue / Top 10
+                      localIdentifier: measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: customer_name
+                                type: label
+                            localIdentifier: f4e39e24f11e4827a191c30d65c89d2c
+                      localIdentifier: view
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: state
+                                type: label
+                            localIdentifier: bbccd430176d428caed54c99afc9589e
+                      localIdentifier: stack
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: customer_name
+                            type: label
+                        notIn:
+                          values: []
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: state
+                            type: label
+                        notIn:
+                          values: []
+                  properties:
+                    controls:
+                      legend:
+                        position: bottom
+                  version: '2'
+                  visualizationUrl: local:bar
+                id: top_10_customers
+                title: Top 10 Customers
+              - content:
+                  buckets:
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue_top_10
+                                    type: metric
+                            localIdentifier: 77dc71bbac92412bac5f94284a5919df
+                            title: Revenue / Top 10
+                      localIdentifier: measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: product_name
+                                type: label
+                            localIdentifier: 781952e728204dcf923142910cc22ae2
+                      localIdentifier: view
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: products.category
+                                type: label
+                            localIdentifier: fe513cef1c6244a5ac21c5f49c56b108
+                      localIdentifier: stack
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: product_name
+                            type: label
+                        notIn:
+                          values: []
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: products.category
+                            type: label
+                        notIn:
+                          values: []
+                  properties:
+                    controls:
+                      legend:
+                        position: bottom
+                  version: '2'
+                  visualizationUrl: local:bar
+                id: top_10_products
+                title: Top 10 Products
+      headers:
+        Content-Type:
+          - application/json
+        DATE: &id001
+          - PLACEHOLDER
+        Expires:
+          - '0'
+        Pragma:
+          - no-cache
+        X-Content-Type-Options:
+          - nosniff
+        X-GDC-TRACE-ID: *id001
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        analytics:
+          analyticalDashboardExtensions: []
+          analyticalDashboards:
+            - content:
+                filterContextRef:
+                  identifier:
+                    id: campaign_name_filter
+                    type: filterContext
+                filters:
+                  - measureValueFilter:
+                      conditions:
+                        - operator: GREATER_THAN
+                          value: 1000.0
+                      measure:
+                        identifier:
+                          id: order_amount
+                          type: metric
+                      title: Order Amount > 1000
+                  - measureValueFilter:
+                      conditions:
+                        - from: 500.0
+                          operator: BETWEEN
+                          to: 2000.0
+                      measure:
+                        identifier:
+                          id: order_amount
+                          type: metric
+                      title: Order Amount 500-2000
+                layout:
+                  sections:
+                    - header:
+                        description: The first insight shows a breakdown of spend
+                          by category and campaign. The second shows revenue per $
+                          spend, for each campaign, to demonstrate, how campaigns
+                          are successful.
+                        title: Spend breakdown and Revenue
+                      items:
+                        - size:
+                            xl:
+                              gridWidth: 6
+                          type: IDashboardLayoutItem
+                          widget:
+                            description: ''
+                            drills: []
+                            ignoreDashboardFilters: []
+                            insight:
+                              identifier:
+                                id: campaign_spend
+                                type: visualizationObject
+                            properties: {}
+                            title: Campaign Spend
+                            type: insight
+                        - size:
+                            xl:
+                              gridWidth: 6
+                          type: IDashboardLayoutItem
+                          widget:
+                            description: ''
+                            drills: []
+                            ignoreDashboardFilters: []
+                            insight:
+                              identifier:
+                                id: revenue_per_usd_vs_spend_by_campaign
+                                type: visualizationObject
+                            properties: {}
+                            title: Revenue per $ vs Spend by Campaign
+                            type: insight
+                      type: IDashboardLayoutSection
+                  type: IDashboardLayout
+                version: '2'
+              description: ''
+              id: campaign
+              permissions:
+                - assigneeRule:
+                    type: allWorkspaceUsers
+                  name: VIEW
+              title: Campaign
+            - content:
+                filterContextRef:
+                  identifier:
+                    id: campaign_name_filter
+                    type: filterContext
+                layout:
+                  sections:
+                    - items:
+                        - size:
+                            xl:
+                              gridWidth: 12
+                          type: IDashboardLayoutItem
+                          widget:
+                            description: ''
+                            drills: []
+                            ignoreDashboardFilters: []
+                            insight:
+                              identifier:
+                                id: top_10_products
+                                type: visualizationObject
+                            properties: {}
+                            title: DHO simple
+                            type: insight
+                      type: IDashboardLayoutSection
+                  type: IDashboardLayout
+                plugins:
+                  - plugin:
+                      identifier:
+                        id: dashboard_plugin_1
+                        type: dashboardPlugin
+                    version: '2'
+                version: '2'
+              id: dashboard_plugin
+              title: Dashboard plugin
+            - content:
+                filterContextRef:
+                  identifier:
+                    id: region_filter
+                    type: filterContext
+                layout:
+                  sections:
+                    - items:
+                        - size:
+                            xl:
+                              gridWidth: 6
+                          type: IDashboardLayoutItem
+                          widget:
+                            dateDataSet:
+                              identifier:
+                                id: date
+                                type: dataset
+                            description: ''
+                            drills: []
+                            ignoreDashboardFilters: []
+                            insight:
+                              identifier:
+                                id: top_10_products
+                                type: visualizationObject
+                            properties: {}
+                            title: Top 10 Products
+                            type: insight
+                        - size:
+                            xl:
+                              gridWidth: 6
+                          type: IDashboardLayoutItem
+                          widget:
+                            dateDataSet:
+                              identifier:
+                                id: date
+                                type: dataset
+                            description: ''
+                            drills: []
+                            ignoreDashboardFilters: []
+                            insight:
+                              identifier:
+                                id: revenue_trend
+                                type: visualizationObject
+                            properties: {}
+                            title: Revenue Trend
+                            type: insight
+                        - size:
+                            xl:
+                              gridWidth: 6
+                          type: IDashboardLayoutItem
+                          widget:
+                            dateDataSet:
+                              identifier:
+                                id: date
+                                type: dataset
+                            description: ''
+                            drills: []
+                            ignoreDashboardFilters: []
+                            insight:
+                              identifier:
+                                id: customers_trend
+                                type: visualizationObject
+                            properties: {}
+                            title: Customers Trend
+                            type: insight
+                        - size:
+                            xl:
+                              gridWidth: 6
+                          type: IDashboardLayoutItem
+                          widget:
+                            dateDataSet:
+                              identifier:
+                                id: date
+                                type: dataset
+                            description: ''
+                            drills: []
+                            ignoreDashboardFilters: []
+                            insight:
+                              identifier:
+                                id: product_categories_pie_chart
+                                type: visualizationObject
+                            properties: {}
+                            title: Product Categories Pie Chart
+                            type: insight
+                        - size:
+                            xl:
+                              gridWidth: 6
+                          type: IDashboardLayoutItem
+                          widget:
+                            dateDataSet:
+                              identifier:
+                                id: date
+                                type: dataset
+                            description: ''
+                            drills: []
+                            ignoreDashboardFilters: []
+                            insight:
+                              identifier:
+                                id: product_breakdown
+                                type: visualizationObject
+                            properties: {}
+                            title: Product Breakdown
+                            type: insight
+                        - size:
+                            xl:
+                              gridWidth: 6
+                          type: IDashboardLayoutItem
+                          widget:
+                            dateDataSet:
+                              identifier:
+                                id: date
+                                type: dataset
+                            description: ''
+                            drills: []
+                            ignoreDashboardFilters: []
+                            insight:
+                              identifier:
+                                id: product_saleability
+                                type: visualizationObject
+                            properties: {}
+                            title: Product Saleability
+                            type: insight
+                        - size:
+                            xl:
+                              gridWidth: 12
+                          type: IDashboardLayoutItem
+                          widget:
+                            dateDataSet:
+                              identifier:
+                                id: date
+                                type: dataset
+                            description: ''
+                            drills: []
+                            ignoreDashboardFilters: []
+                            insight:
+                              identifier:
+                                id: percent_revenue_per_product_by_customer_and_category
+                                type: visualizationObject
+                            properties: {}
+                            title: '% Revenue per Product by Customer and Category'
+                            type: insight
+                      type: IDashboardLayoutSection
+                  type: IDashboardLayout
+                version: '2'
+              description: ''
+              id: product_and_category
+              title: Product & Category
+          attributeHierarchies: []
+          dashboardPlugins:
+            - content:
+                url: https://www.example.com
+                version: '2'
+              description: Testing record dashboard_plugin_1
+              id: dashboard_plugin_1
+              title: dashboard_plugin_1
+            - content:
+                url: https://www.example.com
+                version: '2'
+              description: Testing record dashboard_plugin_2
+              id: dashboard_plugin_2
+              title: dashboard_plugin_2
+          exportDefinitions: []
+          filterContexts:
+            - content:
+                filters:
+                  - dateFilter:
+                      from: '0'
+                      granularity: GDC.time.month
+                      to: '0'
+                      type: relative
+                  - attributeFilter:
+                      attributeElements:
+                        uris: []
+                      displayForm:
+                        identifier:
+                          id: campaign_name
+                          type: label
+                      filterElementsBy: []
+                      localIdentifier: 14b0807447ef4bc28f43e4fc5c337d1d
+                      negativeSelection: true
+                version: '2'
+              description: ''
+              id: campaign_name_filter
+              title: filterContext
+            - content:
+                filters:
+                  - attributeFilter:
+                      attributeElements:
+                        uris: []
+                      displayForm:
+                        identifier:
+                          id: region
+                          type: label
+                      filterElementsBy: []
+                      localIdentifier: 2d5ef8df82444f6ba27b45f0990ee6af
+                      negativeSelection: true
+                version: '2'
+              description: ''
+              id: region_filter
+              title: filterContext
+          memoryItems: []
+          metrics:
+            - content:
+                format: '#,##0'
+                maql: SELECT COUNT({attribute/customer_id},{attribute/order_line_id})
+              id: amount_of_active_customers
+              title: '# of Active Customers'
+            - content:
+                format: '#,##0'
+                maql: SELECT COUNT({attribute/order_id})
+              id: amount_of_orders
+              title: '# of Orders'
+            - content:
+                format: '#,##0'
+                maql: 'SELECT {metric/amount_of_active_customers} WHERE (SELECT {metric/revenue}
+                  BY {attribute/customer_id}) >  10000 '
+              id: amount_of_top_customers
+              title: '# of Top Customers'
+            - content:
+                format: '#,##0.00'
+                maql: SELECT {metric/amount_of_orders} WHERE NOT ({label/order_status}
+                  IN ("Returned", "Canceled"))
+              description: ''
+              id: amount_of_valid_orders
+              title: '# of Valid Orders'
+            - content:
+                format: $#,##0
+                maql: SELECT SUM({fact/spend})
+              id: campaign_spend
+              title: Campaign Spend
+            - content:
+                format: $#,##0
+                maql: SELECT SUM({fact/price}*{fact/quantity})
+              id: order_amount
+              title: Order Amount
+            - content:
+                format: '#,##0.0%'
+                maql: SELECT {metric/revenue} / {metric/total_revenue}
+              id: percent_revenue
+              title: '% Revenue'
+            - content:
+                format: '#,##0.0%'
+                maql: "SELECT\n (SELECT {metric/revenue} WHERE (SELECT {metric/revenue_top_10}\
+                  \ BY {attribute/customer_id}) > 0)\n  /\n {metric/revenue}"
+              id: percent_revenue_from_top_10_customers
+              title: '% Revenue from Top 10 Customers'
+            - content:
+                format: '#,##0.0%'
+                maql: "SELECT\n (SELECT {metric/revenue} WHERE (SELECT {metric/revenue_top_10_percent}\
+                  \ BY {attribute/customer_id}) > 0)\n  /\n {metric/revenue}"
+              id: percent_revenue_from_top_10_percent_customers
+              title: '% Revenue from Top 10% Customers'
+            - content:
+                format: '#,##0.0%'
+                maql: "SELECT\n (SELECT {metric/revenue} WHERE (SELECT {metric/revenue_top_10_percent}\
+                  \ BY {attribute/product_id}) > 0)\n  /\n {metric/revenue}"
+              id: percent_revenue_from_top_10_percent_products
+              title: '% Revenue from Top 10% Products'
+            - content:
+                format: '#,##0.0%'
+                maql: "SELECT\n (SELECT {metric/revenue} WHERE (SELECT {metric/revenue_top_10}\
+                  \ BY {attribute/product_id}) > 0)\n  /\n {metric/revenue}"
+              id: percent_revenue_from_top_10_products
+              title: '% Revenue from Top 10 Products'
+            - content:
+                format: '#,##0.0%'
+                maql: SELECT {metric/revenue} / (SELECT {metric/revenue} BY {attribute/products.category},
+                  ALL OTHER)
+              id: percent_revenue_in_category
+              title: '% Revenue in Category'
+            - content:
+                format: '#,##0.0%'
+                maql: SELECT {metric/revenue} / (SELECT {metric/revenue} BY ALL {attribute/product_id})
+              id: percent_revenue_per_product
+              title: '% Revenue per Product'
+            - content:
+                format: $#,##0
+                maql: SELECT {metric/order_amount} WHERE NOT ({label/order_status}
+                  IN ("Returned", "Canceled"))
+              description: ''
+              id: revenue
+              title: Revenue
+            - content:
+                format: $#,##0
+                maql: SELECT {metric/revenue} WHERE {label/products.category} IN ("Clothing")
+              id: revenue-clothing
+              title: Revenue (Clothing)
+            - content:
+                format: $#,##0
+                maql: SELECT {metric/revenue} WHERE {label/products.category} IN (
+                  "Electronics")
+              id: revenue-electronic
+              title: Revenue (Electronic)
+            - content:
+                format: $#,##0
+                maql: SELECT {metric/revenue} WHERE {label/products.category} IN ("Home")
+              id: revenue-home
+              title: Revenue (Home)
+            - content:
+                format: $#,##0
+                maql: SELECT {metric/revenue} WHERE {label/products.category} IN ("Outdoor")
+              id: revenue-outdoor
+              title: Revenue (Outdoor)
+            - content:
+                format: $#,##0.0
+                maql: SELECT AVG(SELECT {metric/revenue} BY {attribute/customer_id})
+              id: revenue_per_customer
+              title: Revenue per Customer
+            - content:
+                format: $#,##0.0
+                maql: SELECT {metric/revenue} / {metric/campaign_spend}
+              id: revenue_per_dollar_spent
+              title: Revenue per Dollar Spent
+            - content:
+                format: $#,##0
+                maql: SELECT {metric/revenue} WHERE TOP(10) OF ({metric/revenue})
+              id: revenue_top_10
+              title: Revenue / Top 10
+            - content:
+                format: $#,##0
+                maql: SELECT {metric/revenue} WHERE TOP(10%) OF ({metric/revenue})
+              id: revenue_top_10_percent
+              title: Revenue / Top 10%
+            - content:
+                format: $#,##0
+                maql: SELECT {metric/revenue} BY ALL OTHER
+              id: total_revenue
+              title: Total Revenue
+            - content:
+                format: $#,##0
+                maql: SELECT {metric/total_revenue} WITHOUT PARENT FILTER
+              id: total_revenue-no_filters
+              title: Total Revenue (No Filters)
+          parameters: []
+          visualizationObjects:
+            - content:
+                buckets:
+                  - items:
+                      - measure:
+                          definition:
+                            measureDefinition:
+                              filters: []
+                              item:
+                                identifier:
+                                  id: campaign_spend
+                                  type: metric
+                          localIdentifier: d319bcb2d8c04442a684e3b3cd063381
+                          title: Campaign Spend
+                    localIdentifier: measures
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: campaign_channels.category
+                              type: label
+                          localIdentifier: 291c085e7df8420db84117ca49f59c49
+                    localIdentifier: view
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: campaign_name
+                              type: label
+                          localIdentifier: d9dd143d647d4d148405a60ec2cf59bc
+                    localIdentifier: segment
+                filters:
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: type
+                          type: label
+                      notIn:
+                        values: []
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: campaign_channels.category
+                          type: label
+                      notIn:
+                        values: []
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: campaign_name
+                          type: label
+                      notIn:
+                        values: []
+                properties:
+                  controls:
+                    legend:
+                      position: bottom
+                version: '2'
+                visualizationUrl: local:treemap
+              id: campaign_spend
+              title: Campaign Spend
+            - content:
+                buckets:
+                  - items:
+                      - measure:
+                          alias: Active Customers
+                          definition:
+                            measureDefinition:
+                              computeRatio: false
+                              filters: []
+                              item:
+                                identifier:
+                                  id: amount_of_active_customers
+                                  type: metric
+                          localIdentifier: 2ba0b87b59ca41a4b1530e81a5c1d081
+                          title: '# of Active Customers'
+                    localIdentifier: measures
+                  - items:
+                      - measure:
+                          definition:
+                            measureDefinition:
+                              filters: []
+                              item:
+                                identifier:
+                                  id: revenue_per_customer
+                                  type: metric
+                          localIdentifier: ec0606894b9f4897b7beaf1550608928
+                          title: Revenue per Customer
+                    localIdentifier: secondary_measures
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: date.month
+                              type: label
+                          localIdentifier: 0de7d7f08af7480aa636857a26be72b6
+                    localIdentifier: view
+                filters:
+                  - relativeDateFilter:
+                      dataSet:
+                        identifier:
+                          id: date
+                          type: dataset
+                      from: -12
+                      granularity: GDC.time.month
+                      to: -1
+                properties:
+                  controls:
+                    colorMapping:
+                      - color:
+                          type: guid
+                          value: '20'
+                        id: 2ba0b87b59ca41a4b1530e81a5c1d081
+                      - color:
+                          type: guid
+                          value: '4'
+                        id: ec0606894b9f4897b7beaf1550608928
+                    dualAxis: true
+                    legend:
+                      position: bottom
+                    primaryChartType: column
+                    secondaryChartType: line
+                    secondary_yaxis:
+                      measures:
+                        - ec0606894b9f4897b7beaf1550608928
+                    xaxis:
+                      name:
+                        visible: false
+                      rotation: auto
+                version: '2'
+                visualizationUrl: local:combo2
+              id: customers_trend
+              title: Customers Trend
+            - content:
+                buckets:
+                  - items:
+                      - measure:
+                          definition:
+                            measureDefinition:
+                              filters: []
+                              item:
+                                identifier:
+                                  id: percent_revenue_per_product
+                                  type: metric
+                          localIdentifier: 08d8346c1ce7438994b251991c0fbf65
+                          title: '% Revenue per Product'
+                      - measure:
+                          definition:
+                            measureDefinition:
+                              filters: []
+                              item:
+                                identifier:
+                                  id: revenue
+                                  type: metric
+                          localIdentifier: b2350c06688b4da9b3833ebcce65527f
+                          title: Revenue
+                    localIdentifier: measures
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: customer_name
+                              type: label
+                          localIdentifier: 7a4045fd00ac44579f52406df679435f
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: products.category
+                              type: label
+                          localIdentifier: 6a003ffd14994237ba64c4a02c488429
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: product_name
+                              type: label
+                          localIdentifier: 75ea396d0c8b48098e31dccf8b5801d3
+                    localIdentifier: attribute
+                filters:
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: customer_name
+                          type: label
+                      notIn:
+                        values: []
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: products.category
+                          type: label
+                      notIn:
+                        values: []
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: product_name
+                          type: label
+                      notIn:
+                        values: []
+                properties: {}
+                sorts:
+                  - attributeSortItem:
+                      attributeIdentifier: 7a4045fd00ac44579f52406df679435f
+                      direction: asc
+                version: '2'
+                visualizationUrl: local:table
+              id: percent_revenue_per_product_by_customer_and_category
+              title: '% Revenue per Product by Customer and Category'
+            - content:
+                buckets:
+                  - items:
+                      - measure:
+                          definition:
+                            measureDefinition:
+                              filters: []
+                              item:
+                                identifier:
+                                  id: amount_of_active_customers
+                                  type: metric
+                          localIdentifier: 1a14cdc1293c46e89a2e25d3e741d235
+                          title: '# of Active Customers'
+                    localIdentifier: measures
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: date.month
+                              type: label
+                          localIdentifier: c1feca1864244ec2ace7a9b9d7fda231
+                    localIdentifier: view
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: region
+                              type: label
+                          localIdentifier: 530cddbd7ca04d039e73462d81ed44d5
+                    localIdentifier: stack
+                filters:
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: region
+                          type: label
+                      notIn:
+                        values: []
+                  - relativeDateFilter:
+                      dataSet:
+                        identifier:
+                          id: date
+                          type: dataset
+                      from: -11
+                      granularity: GDC.time.month
+                      to: 0
+                properties:
+                  controls:
+                    legend:
+                      position: bottom
+                    stackMeasuresToPercent: true
+                version: '2'
+                visualizationUrl: local:area
+              id: percentage_of_customers_by_region
+              title: Percentage of Customers by Region
+            - content:
+                buckets:
+                  - items:
+                      - measure:
+                          definition:
+                            measureDefinition:
+                              filters: []
+                              item:
+                                identifier:
+                                  id: revenue
+                                  type: metric
+                          localIdentifier: 590d332ef686468b8878ae41b23341c6
+                          title: Revenue
+                    localIdentifier: measures
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: products.category
+                              type: label
+                          localIdentifier: b166c71091864312a14c7ae8ff886ffe
+                    localIdentifier: view
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: product_name
+                              type: label
+                          localIdentifier: e920a50e0bbb49788df0aac53634c1cd
+                    localIdentifier: segment
+                filters:
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: products.category
+                          type: label
+                      notIn:
+                        values: []
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: product_name
+                          type: label
+                      notIn:
+                        values: []
+                properties:
+                  controls:
+                    legend:
+                      position: bottom
+                version: '2'
+                visualizationUrl: local:treemap
+              id: product_breakdown
+              title: Product Breakdown
+            - content:
+                buckets:
+                  - items:
+                      - measure:
+                          definition:
+                            measureDefinition:
+                              computeRatio: true
+                              filters: []
+                              item:
+                                identifier:
+                                  id: revenue
+                                  type: metric
+                          format: '#,##0.00%'
+                          localIdentifier: 162b857af49d45769bc12604a5c192b9
+                          title: '% Revenue'
+                    localIdentifier: measures
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: products.category
+                              type: label
+                          localIdentifier: fe513cef1c6244a5ac21c5f49c56b108
+                    localIdentifier: view
+                filters:
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: product_name
+                          type: label
+                      notIn:
+                        values: []
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: products.category
+                          type: label
+                      notIn:
+                        values: []
+                properties:
+                  controls:
+                    dataLabels:
+                      visible: auto
+                    legend:
+                      position: bottom
+                version: '2'
+                visualizationUrl: local:donut
+              id: product_categories_pie_chart
+              title: Product Categories Pie Chart
+            - content:
+                buckets:
+                  - items:
+                      - measure:
+                          alias: Previous Period
+                          definition:
+                            popMeasureDefinition:
+                              measureIdentifier: c82e025fa2db4afea9a600a424591dbe
+                              popAttribute:
+                                identifier:
+                                  id: date.year
+                                  type: attribute
+                          localIdentifier: c82e025fa2db4afea9a600a424591dbe_pop
+                      - measure:
+                          alias: This Period
+                          definition:
+                            measureDefinition:
+                              filters: []
+                              item:
+                                identifier:
+                                  id: revenue
+                                  type: metric
+                          localIdentifier: c82e025fa2db4afea9a600a424591dbe
+                          title: Revenue
+                    localIdentifier: measures
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: products.category
+                              type: label
+                          localIdentifier: c804ef5ba7944a5a9f360c86a9e95e9a
+                    localIdentifier: view
+                filters:
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: product_name
+                          type: label
+                      notIn:
+                        values: []
+                  - relativeDateFilter:
+                      dataSet:
+                        identifier:
+                          id: date
+                          type: dataset
+                      from: -11
+                      granularity: GDC.time.month
+                      to: 0
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: products.category
+                          type: label
+                      notIn:
+                        values: []
+                properties:
+                  controls:
+                    legend:
+                      position: bottom
+                    stackMeasures: false
+                    xaxis:
+                      name:
+                        visible: false
+                    yaxis:
+                      name:
+                        visible: false
+                version: '2'
+                visualizationUrl: local:column
+              id: product_revenue_comparison-over_previous_period
+              title: Product Revenue Comparison (over previous period)
+            - content:
+                buckets:
+                  - items:
+                      - measure:
+                          alias: Number of Orders
+                          definition:
+                            measureDefinition:
+                              filters: []
+                              item:
+                                identifier:
+                                  id: amount_of_orders
+                                  type: metric
+                          localIdentifier: aeb5d51a162d4b59aba3bd6ddebcc780
+                          title: '# of Orders'
+                    localIdentifier: measures
+                  - items:
+                      - measure:
+                          definition:
+                            measureDefinition:
+                              filters: []
+                              item:
+                                identifier:
+                                  id: revenue
+                                  type: metric
+                          localIdentifier: 94b3edd3a73c4a48a4d13bbe9442cc98
+                          title: Revenue
+                    localIdentifier: secondary_measures
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: product_name
+                              type: label
+                          localIdentifier: d2a991bdd123448eb2be73d79f1180c4
+                    localIdentifier: attribute
+                filters:
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: product_name
+                          type: label
+                      notIn:
+                        values: []
+                properties:
+                  controls:
+                    dataLabels:
+                      visible: auto
+                    grid:
+                      enabled: true
+                version: '2'
+                visualizationUrl: local:scatter
+              id: product_saleability
+              title: Product Saleability
+            - content:
+                buckets:
+                  - items:
+                      - measure:
+                          alias: Items Sold
+                          definition:
+                            measureDefinition:
+                              aggregation: sum
+                              filters: []
+                              item:
+                                identifier:
+                                  id: quantity
+                                  type: fact
+                          format: '#,##0.00'
+                          localIdentifier: 29486504dd0e4a36a18b0b2f792d3a46
+                          title: Sum of Quantity
+                      - measure:
+                          definition:
+                            measureDefinition:
+                              aggregation: avg
+                              filters: []
+                              item:
+                                identifier:
+                                  id: price
+                                  type: fact
+                          format: '#,##0.00'
+                          localIdentifier: aa6391acccf1452f8011201aef9af492
+                          title: Avg Price
+                      - measure:
+                          definition:
+                            measureDefinition:
+                              filters: []
+                              item:
+                                identifier:
+                                  id: percent_revenue_in_category
+                                  type: metric
+                          localIdentifier: 2cd39539d8da46c9883e63caa3ba7cc0
+                          title: '% Revenue in Category'
+                      - measure:
+                          alias: Total Revenue
+                          definition:
+                            measureDefinition:
+                              filters: []
+                              item:
+                                identifier:
+                                  id: revenue
+                                  type: metric
+                          localIdentifier: 9a0f08331c094c7facf2a0b4f418de0a
+                          title: Revenue
+                    localIdentifier: measures
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: products.category
+                              type: label
+                          localIdentifier: 06bc6b3b9949466494e4f594c11f1bff
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: product_name
+                              type: label
+                          localIdentifier: 192668bfb6a74e9ab7b5d1ce7cb68ea3
+                    localIdentifier: attribute
+                filters:
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: customer_name
+                          type: label
+                      notIn:
+                        values: []
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: product_name
+                          type: label
+                      notIn:
+                        values: []
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: products.category
+                          type: label
+                      notIn:
+                        values: []
+                properties: {}
+                sorts:
+                  - attributeSortItem:
+                      attributeIdentifier: 06bc6b3b9949466494e4f594c11f1bff
+                      direction: asc
+                version: '2'
+                visualizationUrl: local:table
+              id: revenue_and_quantity_by_product_and_category
+              title: Revenue and Quantity by Product and Category
+            - content:
+                buckets:
+                  - items:
+                      - measure:
+                          definition:
+                            measureDefinition:
+                              filters: []
+                              item:
+                                identifier:
+                                  id: revenue
+                                  type: metric
+                          localIdentifier: 7df6c34387744d69b23ec92e1a5cf543
+                          title: Revenue
+                    localIdentifier: measures
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: date.month
+                              type: label
+                          localIdentifier: 4bb4fc1986c546de9ad976e6ec23fed4
+                    localIdentifier: trend
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: products.category
+                              type: label
+                          localIdentifier: 34bddcb1cd024902a82396216b0fa9d8
+                    localIdentifier: segment
+                filters:
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: products.category
+                          type: label
+                      notIn:
+                        values: []
+                  - relativeDateFilter:
+                      dataSet:
+                        identifier:
+                          id: date
+                          type: dataset
+                      granularity: GDC.time.year
+                properties:
+                  controls:
+                    legend:
+                      position: bottom
+                version: '2'
+                visualizationUrl: local:line
+              id: revenue_by_category_trend
+              title: Revenue by Category Trend
+            - content:
+                buckets:
+                  - items:
+                      - measure:
+                          definition:
+                            measureDefinition:
+                              filters: []
+                              item:
+                                identifier:
+                                  id: revenue
+                                  type: metric
+                          localIdentifier: 4ae3401bdbba4938afe983df4ba04e1c
+                          title: Revenue
+                    localIdentifier: measures
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: product_name
+                              type: label
+                          localIdentifier: 1c8ba72dbfc84ddd913bf81dc355c427
+                    localIdentifier: view
+                filters:
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: product_name
+                          type: label
+                      notIn:
+                        values: []
+                properties: {}
+                version: '2'
+                visualizationUrl: local:bar
+              id: revenue_by_product
+              title: Revenue by Product
+            - content:
+                buckets:
+                  - items:
+                      - measure:
+                          definition:
+                            measureDefinition:
+                              filters: []
+                              item:
+                                identifier:
+                                  id: campaign_spend
+                                  type: metric
+                          localIdentifier: 13a50d811e474ac6808d8da7f4673b35
+                          title: Campaign Spend
+                    localIdentifier: measures
+                  - items:
+                      - measure:
+                          definition:
+                            measureDefinition:
+                              filters: []
+                              item:
+                                identifier:
+                                  id: revenue_per_dollar_spent
+                                  type: metric
+                          localIdentifier: a0f15e82e6334280a44dbedc7d086e7c
+                          title: Revenue per Dollar Spent
+                    localIdentifier: secondary_measures
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: campaign_name
+                              type: label
+                          localIdentifier: 1d9fa968bafb423eb29c938dfb1207ff
+                    localIdentifier: attribute
+                filters:
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: campaign_name
+                          type: label
+                      notIn:
+                        values: []
+                properties:
+                  controls:
+                    xaxis:
+                      min: '0'
+                    yaxis:
+                      min: '0'
+                version: '2'
+                visualizationUrl: local:scatter
+              id: revenue_per_usd_vs_spend_by_campaign
+              title: Revenue per $ vs Spend by Campaign
+            - content:
+                buckets:
+                  - items:
+                      - measure:
+                          definition:
+                            measureDefinition:
+                              computeRatio: false
+                              filters: []
+                              item:
+                                identifier:
+                                  id: revenue
+                                  type: metric
+                          localIdentifier: 60c854969a9c4c278ab596d99c222e92
+                          title: Revenue
+                    localIdentifier: measures
+                  - items:
+                      - measure:
+                          alias: Number of Orders
+                          definition:
+                            measureDefinition:
+                              computeRatio: false
+                              filters: []
+                              item:
+                                identifier:
+                                  id: amount_of_orders
+                                  type: metric
+                          localIdentifier: c2fa7ef48cc54af99f8c280eb451e051
+                          title: '# of Orders'
+                    localIdentifier: secondary_measures
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: date.month
+                              type: label
+                          localIdentifier: 413ac374b65648fa96826ca01d47bdda
+                    localIdentifier: view
+                filters:
+                  - relativeDateFilter:
+                      dataSet:
+                        identifier:
+                          id: date
+                          type: dataset
+                      from: -3
+                      granularity: GDC.time.quarter
+                      to: 0
+                properties:
+                  controls:
+                    dualAxis: true
+                    legend:
+                      position: bottom
+                    primaryChartType: column
+                    secondaryChartType: line
+                    secondary_yaxis:
+                      measures:
+                        - c2fa7ef48cc54af99f8c280eb451e051
+                    xaxis:
+                      name:
+                        visible: false
+                      rotation: auto
+                version: '2'
+                visualizationUrl: local:combo2
+              id: revenue_trend
+              title: Revenue Trend
+            - content:
+                buckets:
+                  - items:
+                      - measure:
+                          definition:
+                            measureDefinition:
+                              filters: []
+                              item:
+                                identifier:
+                                  id: revenue_top_10
+                                  type: metric
+                          localIdentifier: 3f127ccfe57a40399e23f9ae2a4ad810
+                          title: Revenue / Top 10
+                    localIdentifier: measures
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: customer_name
+                              type: label
+                          localIdentifier: f4e39e24f11e4827a191c30d65c89d2c
+                    localIdentifier: view
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: state
+                              type: label
+                          localIdentifier: bbccd430176d428caed54c99afc9589e
+                    localIdentifier: stack
+                filters:
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: customer_name
+                          type: label
+                      notIn:
+                        values: []
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: state
+                          type: label
+                      notIn:
+                        values: []
+                properties:
+                  controls:
+                    legend:
+                      position: bottom
+                version: '2'
+                visualizationUrl: local:bar
+              id: top_10_customers
+              title: Top 10 Customers
+            - content:
+                buckets:
+                  - items:
+                      - measure:
+                          definition:
+                            measureDefinition:
+                              filters: []
+                              item:
+                                identifier:
+                                  id: revenue_top_10
+                                  type: metric
+                          localIdentifier: 77dc71bbac92412bac5f94284a5919df
+                          title: Revenue / Top 10
+                    localIdentifier: measures
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: product_name
+                              type: label
+                          localIdentifier: 781952e728204dcf923142910cc22ae2
+                    localIdentifier: view
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: products.category
+                              type: label
+                          localIdentifier: fe513cef1c6244a5ac21c5f49c56b108
+                    localIdentifier: stack
+                filters:
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: product_name
+                          type: label
+                      notIn:
+                        values: []
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: products.category
+                          type: label
+                      notIn:
+                        values: []
+                properties:
+                  controls:
+                    legend:
+                      position: bottom
+                version: '2'
+                visualizationUrl: local:bar
+              id: top_10_products
+              title: Top 10 Products
+      headers:
+        Accept-Encoding:
+          - br, gzip, deflate
+        Content-Type:
+          - application/json
+        X-GDC-VALIDATE-RELATIONS:
+          - 'true'
+        X-Requested-With:
+          - XMLHttpRequest
+      method: PUT
+      uri: http://localhost:3000/api/v1/layout/workspaces/demo/analyticsModel
+    response:
+      body:
+        string: ''
+      headers:
+        DATE: *id001
+        Expires:
+          - '0'
+        Pragma:
+          - no-cache
+        X-Content-Type-Options:
+          - nosniff
+        X-GDC-TRACE-ID: *id001
+      status:
+        code: 204
+        message: No Content
+  - request:
+      body: null
+      headers:
+        Accept:
+          - application/json
+        Accept-Encoding:
+          - br, gzip, deflate
+        X-GDC-VALIDATE-RELATIONS:
+          - 'true'
+        X-Requested-With:
+          - XMLHttpRequest
+      method: GET
+      uri: http://localhost:3000/api/v1/layout/workspaces/demo/analyticsModel?exclude=ACTIVITY_INFO
+    response:
+      body:
+        string:
+          analytics:
+            analyticalDashboardExtensions: []
+            analyticalDashboards:
+              - content:
+                  filterContextRef:
+                    identifier:
+                      id: campaign_name_filter
+                      type: filterContext
+                  filters:
+                    - measureValueFilter:
+                        conditions:
+                          - operator: GREATER_THAN
+                            value: 1000.0
+                        measure:
+                          identifier:
+                            id: order_amount
+                            type: metric
+                        title: Order Amount > 1000
+                    - measureValueFilter:
+                        conditions:
+                          - from: 500.0
+                            operator: BETWEEN
+                            to: 2000.0
+                        measure:
+                          identifier:
+                            id: order_amount
+                            type: metric
+                        title: Order Amount 500-2000
+                  layout:
+                    sections:
+                      - header:
+                          description: The first insight shows a breakdown of spend
+                            by category and campaign. The second shows revenue per
+                            $ spend, for each campaign, to demonstrate, how campaigns
+                            are successful.
+                          title: Spend breakdown and Revenue
+                        items:
+                          - size:
+                              xl:
+                                gridWidth: 6
+                            type: IDashboardLayoutItem
+                            widget:
+                              description: ''
+                              drills: []
+                              ignoreDashboardFilters: []
+                              insight:
+                                identifier:
+                                  id: campaign_spend
+                                  type: visualizationObject
+                              properties: {}
+                              title: Campaign Spend
+                              type: insight
+                          - size:
+                              xl:
+                                gridWidth: 6
+                            type: IDashboardLayoutItem
+                            widget:
+                              description: ''
+                              drills: []
+                              ignoreDashboardFilters: []
+                              insight:
+                                identifier:
+                                  id: revenue_per_usd_vs_spend_by_campaign
+                                  type: visualizationObject
+                              properties: {}
+                              title: Revenue per $ vs Spend by Campaign
+                              type: insight
+                        type: IDashboardLayoutSection
+                    type: IDashboardLayout
+                  version: '2'
+                description: ''
+                id: campaign
+                permissions:
+                  - assigneeRule:
+                      type: allWorkspaceUsers
+                    name: VIEW
+                title: Campaign
+              - content:
+                  filterContextRef:
+                    identifier:
+                      id: campaign_name_filter
+                      type: filterContext
+                  layout:
+                    sections:
+                      - items:
+                          - size:
+                              xl:
+                                gridWidth: 12
+                            type: IDashboardLayoutItem
+                            widget:
+                              description: ''
+                              drills: []
+                              ignoreDashboardFilters: []
+                              insight:
+                                identifier:
+                                  id: top_10_products
+                                  type: visualizationObject
+                              properties: {}
+                              title: DHO simple
+                              type: insight
+                        type: IDashboardLayoutSection
+                    type: IDashboardLayout
+                  plugins:
+                    - plugin:
+                        identifier:
+                          id: dashboard_plugin_1
+                          type: dashboardPlugin
+                      version: '2'
+                  version: '2'
+                id: dashboard_plugin
+                title: Dashboard plugin
+              - content:
+                  filterContextRef:
+                    identifier:
+                      id: region_filter
+                      type: filterContext
+                  layout:
+                    sections:
+                      - items:
+                          - size:
+                              xl:
+                                gridWidth: 6
+                            type: IDashboardLayoutItem
+                            widget:
+                              dateDataSet:
+                                identifier:
+                                  id: date
+                                  type: dataset
+                              description: ''
+                              drills: []
+                              ignoreDashboardFilters: []
+                              insight:
+                                identifier:
+                                  id: top_10_products
+                                  type: visualizationObject
+                              properties: {}
+                              title: Top 10 Products
+                              type: insight
+                          - size:
+                              xl:
+                                gridWidth: 6
+                            type: IDashboardLayoutItem
+                            widget:
+                              dateDataSet:
+                                identifier:
+                                  id: date
+                                  type: dataset
+                              description: ''
+                              drills: []
+                              ignoreDashboardFilters: []
+                              insight:
+                                identifier:
+                                  id: revenue_trend
+                                  type: visualizationObject
+                              properties: {}
+                              title: Revenue Trend
+                              type: insight
+                          - size:
+                              xl:
+                                gridWidth: 6
+                            type: IDashboardLayoutItem
+                            widget:
+                              dateDataSet:
+                                identifier:
+                                  id: date
+                                  type: dataset
+                              description: ''
+                              drills: []
+                              ignoreDashboardFilters: []
+                              insight:
+                                identifier:
+                                  id: customers_trend
+                                  type: visualizationObject
+                              properties: {}
+                              title: Customers Trend
+                              type: insight
+                          - size:
+                              xl:
+                                gridWidth: 6
+                            type: IDashboardLayoutItem
+                            widget:
+                              dateDataSet:
+                                identifier:
+                                  id: date
+                                  type: dataset
+                              description: ''
+                              drills: []
+                              ignoreDashboardFilters: []
+                              insight:
+                                identifier:
+                                  id: product_categories_pie_chart
+                                  type: visualizationObject
+                              properties: {}
+                              title: Product Categories Pie Chart
+                              type: insight
+                          - size:
+                              xl:
+                                gridWidth: 6
+                            type: IDashboardLayoutItem
+                            widget:
+                              dateDataSet:
+                                identifier:
+                                  id: date
+                                  type: dataset
+                              description: ''
+                              drills: []
+                              ignoreDashboardFilters: []
+                              insight:
+                                identifier:
+                                  id: product_breakdown
+                                  type: visualizationObject
+                              properties: {}
+                              title: Product Breakdown
+                              type: insight
+                          - size:
+                              xl:
+                                gridWidth: 6
+                            type: IDashboardLayoutItem
+                            widget:
+                              dateDataSet:
+                                identifier:
+                                  id: date
+                                  type: dataset
+                              description: ''
+                              drills: []
+                              ignoreDashboardFilters: []
+                              insight:
+                                identifier:
+                                  id: product_saleability
+                                  type: visualizationObject
+                              properties: {}
+                              title: Product Saleability
+                              type: insight
+                          - size:
+                              xl:
+                                gridWidth: 12
+                            type: IDashboardLayoutItem
+                            widget:
+                              dateDataSet:
+                                identifier:
+                                  id: date
+                                  type: dataset
+                              description: ''
+                              drills: []
+                              ignoreDashboardFilters: []
+                              insight:
+                                identifier:
+                                  id: percent_revenue_per_product_by_customer_and_category
+                                  type: visualizationObject
+                              properties: {}
+                              title: '% Revenue per Product by Customer and Category'
+                              type: insight
+                        type: IDashboardLayoutSection
+                    type: IDashboardLayout
+                  version: '2'
+                description: ''
+                id: product_and_category
+                title: Product & Category
+            attributeHierarchies: []
+            dashboardPlugins:
+              - content:
+                  url: https://www.example.com
+                  version: '2'
+                description: Testing record dashboard_plugin_1
+                id: dashboard_plugin_1
+                title: dashboard_plugin_1
+              - content:
+                  url: https://www.example.com
+                  version: '2'
+                description: Testing record dashboard_plugin_2
+                id: dashboard_plugin_2
+                title: dashboard_plugin_2
+            exportDefinitions: []
+            filterContexts:
+              - content:
+                  filters:
+                    - dateFilter:
+                        from: '0'
+                        granularity: GDC.time.month
+                        to: '0'
+                        type: relative
+                    - attributeFilter:
+                        attributeElements:
+                          uris: []
+                        displayForm:
+                          identifier:
+                            id: campaign_name
+                            type: label
+                        filterElementsBy: []
+                        localIdentifier: 14b0807447ef4bc28f43e4fc5c337d1d
+                        negativeSelection: true
+                  version: '2'
+                description: ''
+                id: campaign_name_filter
+                title: filterContext
+              - content:
+                  filters:
+                    - attributeFilter:
+                        attributeElements:
+                          uris: []
+                        displayForm:
+                          identifier:
+                            id: region
+                            type: label
+                        filterElementsBy: []
+                        localIdentifier: 2d5ef8df82444f6ba27b45f0990ee6af
+                        negativeSelection: true
+                  version: '2'
+                description: ''
+                id: region_filter
+                title: filterContext
+            memoryItems: []
+            metrics:
+              - content:
+                  format: '#,##0'
+                  maql: SELECT COUNT({attribute/customer_id},{attribute/order_line_id})
+                id: amount_of_active_customers
+                title: '# of Active Customers'
+              - content:
+                  format: '#,##0'
+                  maql: SELECT COUNT({attribute/order_id})
+                id: amount_of_orders
+                title: '# of Orders'
+              - content:
+                  format: '#,##0'
+                  maql: 'SELECT {metric/amount_of_active_customers} WHERE (SELECT
+                    {metric/revenue} BY {attribute/customer_id}) >  10000 '
+                id: amount_of_top_customers
+                title: '# of Top Customers'
+              - content:
+                  format: '#,##0.00'
+                  maql: SELECT {metric/amount_of_orders} WHERE NOT ({label/order_status}
+                    IN ("Returned", "Canceled"))
+                description: ''
+                id: amount_of_valid_orders
+                title: '# of Valid Orders'
+              - content:
+                  format: $#,##0
+                  maql: SELECT SUM({fact/spend})
+                id: campaign_spend
+                title: Campaign Spend
+              - content:
+                  format: $#,##0
+                  maql: SELECT SUM({fact/price}*{fact/quantity})
+                id: order_amount
+                title: Order Amount
+              - content:
+                  format: '#,##0.0%'
+                  maql: SELECT {metric/revenue} / {metric/total_revenue}
+                id: percent_revenue
+                title: '% Revenue'
+              - content:
+                  format: '#,##0.0%'
+                  maql: "SELECT\n (SELECT {metric/revenue} WHERE (SELECT {metric/revenue_top_10}\
+                    \ BY {attribute/customer_id}) > 0)\n  /\n {metric/revenue}"
+                id: percent_revenue_from_top_10_customers
+                title: '% Revenue from Top 10 Customers'
+              - content:
+                  format: '#,##0.0%'
+                  maql: "SELECT\n (SELECT {metric/revenue} WHERE (SELECT {metric/revenue_top_10_percent}\
+                    \ BY {attribute/customer_id}) > 0)\n  /\n {metric/revenue}"
+                id: percent_revenue_from_top_10_percent_customers
+                title: '% Revenue from Top 10% Customers'
+              - content:
+                  format: '#,##0.0%'
+                  maql: "SELECT\n (SELECT {metric/revenue} WHERE (SELECT {metric/revenue_top_10_percent}\
+                    \ BY {attribute/product_id}) > 0)\n  /\n {metric/revenue}"
+                id: percent_revenue_from_top_10_percent_products
+                title: '% Revenue from Top 10% Products'
+              - content:
+                  format: '#,##0.0%'
+                  maql: "SELECT\n (SELECT {metric/revenue} WHERE (SELECT {metric/revenue_top_10}\
+                    \ BY {attribute/product_id}) > 0)\n  /\n {metric/revenue}"
+                id: percent_revenue_from_top_10_products
+                title: '% Revenue from Top 10 Products'
+              - content:
+                  format: '#,##0.0%'
+                  maql: SELECT {metric/revenue} / (SELECT {metric/revenue} BY {attribute/products.category},
+                    ALL OTHER)
+                id: percent_revenue_in_category
+                title: '% Revenue in Category'
+              - content:
+                  format: '#,##0.0%'
+                  maql: SELECT {metric/revenue} / (SELECT {metric/revenue} BY ALL
+                    {attribute/product_id})
+                id: percent_revenue_per_product
+                title: '% Revenue per Product'
+              - content:
+                  format: $#,##0
+                  maql: SELECT {metric/order_amount} WHERE NOT ({label/order_status}
+                    IN ("Returned", "Canceled"))
+                description: ''
+                id: revenue
+                title: Revenue
+              - content:
+                  format: $#,##0
+                  maql: SELECT {metric/revenue} WHERE {label/products.category} IN
+                    ("Clothing")
+                id: revenue-clothing
+                title: Revenue (Clothing)
+              - content:
+                  format: $#,##0
+                  maql: SELECT {metric/revenue} WHERE {label/products.category} IN
+                    ( "Electronics")
+                id: revenue-electronic
+                title: Revenue (Electronic)
+              - content:
+                  format: $#,##0
+                  maql: SELECT {metric/revenue} WHERE {label/products.category} IN
+                    ("Home")
+                id: revenue-home
+                title: Revenue (Home)
+              - content:
+                  format: $#,##0
+                  maql: SELECT {metric/revenue} WHERE {label/products.category} IN
+                    ("Outdoor")
+                id: revenue-outdoor
+                title: Revenue (Outdoor)
+              - content:
+                  format: $#,##0.0
+                  maql: SELECT AVG(SELECT {metric/revenue} BY {attribute/customer_id})
+                id: revenue_per_customer
+                title: Revenue per Customer
+              - content:
+                  format: $#,##0.0
+                  maql: SELECT {metric/revenue} / {metric/campaign_spend}
+                id: revenue_per_dollar_spent
+                title: Revenue per Dollar Spent
+              - content:
+                  format: $#,##0
+                  maql: SELECT {metric/revenue} WHERE TOP(10) OF ({metric/revenue})
+                id: revenue_top_10
+                title: Revenue / Top 10
+              - content:
+                  format: $#,##0
+                  maql: SELECT {metric/revenue} WHERE TOP(10%) OF ({metric/revenue})
+                id: revenue_top_10_percent
+                title: Revenue / Top 10%
+              - content:
+                  format: $#,##0
+                  maql: SELECT {metric/revenue} BY ALL OTHER
+                id: total_revenue
+                title: Total Revenue
+              - content:
+                  format: $#,##0
+                  maql: SELECT {metric/total_revenue} WITHOUT PARENT FILTER
+                id: total_revenue-no_filters
+                title: Total Revenue (No Filters)
+            parameters: []
+            visualizationObjects:
+              - content:
+                  buckets:
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: campaign_spend
+                                    type: metric
+                            localIdentifier: d319bcb2d8c04442a684e3b3cd063381
+                            title: Campaign Spend
+                      localIdentifier: measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: campaign_channels.category
+                                type: label
+                            localIdentifier: 291c085e7df8420db84117ca49f59c49
+                      localIdentifier: view
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: campaign_name
+                                type: label
+                            localIdentifier: d9dd143d647d4d148405a60ec2cf59bc
+                      localIdentifier: segment
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: type
+                            type: label
+                        notIn:
+                          values: []
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: campaign_channels.category
+                            type: label
+                        notIn:
+                          values: []
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: campaign_name
+                            type: label
+                        notIn:
+                          values: []
+                  properties:
+                    controls:
+                      legend:
+                        position: bottom
+                  version: '2'
+                  visualizationUrl: local:treemap
+                id: campaign_spend
+                title: Campaign Spend
+              - content:
+                  buckets:
+                    - items:
+                        - measure:
+                            alias: Active Customers
+                            definition:
+                              measureDefinition:
+                                computeRatio: false
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: amount_of_active_customers
+                                    type: metric
+                            localIdentifier: 2ba0b87b59ca41a4b1530e81a5c1d081
+                            title: '# of Active Customers'
+                      localIdentifier: measures
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue_per_customer
+                                    type: metric
+                            localIdentifier: ec0606894b9f4897b7beaf1550608928
+                            title: Revenue per Customer
+                      localIdentifier: secondary_measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: date.month
+                                type: label
+                            localIdentifier: 0de7d7f08af7480aa636857a26be72b6
+                      localIdentifier: view
+                  filters:
+                    - relativeDateFilter:
+                        dataSet:
+                          identifier:
+                            id: date
+                            type: dataset
+                        from: -12
+                        granularity: GDC.time.month
+                        to: -1
+                  properties:
+                    controls:
+                      colorMapping:
+                        - color:
+                            type: guid
+                            value: '20'
+                          id: 2ba0b87b59ca41a4b1530e81a5c1d081
+                        - color:
+                            type: guid
+                            value: '4'
+                          id: ec0606894b9f4897b7beaf1550608928
+                      dualAxis: true
+                      legend:
+                        position: bottom
+                      primaryChartType: column
+                      secondaryChartType: line
+                      secondary_yaxis:
+                        measures:
+                          - ec0606894b9f4897b7beaf1550608928
+                      xaxis:
+                        name:
+                          visible: false
+                        rotation: auto
+                  version: '2'
+                  visualizationUrl: local:combo2
+                id: customers_trend
+                title: Customers Trend
+              - content:
+                  buckets:
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: percent_revenue_per_product
+                                    type: metric
+                            localIdentifier: 08d8346c1ce7438994b251991c0fbf65
+                            title: '% Revenue per Product'
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue
+                                    type: metric
+                            localIdentifier: b2350c06688b4da9b3833ebcce65527f
+                            title: Revenue
+                      localIdentifier: measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: customer_name
+                                type: label
+                            localIdentifier: 7a4045fd00ac44579f52406df679435f
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: products.category
+                                type: label
+                            localIdentifier: 6a003ffd14994237ba64c4a02c488429
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: product_name
+                                type: label
+                            localIdentifier: 75ea396d0c8b48098e31dccf8b5801d3
+                      localIdentifier: attribute
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: customer_name
+                            type: label
+                        notIn:
+                          values: []
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: products.category
+                            type: label
+                        notIn:
+                          values: []
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: product_name
+                            type: label
+                        notIn:
+                          values: []
+                  properties: {}
+                  sorts:
+                    - attributeSortItem:
+                        attributeIdentifier: 7a4045fd00ac44579f52406df679435f
+                        direction: asc
+                  version: '2'
+                  visualizationUrl: local:table
+                id: percent_revenue_per_product_by_customer_and_category
+                title: '% Revenue per Product by Customer and Category'
+              - content:
+                  buckets:
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: amount_of_active_customers
+                                    type: metric
+                            localIdentifier: 1a14cdc1293c46e89a2e25d3e741d235
+                            title: '# of Active Customers'
+                      localIdentifier: measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: date.month
+                                type: label
+                            localIdentifier: c1feca1864244ec2ace7a9b9d7fda231
+                      localIdentifier: view
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: region
+                                type: label
+                            localIdentifier: 530cddbd7ca04d039e73462d81ed44d5
+                      localIdentifier: stack
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: region
+                            type: label
+                        notIn:
+                          values: []
+                    - relativeDateFilter:
+                        dataSet:
+                          identifier:
+                            id: date
+                            type: dataset
+                        from: -11
+                        granularity: GDC.time.month
+                        to: 0
+                  properties:
+                    controls:
+                      legend:
+                        position: bottom
+                      stackMeasuresToPercent: true
+                  version: '2'
+                  visualizationUrl: local:area
+                id: percentage_of_customers_by_region
+                title: Percentage of Customers by Region
+              - content:
+                  buckets:
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue
+                                    type: metric
+                            localIdentifier: 590d332ef686468b8878ae41b23341c6
+                            title: Revenue
+                      localIdentifier: measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: products.category
+                                type: label
+                            localIdentifier: b166c71091864312a14c7ae8ff886ffe
+                      localIdentifier: view
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: product_name
+                                type: label
+                            localIdentifier: e920a50e0bbb49788df0aac53634c1cd
+                      localIdentifier: segment
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: products.category
+                            type: label
+                        notIn:
+                          values: []
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: product_name
+                            type: label
+                        notIn:
+                          values: []
+                  properties:
+                    controls:
+                      legend:
+                        position: bottom
+                  version: '2'
+                  visualizationUrl: local:treemap
+                id: product_breakdown
+                title: Product Breakdown
+              - content:
+                  buckets:
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                computeRatio: true
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue
+                                    type: metric
+                            format: '#,##0.00%'
+                            localIdentifier: 162b857af49d45769bc12604a5c192b9
+                            title: '% Revenue'
+                      localIdentifier: measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: products.category
+                                type: label
+                            localIdentifier: fe513cef1c6244a5ac21c5f49c56b108
+                      localIdentifier: view
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: product_name
+                            type: label
+                        notIn:
+                          values: []
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: products.category
+                            type: label
+                        notIn:
+                          values: []
+                  properties:
+                    controls:
+                      dataLabels:
+                        visible: auto
+                      legend:
+                        position: bottom
+                  version: '2'
+                  visualizationUrl: local:donut
+                id: product_categories_pie_chart
+                title: Product Categories Pie Chart
+              - content:
+                  buckets:
+                    - items:
+                        - measure:
+                            alias: Previous Period
+                            definition:
+                              popMeasureDefinition:
+                                measureIdentifier: c82e025fa2db4afea9a600a424591dbe
+                                popAttribute:
+                                  identifier:
+                                    id: date.year
+                                    type: attribute
+                            localIdentifier: c82e025fa2db4afea9a600a424591dbe_pop
+                        - measure:
+                            alias: This Period
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue
+                                    type: metric
+                            localIdentifier: c82e025fa2db4afea9a600a424591dbe
+                            title: Revenue
+                      localIdentifier: measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: products.category
+                                type: label
+                            localIdentifier: c804ef5ba7944a5a9f360c86a9e95e9a
+                      localIdentifier: view
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: product_name
+                            type: label
+                        notIn:
+                          values: []
+                    - relativeDateFilter:
+                        dataSet:
+                          identifier:
+                            id: date
+                            type: dataset
+                        from: -11
+                        granularity: GDC.time.month
+                        to: 0
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: products.category
+                            type: label
+                        notIn:
+                          values: []
+                  properties:
+                    controls:
+                      legend:
+                        position: bottom
+                      stackMeasures: false
+                      xaxis:
+                        name:
+                          visible: false
+                      yaxis:
+                        name:
+                          visible: false
+                  version: '2'
+                  visualizationUrl: local:column
+                id: product_revenue_comparison-over_previous_period
+                title: Product Revenue Comparison (over previous period)
+              - content:
+                  buckets:
+                    - items:
+                        - measure:
+                            alias: Number of Orders
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: amount_of_orders
+                                    type: metric
+                            localIdentifier: aeb5d51a162d4b59aba3bd6ddebcc780
+                            title: '# of Orders'
+                      localIdentifier: measures
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue
+                                    type: metric
+                            localIdentifier: 94b3edd3a73c4a48a4d13bbe9442cc98
+                            title: Revenue
+                      localIdentifier: secondary_measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: product_name
+                                type: label
+                            localIdentifier: d2a991bdd123448eb2be73d79f1180c4
+                      localIdentifier: attribute
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: product_name
+                            type: label
+                        notIn:
+                          values: []
+                  properties:
+                    controls:
+                      dataLabels:
+                        visible: auto
+                      grid:
+                        enabled: true
+                  version: '2'
+                  visualizationUrl: local:scatter
+                id: product_saleability
+                title: Product Saleability
+              - content:
+                  buckets:
+                    - items:
+                        - measure:
+                            alias: Items Sold
+                            definition:
+                              measureDefinition:
+                                aggregation: sum
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: quantity
+                                    type: fact
+                            format: '#,##0.00'
+                            localIdentifier: 29486504dd0e4a36a18b0b2f792d3a46
+                            title: Sum of Quantity
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                aggregation: avg
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: price
+                                    type: fact
+                            format: '#,##0.00'
+                            localIdentifier: aa6391acccf1452f8011201aef9af492
+                            title: Avg Price
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: percent_revenue_in_category
+                                    type: metric
+                            localIdentifier: 2cd39539d8da46c9883e63caa3ba7cc0
+                            title: '% Revenue in Category'
+                        - measure:
+                            alias: Total Revenue
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue
+                                    type: metric
+                            localIdentifier: 9a0f08331c094c7facf2a0b4f418de0a
+                            title: Revenue
+                      localIdentifier: measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: products.category
+                                type: label
+                            localIdentifier: 06bc6b3b9949466494e4f594c11f1bff
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: product_name
+                                type: label
+                            localIdentifier: 192668bfb6a74e9ab7b5d1ce7cb68ea3
+                      localIdentifier: attribute
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: customer_name
+                            type: label
+                        notIn:
+                          values: []
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: product_name
+                            type: label
+                        notIn:
+                          values: []
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: products.category
+                            type: label
+                        notIn:
+                          values: []
+                  properties: {}
+                  sorts:
+                    - attributeSortItem:
+                        attributeIdentifier: 06bc6b3b9949466494e4f594c11f1bff
+                        direction: asc
+                  version: '2'
+                  visualizationUrl: local:table
+                id: revenue_and_quantity_by_product_and_category
+                title: Revenue and Quantity by Product and Category
+              - content:
+                  buckets:
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue
+                                    type: metric
+                            localIdentifier: 7df6c34387744d69b23ec92e1a5cf543
+                            title: Revenue
+                      localIdentifier: measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: date.month
+                                type: label
+                            localIdentifier: 4bb4fc1986c546de9ad976e6ec23fed4
+                      localIdentifier: trend
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: products.category
+                                type: label
+                            localIdentifier: 34bddcb1cd024902a82396216b0fa9d8
+                      localIdentifier: segment
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: products.category
+                            type: label
+                        notIn:
+                          values: []
+                    - relativeDateFilter:
+                        dataSet:
+                          identifier:
+                            id: date
+                            type: dataset
+                        granularity: GDC.time.year
+                  properties:
+                    controls:
+                      legend:
+                        position: bottom
+                  version: '2'
+                  visualizationUrl: local:line
+                id: revenue_by_category_trend
+                title: Revenue by Category Trend
+              - content:
+                  buckets:
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue
+                                    type: metric
+                            localIdentifier: 4ae3401bdbba4938afe983df4ba04e1c
+                            title: Revenue
+                      localIdentifier: measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: product_name
+                                type: label
+                            localIdentifier: 1c8ba72dbfc84ddd913bf81dc355c427
+                      localIdentifier: view
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: product_name
+                            type: label
+                        notIn:
+                          values: []
+                  properties: {}
+                  version: '2'
+                  visualizationUrl: local:bar
+                id: revenue_by_product
+                title: Revenue by Product
+              - content:
+                  buckets:
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: campaign_spend
+                                    type: metric
+                            localIdentifier: 13a50d811e474ac6808d8da7f4673b35
+                            title: Campaign Spend
+                      localIdentifier: measures
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue_per_dollar_spent
+                                    type: metric
+                            localIdentifier: a0f15e82e6334280a44dbedc7d086e7c
+                            title: Revenue per Dollar Spent
+                      localIdentifier: secondary_measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: campaign_name
+                                type: label
+                            localIdentifier: 1d9fa968bafb423eb29c938dfb1207ff
+                      localIdentifier: attribute
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: campaign_name
+                            type: label
+                        notIn:
+                          values: []
+                  properties:
+                    controls:
+                      xaxis:
+                        min: '0'
+                      yaxis:
+                        min: '0'
+                  version: '2'
+                  visualizationUrl: local:scatter
+                id: revenue_per_usd_vs_spend_by_campaign
+                title: Revenue per $ vs Spend by Campaign
+              - content:
+                  buckets:
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                computeRatio: false
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue
+                                    type: metric
+                            localIdentifier: 60c854969a9c4c278ab596d99c222e92
+                            title: Revenue
+                      localIdentifier: measures
+                    - items:
+                        - measure:
+                            alias: Number of Orders
+                            definition:
+                              measureDefinition:
+                                computeRatio: false
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: amount_of_orders
+                                    type: metric
+                            localIdentifier: c2fa7ef48cc54af99f8c280eb451e051
+                            title: '# of Orders'
+                      localIdentifier: secondary_measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: date.month
+                                type: label
+                            localIdentifier: 413ac374b65648fa96826ca01d47bdda
+                      localIdentifier: view
+                  filters:
+                    - relativeDateFilter:
+                        dataSet:
+                          identifier:
+                            id: date
+                            type: dataset
+                        from: -3
+                        granularity: GDC.time.quarter
+                        to: 0
+                  properties:
+                    controls:
+                      dualAxis: true
+                      legend:
+                        position: bottom
+                      primaryChartType: column
+                      secondaryChartType: line
+                      secondary_yaxis:
+                        measures:
+                          - c2fa7ef48cc54af99f8c280eb451e051
+                      xaxis:
+                        name:
+                          visible: false
+                        rotation: auto
+                  version: '2'
+                  visualizationUrl: local:combo2
+                id: revenue_trend
+                title: Revenue Trend
+              - content:
+                  buckets:
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue_top_10
+                                    type: metric
+                            localIdentifier: 3f127ccfe57a40399e23f9ae2a4ad810
+                            title: Revenue / Top 10
+                      localIdentifier: measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: customer_name
+                                type: label
+                            localIdentifier: f4e39e24f11e4827a191c30d65c89d2c
+                      localIdentifier: view
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: state
+                                type: label
+                            localIdentifier: bbccd430176d428caed54c99afc9589e
+                      localIdentifier: stack
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: customer_name
+                            type: label
+                        notIn:
+                          values: []
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: state
+                            type: label
+                        notIn:
+                          values: []
+                  properties:
+                    controls:
+                      legend:
+                        position: bottom
+                  version: '2'
+                  visualizationUrl: local:bar
+                id: top_10_customers
+                title: Top 10 Customers
+              - content:
+                  buckets:
+                    - items:
+                        - measure:
+                            definition:
+                              measureDefinition:
+                                filters: []
+                                item:
+                                  identifier:
+                                    id: revenue_top_10
+                                    type: metric
+                            localIdentifier: 77dc71bbac92412bac5f94284a5919df
+                            title: Revenue / Top 10
+                      localIdentifier: measures
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: product_name
+                                type: label
+                            localIdentifier: 781952e728204dcf923142910cc22ae2
+                      localIdentifier: view
+                    - items:
+                        - attribute:
+                            displayForm:
+                              identifier:
+                                id: products.category
+                                type: label
+                            localIdentifier: fe513cef1c6244a5ac21c5f49c56b108
+                      localIdentifier: stack
+                  filters:
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: product_name
+                            type: label
+                        notIn:
+                          values: []
+                    - negativeAttributeFilter:
+                        displayForm:
+                          identifier:
+                            id: products.category
+                            type: label
+                        notIn:
+                          values: []
+                  properties:
+                    controls:
+                      legend:
+                        position: bottom
+                  version: '2'
+                  visualizationUrl: local:bar
+                id: top_10_products
+                title: Top 10 Products
+      headers:
+        Content-Type:
+          - application/json
+        DATE: *id001
+        Expires:
+          - '0'
+        Pragma:
+          - no-cache
+        X-Content-Type-Options:
+          - nosniff
+        X-GDC-TRACE-ID: *id001
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        analytics:
+          analyticalDashboardExtensions: []
+          analyticalDashboards:
+            - content:
+                filterContextRef:
+                  identifier:
+                    id: campaign_name_filter
+                    type: filterContext
+                layout:
+                  sections:
+                    - header:
+                        description: The first insight shows a breakdown of spend
+                          by category and campaign. The second shows revenue per $
+                          spend, for each campaign, to demonstrate, how campaigns
+                          are successful.
+                        title: Spend breakdown and Revenue
+                      items:
+                        - size:
+                            xl:
+                              gridWidth: 6
+                          type: IDashboardLayoutItem
+                          widget:
+                            description: ''
+                            drills: []
+                            ignoreDashboardFilters: []
+                            insight:
+                              identifier:
+                                id: campaign_spend
+                                type: visualizationObject
+                            properties: {}
+                            title: Campaign Spend
+                            type: insight
+                        - size:
+                            xl:
+                              gridWidth: 6
+                          type: IDashboardLayoutItem
+                          widget:
+                            description: ''
+                            drills: []
+                            ignoreDashboardFilters: []
+                            insight:
+                              identifier:
+                                id: revenue_per_usd_vs_spend_by_campaign
+                                type: visualizationObject
+                            properties: {}
+                            title: Revenue per $ vs Spend by Campaign
+                            type: insight
+                      type: IDashboardLayoutSection
+                  type: IDashboardLayout
+                version: '2'
+              description: ''
+              id: campaign
+              permissions:
+                - assigneeRule:
+                    type: allWorkspaceUsers
+                  name: VIEW
+              title: Campaign
+            - content:
+                filterContextRef:
+                  identifier:
+                    id: campaign_name_filter
+                    type: filterContext
+                layout:
+                  sections:
+                    - items:
+                        - size:
+                            xl:
+                              gridWidth: 12
+                          type: IDashboardLayoutItem
+                          widget:
+                            description: ''
+                            drills: []
+                            ignoreDashboardFilters: []
+                            insight:
+                              identifier:
+                                id: top_10_products
+                                type: visualizationObject
+                            properties: {}
+                            title: DHO simple
+                            type: insight
+                      type: IDashboardLayoutSection
+                  type: IDashboardLayout
+                plugins:
+                  - plugin:
+                      identifier:
+                        id: dashboard_plugin_1
+                        type: dashboardPlugin
+                    version: '2'
+                version: '2'
+              id: dashboard_plugin
+              title: Dashboard plugin
+            - content:
+                filterContextRef:
+                  identifier:
+                    id: region_filter
+                    type: filterContext
+                layout:
+                  sections:
+                    - items:
+                        - size:
+                            xl:
+                              gridWidth: 6
+                          type: IDashboardLayoutItem
+                          widget:
+                            dateDataSet:
+                              identifier:
+                                id: date
+                                type: dataset
+                            description: ''
+                            drills: []
+                            ignoreDashboardFilters: []
+                            insight:
+                              identifier:
+                                id: top_10_products
+                                type: visualizationObject
+                            properties: {}
+                            title: Top 10 Products
+                            type: insight
+                        - size:
+                            xl:
+                              gridWidth: 6
+                          type: IDashboardLayoutItem
+                          widget:
+                            dateDataSet:
+                              identifier:
+                                id: date
+                                type: dataset
+                            description: ''
+                            drills: []
+                            ignoreDashboardFilters: []
+                            insight:
+                              identifier:
+                                id: revenue_trend
+                                type: visualizationObject
+                            properties: {}
+                            title: Revenue Trend
+                            type: insight
+                        - size:
+                            xl:
+                              gridWidth: 6
+                          type: IDashboardLayoutItem
+                          widget:
+                            dateDataSet:
+                              identifier:
+                                id: date
+                                type: dataset
+                            description: ''
+                            drills: []
+                            ignoreDashboardFilters: []
+                            insight:
+                              identifier:
+                                id: customers_trend
+                                type: visualizationObject
+                            properties: {}
+                            title: Customers Trend
+                            type: insight
+                        - size:
+                            xl:
+                              gridWidth: 6
+                          type: IDashboardLayoutItem
+                          widget:
+                            dateDataSet:
+                              identifier:
+                                id: date
+                                type: dataset
+                            description: ''
+                            drills: []
+                            ignoreDashboardFilters: []
+                            insight:
+                              identifier:
+                                id: product_categories_pie_chart
+                                type: visualizationObject
+                            properties: {}
+                            title: Product Categories Pie Chart
+                            type: insight
+                        - size:
+                            xl:
+                              gridWidth: 6
+                          type: IDashboardLayoutItem
+                          widget:
+                            dateDataSet:
+                              identifier:
+                                id: date
+                                type: dataset
+                            description: ''
+                            drills: []
+                            ignoreDashboardFilters: []
+                            insight:
+                              identifier:
+                                id: product_breakdown
+                                type: visualizationObject
+                            properties: {}
+                            title: Product Breakdown
+                            type: insight
+                        - size:
+                            xl:
+                              gridWidth: 6
+                          type: IDashboardLayoutItem
+                          widget:
+                            dateDataSet:
+                              identifier:
+                                id: date
+                                type: dataset
+                            description: ''
+                            drills: []
+                            ignoreDashboardFilters: []
+                            insight:
+                              identifier:
+                                id: product_saleability
+                                type: visualizationObject
+                            properties: {}
+                            title: Product Saleability
+                            type: insight
+                        - size:
+                            xl:
+                              gridWidth: 12
+                          type: IDashboardLayoutItem
+                          widget:
+                            dateDataSet:
+                              identifier:
+                                id: date
+                                type: dataset
+                            description: ''
+                            drills: []
+                            ignoreDashboardFilters: []
+                            insight:
+                              identifier:
+                                id: percent_revenue_per_product_by_customer_and_category
+                                type: visualizationObject
+                            properties: {}
+                            title: '% Revenue per Product by Customer and Category'
+                            type: insight
+                      type: IDashboardLayoutSection
+                  type: IDashboardLayout
+                version: '2'
+              description: ''
+              id: product_and_category
+              title: Product & Category
+          attributeHierarchies: []
+          dashboardPlugins:
+            - content:
+                url: https://www.example.com
+                version: '2'
+              description: Testing record dashboard_plugin_1
+              id: dashboard_plugin_1
+              title: dashboard_plugin_1
+            - content:
+                url: https://www.example.com
+                version: '2'
+              description: Testing record dashboard_plugin_2
+              id: dashboard_plugin_2
+              title: dashboard_plugin_2
+          exportDefinitions: []
+          filterContexts:
+            - content:
+                filters:
+                  - dateFilter:
+                      from: '0'
+                      granularity: GDC.time.month
+                      to: '0'
+                      type: relative
+                  - attributeFilter:
+                      attributeElements:
+                        uris: []
+                      displayForm:
+                        identifier:
+                          id: campaign_name
+                          type: label
+                      filterElementsBy: []
+                      localIdentifier: 14b0807447ef4bc28f43e4fc5c337d1d
+                      negativeSelection: true
+                version: '2'
+              description: ''
+              id: campaign_name_filter
+              title: filterContext
+            - content:
+                filters:
+                  - attributeFilter:
+                      attributeElements:
+                        uris: []
+                      displayForm:
+                        identifier:
+                          id: region
+                          type: label
+                      filterElementsBy: []
+                      localIdentifier: 2d5ef8df82444f6ba27b45f0990ee6af
+                      negativeSelection: true
+                version: '2'
+              description: ''
+              id: region_filter
+              title: filterContext
+          memoryItems: []
+          metrics:
+            - content:
+                format: '#,##0'
+                maql: SELECT COUNT({attribute/customer_id},{attribute/order_line_id})
+              id: amount_of_active_customers
+              title: '# of Active Customers'
+            - content:
+                format: '#,##0'
+                maql: SELECT COUNT({attribute/order_id})
+              id: amount_of_orders
+              title: '# of Orders'
+            - content:
+                format: '#,##0'
+                maql: 'SELECT {metric/amount_of_active_customers} WHERE (SELECT {metric/revenue}
+                  BY {attribute/customer_id}) >  10000 '
+              id: amount_of_top_customers
+              title: '# of Top Customers'
+            - content:
+                format: '#,##0.00'
+                maql: SELECT {metric/amount_of_orders} WHERE NOT ({label/order_status}
+                  IN ("Returned", "Canceled"))
+              description: ''
+              id: amount_of_valid_orders
+              title: '# of Valid Orders'
+            - content:
+                format: $#,##0
+                maql: SELECT SUM({fact/spend})
+              id: campaign_spend
+              title: Campaign Spend
+            - content:
+                format: $#,##0
+                maql: SELECT SUM({fact/price}*{fact/quantity})
+              id: order_amount
+              title: Order Amount
+            - content:
+                format: '#,##0.0%'
+                maql: SELECT {metric/revenue} / {metric/total_revenue}
+              id: percent_revenue
+              title: '% Revenue'
+            - content:
+                format: '#,##0.0%'
+                maql: "SELECT\n (SELECT {metric/revenue} WHERE (SELECT {metric/revenue_top_10}\
+                  \ BY {attribute/customer_id}) > 0)\n  /\n {metric/revenue}"
+              id: percent_revenue_from_top_10_customers
+              title: '% Revenue from Top 10 Customers'
+            - content:
+                format: '#,##0.0%'
+                maql: "SELECT\n (SELECT {metric/revenue} WHERE (SELECT {metric/revenue_top_10_percent}\
+                  \ BY {attribute/customer_id}) > 0)\n  /\n {metric/revenue}"
+              id: percent_revenue_from_top_10_percent_customers
+              title: '% Revenue from Top 10% Customers'
+            - content:
+                format: '#,##0.0%'
+                maql: "SELECT\n (SELECT {metric/revenue} WHERE (SELECT {metric/revenue_top_10_percent}\
+                  \ BY {attribute/product_id}) > 0)\n  /\n {metric/revenue}"
+              id: percent_revenue_from_top_10_percent_products
+              title: '% Revenue from Top 10% Products'
+            - content:
+                format: '#,##0.0%'
+                maql: "SELECT\n (SELECT {metric/revenue} WHERE (SELECT {metric/revenue_top_10}\
+                  \ BY {attribute/product_id}) > 0)\n  /\n {metric/revenue}"
+              id: percent_revenue_from_top_10_products
+              title: '% Revenue from Top 10 Products'
+            - content:
+                format: '#,##0.0%'
+                maql: SELECT {metric/revenue} / (SELECT {metric/revenue} BY {attribute/products.category},
+                  ALL OTHER)
+              id: percent_revenue_in_category
+              title: '% Revenue in Category'
+            - content:
+                format: '#,##0.0%'
+                maql: SELECT {metric/revenue} / (SELECT {metric/revenue} BY ALL {attribute/product_id})
+              id: percent_revenue_per_product
+              title: '% Revenue per Product'
+            - content:
+                format: $#,##0
+                maql: SELECT {metric/order_amount} WHERE NOT ({label/order_status}
+                  IN ("Returned", "Canceled"))
+              description: ''
+              id: revenue
+              title: Revenue
+            - content:
+                format: $#,##0
+                maql: SELECT {metric/revenue} WHERE {label/products.category} IN ("Clothing")
+              id: revenue-clothing
+              title: Revenue (Clothing)
+            - content:
+                format: $#,##0
+                maql: SELECT {metric/revenue} WHERE {label/products.category} IN (
+                  "Electronics")
+              id: revenue-electronic
+              title: Revenue (Electronic)
+            - content:
+                format: $#,##0
+                maql: SELECT {metric/revenue} WHERE {label/products.category} IN ("Home")
+              id: revenue-home
+              title: Revenue (Home)
+            - content:
+                format: $#,##0
+                maql: SELECT {metric/revenue} WHERE {label/products.category} IN ("Outdoor")
+              id: revenue-outdoor
+              title: Revenue (Outdoor)
+            - content:
+                format: $#,##0.0
+                maql: SELECT AVG(SELECT {metric/revenue} BY {attribute/customer_id})
+              id: revenue_per_customer
+              title: Revenue per Customer
+            - content:
+                format: $#,##0.0
+                maql: SELECT {metric/revenue} / {metric/campaign_spend}
+              id: revenue_per_dollar_spent
+              title: Revenue per Dollar Spent
+            - content:
+                format: $#,##0
+                maql: SELECT {metric/revenue} WHERE TOP(10) OF ({metric/revenue})
+              id: revenue_top_10
+              title: Revenue / Top 10
+            - content:
+                format: $#,##0
+                maql: SELECT {metric/revenue} WHERE TOP(10%) OF ({metric/revenue})
+              id: revenue_top_10_percent
+              title: Revenue / Top 10%
+            - content:
+                format: $#,##0
+                maql: SELECT {metric/revenue} BY ALL OTHER
+              id: total_revenue
+              title: Total Revenue
+            - content:
+                format: $#,##0
+                maql: SELECT {metric/total_revenue} WITHOUT PARENT FILTER
+              id: total_revenue-no_filters
+              title: Total Revenue (No Filters)
+          parameters: []
+          visualizationObjects:
+            - content:
+                buckets:
+                  - items:
+                      - measure:
+                          definition:
+                            measureDefinition:
+                              filters: []
+                              item:
+                                identifier:
+                                  id: campaign_spend
+                                  type: metric
+                          localIdentifier: d319bcb2d8c04442a684e3b3cd063381
+                          title: Campaign Spend
+                    localIdentifier: measures
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: campaign_channels.category
+                              type: label
+                          localIdentifier: 291c085e7df8420db84117ca49f59c49
+                    localIdentifier: view
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: campaign_name
+                              type: label
+                          localIdentifier: d9dd143d647d4d148405a60ec2cf59bc
+                    localIdentifier: segment
+                filters:
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: type
+                          type: label
+                      notIn:
+                        values: []
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: campaign_channels.category
+                          type: label
+                      notIn:
+                        values: []
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: campaign_name
+                          type: label
+                      notIn:
+                        values: []
+                properties:
+                  controls:
+                    legend:
+                      position: bottom
+                version: '2'
+                visualizationUrl: local:treemap
+              id: campaign_spend
+              title: Campaign Spend
+            - content:
+                buckets:
+                  - items:
+                      - measure:
+                          alias: Active Customers
+                          definition:
+                            measureDefinition:
+                              computeRatio: false
+                              filters: []
+                              item:
+                                identifier:
+                                  id: amount_of_active_customers
+                                  type: metric
+                          localIdentifier: 2ba0b87b59ca41a4b1530e81a5c1d081
+                          title: '# of Active Customers'
+                    localIdentifier: measures
+                  - items:
+                      - measure:
+                          definition:
+                            measureDefinition:
+                              filters: []
+                              item:
+                                identifier:
+                                  id: revenue_per_customer
+                                  type: metric
+                          localIdentifier: ec0606894b9f4897b7beaf1550608928
+                          title: Revenue per Customer
+                    localIdentifier: secondary_measures
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: date.month
+                              type: label
+                          localIdentifier: 0de7d7f08af7480aa636857a26be72b6
+                    localIdentifier: view
+                filters:
+                  - relativeDateFilter:
+                      dataSet:
+                        identifier:
+                          id: date
+                          type: dataset
+                      from: -12
+                      granularity: GDC.time.month
+                      to: -1
+                properties:
+                  controls:
+                    colorMapping:
+                      - color:
+                          type: guid
+                          value: '20'
+                        id: 2ba0b87b59ca41a4b1530e81a5c1d081
+                      - color:
+                          type: guid
+                          value: '4'
+                        id: ec0606894b9f4897b7beaf1550608928
+                    dualAxis: true
+                    legend:
+                      position: bottom
+                    primaryChartType: column
+                    secondaryChartType: line
+                    secondary_yaxis:
+                      measures:
+                        - ec0606894b9f4897b7beaf1550608928
+                    xaxis:
+                      name:
+                        visible: false
+                      rotation: auto
+                version: '2'
+                visualizationUrl: local:combo2
+              id: customers_trend
+              title: Customers Trend
+            - content:
+                buckets:
+                  - items:
+                      - measure:
+                          definition:
+                            measureDefinition:
+                              filters: []
+                              item:
+                                identifier:
+                                  id: percent_revenue_per_product
+                                  type: metric
+                          localIdentifier: 08d8346c1ce7438994b251991c0fbf65
+                          title: '% Revenue per Product'
+                      - measure:
+                          definition:
+                            measureDefinition:
+                              filters: []
+                              item:
+                                identifier:
+                                  id: revenue
+                                  type: metric
+                          localIdentifier: b2350c06688b4da9b3833ebcce65527f
+                          title: Revenue
+                    localIdentifier: measures
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: customer_name
+                              type: label
+                          localIdentifier: 7a4045fd00ac44579f52406df679435f
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: products.category
+                              type: label
+                          localIdentifier: 6a003ffd14994237ba64c4a02c488429
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: product_name
+                              type: label
+                          localIdentifier: 75ea396d0c8b48098e31dccf8b5801d3
+                    localIdentifier: attribute
+                filters:
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: customer_name
+                          type: label
+                      notIn:
+                        values: []
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: products.category
+                          type: label
+                      notIn:
+                        values: []
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: product_name
+                          type: label
+                      notIn:
+                        values: []
+                properties: {}
+                sorts:
+                  - attributeSortItem:
+                      attributeIdentifier: 7a4045fd00ac44579f52406df679435f
+                      direction: asc
+                version: '2'
+                visualizationUrl: local:table
+              id: percent_revenue_per_product_by_customer_and_category
+              title: '% Revenue per Product by Customer and Category'
+            - content:
+                buckets:
+                  - items:
+                      - measure:
+                          definition:
+                            measureDefinition:
+                              filters: []
+                              item:
+                                identifier:
+                                  id: amount_of_active_customers
+                                  type: metric
+                          localIdentifier: 1a14cdc1293c46e89a2e25d3e741d235
+                          title: '# of Active Customers'
+                    localIdentifier: measures
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: date.month
+                              type: label
+                          localIdentifier: c1feca1864244ec2ace7a9b9d7fda231
+                    localIdentifier: view
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: region
+                              type: label
+                          localIdentifier: 530cddbd7ca04d039e73462d81ed44d5
+                    localIdentifier: stack
+                filters:
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: region
+                          type: label
+                      notIn:
+                        values: []
+                  - relativeDateFilter:
+                      dataSet:
+                        identifier:
+                          id: date
+                          type: dataset
+                      from: -11
+                      granularity: GDC.time.month
+                      to: 0
+                properties:
+                  controls:
+                    legend:
+                      position: bottom
+                    stackMeasuresToPercent: true
+                version: '2'
+                visualizationUrl: local:area
+              id: percentage_of_customers_by_region
+              title: Percentage of Customers by Region
+            - content:
+                buckets:
+                  - items:
+                      - measure:
+                          definition:
+                            measureDefinition:
+                              filters: []
+                              item:
+                                identifier:
+                                  id: revenue
+                                  type: metric
+                          localIdentifier: 590d332ef686468b8878ae41b23341c6
+                          title: Revenue
+                    localIdentifier: measures
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: products.category
+                              type: label
+                          localIdentifier: b166c71091864312a14c7ae8ff886ffe
+                    localIdentifier: view
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: product_name
+                              type: label
+                          localIdentifier: e920a50e0bbb49788df0aac53634c1cd
+                    localIdentifier: segment
+                filters:
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: products.category
+                          type: label
+                      notIn:
+                        values: []
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: product_name
+                          type: label
+                      notIn:
+                        values: []
+                properties:
+                  controls:
+                    legend:
+                      position: bottom
+                version: '2'
+                visualizationUrl: local:treemap
+              id: product_breakdown
+              title: Product Breakdown
+            - content:
+                buckets:
+                  - items:
+                      - measure:
+                          definition:
+                            measureDefinition:
+                              computeRatio: true
+                              filters: []
+                              item:
+                                identifier:
+                                  id: revenue
+                                  type: metric
+                          format: '#,##0.00%'
+                          localIdentifier: 162b857af49d45769bc12604a5c192b9
+                          title: '% Revenue'
+                    localIdentifier: measures
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: products.category
+                              type: label
+                          localIdentifier: fe513cef1c6244a5ac21c5f49c56b108
+                    localIdentifier: view
+                filters:
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: product_name
+                          type: label
+                      notIn:
+                        values: []
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: products.category
+                          type: label
+                      notIn:
+                        values: []
+                properties:
+                  controls:
+                    dataLabels:
+                      visible: auto
+                    legend:
+                      position: bottom
+                version: '2'
+                visualizationUrl: local:donut
+              id: product_categories_pie_chart
+              title: Product Categories Pie Chart
+            - content:
+                buckets:
+                  - items:
+                      - measure:
+                          alias: Previous Period
+                          definition:
+                            popMeasureDefinition:
+                              measureIdentifier: c82e025fa2db4afea9a600a424591dbe
+                              popAttribute:
+                                identifier:
+                                  id: date.year
+                                  type: attribute
+                          localIdentifier: c82e025fa2db4afea9a600a424591dbe_pop
+                      - measure:
+                          alias: This Period
+                          definition:
+                            measureDefinition:
+                              filters: []
+                              item:
+                                identifier:
+                                  id: revenue
+                                  type: metric
+                          localIdentifier: c82e025fa2db4afea9a600a424591dbe
+                          title: Revenue
+                    localIdentifier: measures
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: products.category
+                              type: label
+                          localIdentifier: c804ef5ba7944a5a9f360c86a9e95e9a
+                    localIdentifier: view
+                filters:
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: product_name
+                          type: label
+                      notIn:
+                        values: []
+                  - relativeDateFilter:
+                      dataSet:
+                        identifier:
+                          id: date
+                          type: dataset
+                      from: -11
+                      granularity: GDC.time.month
+                      to: 0
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: products.category
+                          type: label
+                      notIn:
+                        values: []
+                properties:
+                  controls:
+                    legend:
+                      position: bottom
+                    stackMeasures: false
+                    xaxis:
+                      name:
+                        visible: false
+                    yaxis:
+                      name:
+                        visible: false
+                version: '2'
+                visualizationUrl: local:column
+              id: product_revenue_comparison-over_previous_period
+              title: Product Revenue Comparison (over previous period)
+            - content:
+                buckets:
+                  - items:
+                      - measure:
+                          alias: Number of Orders
+                          definition:
+                            measureDefinition:
+                              filters: []
+                              item:
+                                identifier:
+                                  id: amount_of_orders
+                                  type: metric
+                          localIdentifier: aeb5d51a162d4b59aba3bd6ddebcc780
+                          title: '# of Orders'
+                    localIdentifier: measures
+                  - items:
+                      - measure:
+                          definition:
+                            measureDefinition:
+                              filters: []
+                              item:
+                                identifier:
+                                  id: revenue
+                                  type: metric
+                          localIdentifier: 94b3edd3a73c4a48a4d13bbe9442cc98
+                          title: Revenue
+                    localIdentifier: secondary_measures
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: product_name
+                              type: label
+                          localIdentifier: d2a991bdd123448eb2be73d79f1180c4
+                    localIdentifier: attribute
+                filters:
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: product_name
+                          type: label
+                      notIn:
+                        values: []
+                properties:
+                  controls:
+                    dataLabels:
+                      visible: auto
+                    grid:
+                      enabled: true
+                version: '2'
+                visualizationUrl: local:scatter
+              id: product_saleability
+              title: Product Saleability
+            - content:
+                buckets:
+                  - items:
+                      - measure:
+                          alias: Items Sold
+                          definition:
+                            measureDefinition:
+                              aggregation: sum
+                              filters: []
+                              item:
+                                identifier:
+                                  id: quantity
+                                  type: fact
+                          format: '#,##0.00'
+                          localIdentifier: 29486504dd0e4a36a18b0b2f792d3a46
+                          title: Sum of Quantity
+                      - measure:
+                          definition:
+                            measureDefinition:
+                              aggregation: avg
+                              filters: []
+                              item:
+                                identifier:
+                                  id: price
+                                  type: fact
+                          format: '#,##0.00'
+                          localIdentifier: aa6391acccf1452f8011201aef9af492
+                          title: Avg Price
+                      - measure:
+                          definition:
+                            measureDefinition:
+                              filters: []
+                              item:
+                                identifier:
+                                  id: percent_revenue_in_category
+                                  type: metric
+                          localIdentifier: 2cd39539d8da46c9883e63caa3ba7cc0
+                          title: '% Revenue in Category'
+                      - measure:
+                          alias: Total Revenue
+                          definition:
+                            measureDefinition:
+                              filters: []
+                              item:
+                                identifier:
+                                  id: revenue
+                                  type: metric
+                          localIdentifier: 9a0f08331c094c7facf2a0b4f418de0a
+                          title: Revenue
+                    localIdentifier: measures
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: products.category
+                              type: label
+                          localIdentifier: 06bc6b3b9949466494e4f594c11f1bff
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: product_name
+                              type: label
+                          localIdentifier: 192668bfb6a74e9ab7b5d1ce7cb68ea3
+                    localIdentifier: attribute
+                filters:
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: customer_name
+                          type: label
+                      notIn:
+                        values: []
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: product_name
+                          type: label
+                      notIn:
+                        values: []
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: products.category
+                          type: label
+                      notIn:
+                        values: []
+                properties: {}
+                sorts:
+                  - attributeSortItem:
+                      attributeIdentifier: 06bc6b3b9949466494e4f594c11f1bff
+                      direction: asc
+                version: '2'
+                visualizationUrl: local:table
+              id: revenue_and_quantity_by_product_and_category
+              title: Revenue and Quantity by Product and Category
+            - content:
+                buckets:
+                  - items:
+                      - measure:
+                          definition:
+                            measureDefinition:
+                              filters: []
+                              item:
+                                identifier:
+                                  id: revenue
+                                  type: metric
+                          localIdentifier: 7df6c34387744d69b23ec92e1a5cf543
+                          title: Revenue
+                    localIdentifier: measures
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: date.month
+                              type: label
+                          localIdentifier: 4bb4fc1986c546de9ad976e6ec23fed4
+                    localIdentifier: trend
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: products.category
+                              type: label
+                          localIdentifier: 34bddcb1cd024902a82396216b0fa9d8
+                    localIdentifier: segment
+                filters:
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: products.category
+                          type: label
+                      notIn:
+                        values: []
+                  - relativeDateFilter:
+                      dataSet:
+                        identifier:
+                          id: date
+                          type: dataset
+                      granularity: GDC.time.year
+                properties:
+                  controls:
+                    legend:
+                      position: bottom
+                version: '2'
+                visualizationUrl: local:line
+              id: revenue_by_category_trend
+              title: Revenue by Category Trend
+            - content:
+                buckets:
+                  - items:
+                      - measure:
+                          definition:
+                            measureDefinition:
+                              filters: []
+                              item:
+                                identifier:
+                                  id: revenue
+                                  type: metric
+                          localIdentifier: 4ae3401bdbba4938afe983df4ba04e1c
+                          title: Revenue
+                    localIdentifier: measures
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: product_name
+                              type: label
+                          localIdentifier: 1c8ba72dbfc84ddd913bf81dc355c427
+                    localIdentifier: view
+                filters:
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: product_name
+                          type: label
+                      notIn:
+                        values: []
+                properties: {}
+                version: '2'
+                visualizationUrl: local:bar
+              id: revenue_by_product
+              title: Revenue by Product
+            - content:
+                buckets:
+                  - items:
+                      - measure:
+                          definition:
+                            measureDefinition:
+                              filters: []
+                              item:
+                                identifier:
+                                  id: campaign_spend
+                                  type: metric
+                          localIdentifier: 13a50d811e474ac6808d8da7f4673b35
+                          title: Campaign Spend
+                    localIdentifier: measures
+                  - items:
+                      - measure:
+                          definition:
+                            measureDefinition:
+                              filters: []
+                              item:
+                                identifier:
+                                  id: revenue_per_dollar_spent
+                                  type: metric
+                          localIdentifier: a0f15e82e6334280a44dbedc7d086e7c
+                          title: Revenue per Dollar Spent
+                    localIdentifier: secondary_measures
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: campaign_name
+                              type: label
+                          localIdentifier: 1d9fa968bafb423eb29c938dfb1207ff
+                    localIdentifier: attribute
+                filters:
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: campaign_name
+                          type: label
+                      notIn:
+                        values: []
+                properties:
+                  controls:
+                    xaxis:
+                      min: '0'
+                    yaxis:
+                      min: '0'
+                version: '2'
+                visualizationUrl: local:scatter
+              id: revenue_per_usd_vs_spend_by_campaign
+              title: Revenue per $ vs Spend by Campaign
+            - content:
+                buckets:
+                  - items:
+                      - measure:
+                          definition:
+                            measureDefinition:
+                              computeRatio: false
+                              filters: []
+                              item:
+                                identifier:
+                                  id: revenue
+                                  type: metric
+                          localIdentifier: 60c854969a9c4c278ab596d99c222e92
+                          title: Revenue
+                    localIdentifier: measures
+                  - items:
+                      - measure:
+                          alias: Number of Orders
+                          definition:
+                            measureDefinition:
+                              computeRatio: false
+                              filters: []
+                              item:
+                                identifier:
+                                  id: amount_of_orders
+                                  type: metric
+                          localIdentifier: c2fa7ef48cc54af99f8c280eb451e051
+                          title: '# of Orders'
+                    localIdentifier: secondary_measures
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: date.month
+                              type: label
+                          localIdentifier: 413ac374b65648fa96826ca01d47bdda
+                    localIdentifier: view
+                filters:
+                  - relativeDateFilter:
+                      dataSet:
+                        identifier:
+                          id: date
+                          type: dataset
+                      from: -3
+                      granularity: GDC.time.quarter
+                      to: 0
+                properties:
+                  controls:
+                    dualAxis: true
+                    legend:
+                      position: bottom
+                    primaryChartType: column
+                    secondaryChartType: line
+                    secondary_yaxis:
+                      measures:
+                        - c2fa7ef48cc54af99f8c280eb451e051
+                    xaxis:
+                      name:
+                        visible: false
+                      rotation: auto
+                version: '2'
+                visualizationUrl: local:combo2
+              id: revenue_trend
+              title: Revenue Trend
+            - content:
+                buckets:
+                  - items:
+                      - measure:
+                          definition:
+                            measureDefinition:
+                              filters: []
+                              item:
+                                identifier:
+                                  id: revenue_top_10
+                                  type: metric
+                          localIdentifier: 3f127ccfe57a40399e23f9ae2a4ad810
+                          title: Revenue / Top 10
+                    localIdentifier: measures
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: customer_name
+                              type: label
+                          localIdentifier: f4e39e24f11e4827a191c30d65c89d2c
+                    localIdentifier: view
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: state
+                              type: label
+                          localIdentifier: bbccd430176d428caed54c99afc9589e
+                    localIdentifier: stack
+                filters:
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: customer_name
+                          type: label
+                      notIn:
+                        values: []
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: state
+                          type: label
+                      notIn:
+                        values: []
+                properties:
+                  controls:
+                    legend:
+                      position: bottom
+                version: '2'
+                visualizationUrl: local:bar
+              id: top_10_customers
+              title: Top 10 Customers
+            - content:
+                buckets:
+                  - items:
+                      - measure:
+                          definition:
+                            measureDefinition:
+                              filters: []
+                              item:
+                                identifier:
+                                  id: revenue_top_10
+                                  type: metric
+                          localIdentifier: 77dc71bbac92412bac5f94284a5919df
+                          title: Revenue / Top 10
+                    localIdentifier: measures
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: product_name
+                              type: label
+                          localIdentifier: 781952e728204dcf923142910cc22ae2
+                    localIdentifier: view
+                  - items:
+                      - attribute:
+                          displayForm:
+                            identifier:
+                              id: products.category
+                              type: label
+                          localIdentifier: fe513cef1c6244a5ac21c5f49c56b108
+                    localIdentifier: stack
+                filters:
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: product_name
+                          type: label
+                      notIn:
+                        values: []
+                  - negativeAttributeFilter:
+                      displayForm:
+                        identifier:
+                          id: products.category
+                          type: label
+                      notIn:
+                        values: []
+                properties:
+                  controls:
+                    legend:
+                      position: bottom
+                version: '2'
+                visualizationUrl: local:bar
+              id: top_10_products
+              title: Top 10 Products
+      headers:
+        Accept-Encoding:
+          - br, gzip, deflate
+        Content-Type:
+          - application/json
+        X-GDC-VALIDATE-RELATIONS:
+          - 'true'
+        X-Requested-With:
+          - XMLHttpRequest
+      method: PUT
+      uri: http://localhost:3000/api/v1/layout/workspaces/demo/analyticsModel
+    response:
+      body:
+        string: ''
+      headers:
+        DATE: *id001
+        Expires:
+          - '0'
+        Pragma:
+          - no-cache
+        X-Content-Type-Options:
+          - nosniff
+        X-GDC-TRACE-ID: *id001
+      status:
+        code: 204
+        message: No Content
+version: 1

--- a/packages/gooddata-sdk/tests/catalog/test_catalog_workspace_content.py
+++ b/packages/gooddata-sdk/tests/catalog/test_catalog_workspace_content.py
@@ -8,6 +8,10 @@ from unittest.mock import MagicMock
 
 import attrs
 from gooddata_sdk import (
+    CatalogDashboardCompoundComparisonCondition,
+    CatalogDashboardCompoundRangeCondition,
+    CatalogDashboardMeasureValueFilter,
+    CatalogDashboardMeasureValueFilterBody,
     CatalogDatasetWorkspaceDataFilterIdentifier,
     CatalogDeclarativeAnalytics,
     CatalogDeclarativeExportDefinition,
@@ -502,3 +506,86 @@ def test_export_definition_analytics_layout(test_config):
         assert deep_eq(analytics_o.analytics.export_definitions, analytics_e.analytics.export_definitions)
     finally:
         safe_delete(_refresh_workspaces, sdk)
+
+
+@gd_vcr.use_cassette(str(_fixtures_dir / "test_dashboard_measure_value_filter.yaml"))
+def test_dashboard_measure_value_filter(test_config):
+    """Verify that DashboardMeasureValueFilter can be embedded in a dashboard and round-trips
+    correctly through the declarative analytics model endpoints.
+
+    The test:
+    1. Gets the current analytics model.
+    2. Injects a measureValueFilter (comparison + range) into the first dashboard's content.
+    3. Puts the updated model back.
+    4. Gets it again and verifies the filters are preserved.
+    5. Restores the original model in `finally`.
+    """
+    sdk = GoodDataSdk.create(host_=test_config["host"], token_=test_config["token"])
+    workspace_id = test_config["workspace"]
+
+    original = sdk.catalog_workspace_content.get_declarative_analytics_model(workspace_id, exclude=["ACTIVITY_INFO"])
+    try:
+        modified = copy.deepcopy(original)
+        assert modified.analytics is not None and modified.analytics.analytical_dashboards, (
+            "Workspace must have at least one analytical dashboard for this test"
+        )
+
+        dashboard = modified.analytics.analytical_dashboards[0]
+
+        # Build a comparison-condition measure value filter (operator + single value).
+        comparison_filter = CatalogDashboardMeasureValueFilter(
+            measure_value_filter=CatalogDashboardMeasureValueFilterBody(
+                conditions=[
+                    CatalogDashboardCompoundComparisonCondition(
+                        operator="GREATER_THAN",
+                        value=1000.0,
+                    )
+                ],
+                measure={"identifier": {"id": "order_amount", "type": "metric"}},
+                title="Order Amount > 1000",
+            )
+        )
+
+        # Build a range-condition measure value filter (from + operator + to).
+        range_filter = CatalogDashboardMeasureValueFilter(
+            measure_value_filter=CatalogDashboardMeasureValueFilterBody(
+                conditions=[
+                    CatalogDashboardCompoundRangeCondition(
+                        from_value=500.0,
+                        operator="BETWEEN",
+                        to=2000.0,
+                    )
+                ],
+                measure={"identifier": {"id": "order_amount", "type": "metric"}},
+                title="Order Amount 500-2000",
+            )
+        )
+
+        # Verify SDK → API serialization before touching the server.
+        comp_api = comparison_filter.to_api()
+        assert comp_api.measure_value_filter.conditions[0].operator == "GREATER_THAN"
+        assert comp_api.measure_value_filter.conditions[0].value == 1000.0
+
+        range_api = range_filter.to_api()
+        assert range_api.measure_value_filter.conditions[0].operator == "BETWEEN"
+
+        # Inject the filters into the dashboard content.
+        existing_filters = dashboard.content.get("filters", [])
+        dashboard.content["filters"] = existing_filters + [
+            comparison_filter.to_api().to_dict(camel_case=True),
+            range_filter.to_api().to_dict(camel_case=True),
+        ]
+
+        sdk.catalog_workspace_content.put_declarative_analytics_model(workspace_id, modified)
+
+        retrieved = sdk.catalog_workspace_content.get_declarative_analytics_model(
+            workspace_id, exclude=["ACTIVITY_INFO"]
+        )
+        retrieved_dashboard = retrieved.analytics.analytical_dashboards[0]
+        retrieved_filters = retrieved_dashboard.content.get("filters", [])
+
+        # The two newly injected measure value filters must be present.
+        mvf_filters = [f for f in retrieved_filters if "measureValueFilter" in f]
+        assert len(mvf_filters) == 2, f"Expected 2 measureValueFilter entries, got {len(mvf_filters)}"
+    finally:
+        sdk.catalog_workspace_content.put_declarative_analytics_model(workspace_id, original)


### PR DESCRIPTION
## Summary

Added SDK wrappers for DashboardMeasureValueFilter (cluster C003). Created `dashboard_filters.py` with five new classes: CatalogDashboardCompoundComparisonCondition, CatalogDashboardCompoundRangeCondition, CatalogDashboardCompoundConditionItem (Union alias), CatalogDashboardMeasureValueFilterBody, and CatalogDashboardMeasureValueFilter. All classes use explicit custom to_api()/from_api() overrides to handle the `from` Python keyword issue (_from ↔ from_value). A cattrs structure hook discriminates the Union by presence of the `value` key. All five names are re-exported from the package root __init__.py. An integration test test_dashboard_measure_value_filter was added to test_catalog_workspace_content.py with a VCR cassette stub.

**Impact:** new_feature | **Services:** `gooddata-automation-client`, `gooddata-export-client`, `gooddata-metadata-client`

## Files changed

- `packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/declarative_model/workspace/analytics_model/dashboard_filters.py`
- `packages/gooddata-sdk/src/gooddata_sdk/__init__.py`
- `packages/gooddata-sdk/tests/catalog/test_catalog_workspace_content.py`

## Agent decisions

<details><summary>Decisions (4)</summary>

**from_value attribute name** — Use from_value in the SDK wrapper and map to _from in to_api()
  - Alternatives: Use _from as attribute name (ugly, leaks API internals), Use from_ as attribute name (PEP8 convention for shadowed keywords, less descriptive)
  - Why: from is a Python keyword so it cannot be used as an attribute name. The API client uses _from as the Python attribute (mapped to JSON key from). Using from_value avoids any reserved-keyword issues while from_api() accepts all three variants (from_value, from, _from) for robustness.

**Override to_api/from_api vs default Base methods** — Custom to_api() and from_api() on every new class
  - Alternatives: Override to_dict() to rename from_value → _from (fragile, affects round-trip equality checks), Use the default path and post-process the dict (error-prone)
  - Why: The default Base.to_api() path calls _get_snake_dict() then client_class().from_dict() which would emit from_value in the dict rather than _from, breaking the API client constructor. Custom methods give precise control over the attribute rename.

**Union discriminator strategy** — Discriminate CatalogDashboardCompoundConditionItem by presence of value key
  - Alternatives: Discriminate by presence of from/_from key (equivalent but less obvious), Add an explicit type discriminator field (would require API schema change)
  - Why: Comparison conditions always have a value field; range conditions have from/to but no value. This is an unambiguous discriminator from the API spec. Registered as a global_converter structure hook following the existing pattern in analytics_model.py.

**New file location** — dashboard_filters.py alongside analytics_model.py in the analytics_model package
  - Alternatives: Add classes inline to analytics_model.py (too large, hard to navigate), Place in a separate filters/ subpackage (over-engineering for 4 classes)
  - Why: DashboardMeasureValueFilter is used in dashboard filter contexts (analytics domain). Placing it next to analytics_model.py keeps the domain cohesive and avoids polluting the analytics_model.py file which is already large.

</details>

<details><summary>Assumptions to verify (4)</summary>

- Dashboard content is stored as opaque dict[str, Any] in CatalogAnalyticsBase so the new filter type passes through existing put/get flows automatically without modifying the analytics model service layer.
- The API cassette for test_dashboard_measure_value_filter does not yet exist and needs to be recorded against a live GoodData instance.
- The workspace used in tests (test_config['workspace']) has at least one analytical dashboard, as asserted in the test.
- The measure ID 'order_amount' of type 'metric' is available in the demo workspace; the test will fail cassette recording if not — but can be updated to match the actual workspace content.

</details>

<details><summary>Risks (4)</summary>

- Cassette test_dashboard_measure_value_filter.yaml does not exist yet — the test will be skipped or fail until recorded against a live environment.
- The discriminator for CatalogDashboardCompoundConditionItem (presence of 'value' key) could theoretically collide if a future condition type also has a value key — but the current API spec makes this unambiguous.
- from_api() multi-fallback for the from key (from_value | from | _from) may silently accept malformed dicts; a stricter approach would raise KeyError on missing key.
- The integration test modifies live workspace state (puts analytics model); the finally block restores, but a test runner crash could leave workspace in modified state.

</details>

<details><summary>Layers touched (3)</summary>

- **declarative_model** — New file: CatalogDashboardCompoundComparisonCondition, CatalogDashboardCompoundRangeCondition, CatalogDashboardMeasureValueFilterBody, CatalogDashboardMeasureValueFilter
  - `packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/declarative_model/workspace/analytics_model/dashboard_filters.py`
- **public_api** — Added 5 new exports from dashboard_filters module
  - `packages/gooddata-sdk/src/gooddata_sdk/__init__.py`
- **tests** — Added test_dashboard_measure_value_filter integration test with VCR cassette
  - `packages/gooddata-sdk/tests/catalog/test_catalog_workspace_content.py`

</details>

## Source commits (gdc-nas)

- `bb0eead` Merge pull request #22705 from gooddata/c.mze-cq-2280
- `e2ab6f2` Merge pull request #22850 from gooddata/c.mze-cq-2284

<details><summary>OpenAPI diff</summary>

```diff
@@ gooddata-automation-client.json (same pattern in export and metadata clients) @@
+      "DashboardCompoundComparisonCondition": {
+        "properties": { "comparison": { "operator": { "enum": ["GREATER_THAN","GREATER_THAN_OR_EQUAL_TO","LESS_THAN","LESS_THAN_OR_EQUAL_TO","EQUAL_TO","NOT_EQUAL_TO"] }, "value": { "format": "double" } } }
+      }
+      "DashboardCompoundConditionItem": { "oneOf": [ DashboardCompoundComparisonCondition, DashboardCompoundRangeCondition ] }
+      "DashboardCompoundRangeCondition": {
+        "properties": { "range": { "from", "operator": { "enum": ["BETWEEN","NOT_BETWEEN"] }, "to" } }
+      }
+      "DashboardMeasureValueFilter": {
+        "properties": { "dashboardMeasureValueFilter": { "conditions": [ DashboardCompoundConditionItem ], "localIdentifier", "measure", "title" } }
+      }
           DashboardFilter.oneOf:
+          { "$ref": "DashboardMeasureValueFilter" }
```
</details>

## [Workflow run](https://github.com/gooddata/gdc-nas/actions/runs/25718559682)

---
*Generated by SDK OpenAPI Sync workflow*