### PR TITLE
feat(gooddata-sdk): [AUTO] Migrate uploadNotification from entities to actions endpoint path

### DIFF
--- a/packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/service.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/service.py
@@ -191,6 +191,18 @@ class CatalogWorkspaceService(CatalogServiceBase):
         workspace_settings = load_all_entities(get_workspace_settings).data
         return [CatalogWorkspaceSetting.from_api(ws) for ws in workspace_settings]
 
+    def register_workspace_upload_notification(self, workspace_id: str) -> None:
+        """Invalidate cache of computed reports in a workspace to force recomputation with new data.
+
+        Args:
+            workspace_id (str):
+                Workspace identification string e.g. "demo"
+
+        Returns:
+            None
+        """
+        self._actions_api.register_workspace_upload_notification(workspace_id)
+
     def resolve_all_workspace_settings(self, workspace_id: str) -> dict:
         """Resolve values for all settings in a workspace.
 

--- a/packages/gooddata-sdk/tests/catalog/fixtures/workspaces/register_workspace_upload_notification.yaml
+++ b/packages/gooddata-sdk/tests/catalog/fixtures/workspaces/register_workspace_upload_notification.yaml
@@ -1,0 +1,31 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept-Encoding:
+          - br, gzip, deflate
+        Content-Type:
+          - application/json
+        X-GDC-VALIDATE-RELATIONS:
+          - 'true'
+        X-Requested-With:
+          - XMLHttpRequest
+      method: POST
+      uri: http://localhost:3000/api/v1/actions/workspaces/demo/uploadNotification
+    response:
+      body:
+        string: ''
+      headers:
+        DATE: &id001
+          - PLACEHOLDER
+        Expires:
+          - '0'
+        Pragma:
+          - no-cache
+        X-Content-Type-Options:
+          - nosniff
+        X-GDC-TRACE-ID: *id001
+      status:
+        code: 204
+        message: No Content
+version: 1

--- a/packages/gooddata-sdk/tests/catalog/test_catalog_workspace.py
+++ b/packages/gooddata-sdk/tests/catalog/test_catalog_workspace.py
@@ -1032,3 +1032,10 @@ def test_layout_filter_views(test_config):
         assert filter_views_expected == filter_views_o
     finally:
         safe_delete(sdk.catalog_workspace.put_declarative_filter_views, workspace_id, [])
+
+
+@gd_vcr.use_cassette(str(_fixtures_dir / "register_workspace_upload_notification.yaml"))
+def test_register_workspace_upload_notification(test_config):
+    sdk = GoodDataSdk.create(host_=test_config["host"], token_=test_config["token"])
+    # Calling register_workspace_upload_notification should succeed (HTTP 204, no body)
+    sdk.catalog_workspace.register_workspace_upload_notification(test_config["workspace"])


### PR DESCRIPTION
## Summary

Added `register_workspace_upload_notification(workspace_id)` method to `CatalogWorkspaceService` that wraps the new `/api/v1/actions/workspaces/{workspaceId}/uploadNotification` endpoint. The generated API client (`ActionsApi`) already contains the `register_workspace_upload_notification` method; only the SDK wrapper layer and integration test were missing. Added an integration test in `test_catalog_workspace.py` with a VCR cassette reference.

**Impact:** modification | **Services:** `gooddata-metadata-client`

## Files changed

- `packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/service.py`
- `packages/gooddata-sdk/tests/catalog/test_catalog_workspace.py`

## Agent decisions

<details><summary>Decisions (3)</summary>

**placement of new method** — Added to CatalogWorkspaceService in service.py, not to a separate module
  - Alternatives: Create a new action model file, Add to content_service.py
  - Why: All other workspace-scoped action methods (e.g., resolve_all_workspace_settings, set_metadata_localization) live in CatalogWorkspaceService.service.py. The data-source analogue register_upload_notification is in CatalogDataSourceService.service.py following the same pattern.

**no new public __init__.py export** — Did not add export to gooddata_sdk/__init__.py
  - Alternatives: Export the method name as a constant for discoverability
  - Why: The method is accessed via sdk.catalog_workspace.register_workspace_upload_notification(), which is already reachable through the existing CatalogWorkspaceService export. No new class or constant needs to be exported.

**test strategy for 204 No Content endpoint** — Integration test that calls the method and asserts no exception is raised
  - Alternatives: Assert on execution result IDs changing (complex, requires additional setup), Skip the integration test
  - Why: The endpoint returns HTTP 204 with no body. There is nothing to assert on the response; success is the absence of an exception. This mirrors similar fire-and-forget tests in the codebase (e.g., test_register_upload_notification for data sources).

</details>

<details><summary>Assumptions to verify (3)</summary>

- The old /entities/workspaces/{workspaceId}/uploadNotification endpoint never had an SDK wrapper in this codebase (search for uploadNotification, upload_notification, UploadNotification returned no SDK hits), so this is effectively a new method rather than a migration of existing code.
- The ActionsApi.register_workspace_upload_notification() accepts only workspace_id as a positional argument with no request body, consistent with the new endpoint definition.
- test_config['workspace'] in the test environment refers to a valid workspace ID that accepts upload notifications.

</details>

<details><summary>Risks (1)</summary>

- test_register_workspace_upload_notification will fail recording if the test environment workspace does not have a data source with uploaded data (the endpoint triggers cache invalidation; it should still return 204 even if there is nothing to invalidate, but backend behavior may vary).

</details>

<details><summary>Layers touched (2)</summary>

- **public_api** — New service method register_workspace_upload_notification added to CatalogWorkspaceService
  - `packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/service.py`
- **tests** — Integration test test_register_workspace_upload_notification added with VCR cassette reference
  - `packages/gooddata-sdk/tests/catalog/test_catalog_workspace.py`

</details>

## Source commits (gdc-nas)

- `90b39cc` Merge pull request #22334 from Tjev/cq-2080-endpoint
- `4ef0a1e` Merge pull request #22379 from Tjev/cq-2244-ws-ds-removal

<details><summary>OpenAPI diff</summary>

```diff
@@ gooddata-metadata-client.json @@
+    "/api/v1/actions/workspaces/{workspaceId}/uploadNotification": {
+      "post": {
+        "description": "Notification sets up all reports to be computed again with new data.",
+        "operationId": "registerWorkspaceUploadNotification",
+        "responses": { "204": { "description": "An upload notification has been successfully registered." } },
+        "summary": "Register an upload notification"
+      }
+    }
 (net: old /entities/.../uploadNotification with WorkspaceUploadNotificationRequest body removed; new /actions/... endpoint without request body is the net result)
```
</details>

## [Workflow run](https://github.com/gooddata/gdc-nas/actions/runs/25718559682)

---
*Generated by SDK OpenAPI Sync workflow*