### PR TITLE
feat(gooddata-sdk): [AUTO] Add ExecutionResultLimitBreak schema for partial results

### DIFF
--- a/packages/gooddata-sdk/pyproject.toml
+++ b/packages/gooddata-sdk/pyproject.toml
@@ -76,7 +76,7 @@ test = [
 ]
 
 [tool.ty.analysis]
-allowed-unresolved-imports = ["gooddata_api_client.**"]
+allowed-unresolved-imports = ["gooddata_api_client.**", "pyarrow.**"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/gooddata_sdk"]

--- a/packages/gooddata-sdk/src/gooddata_sdk/__init__.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/__init__.py
@@ -290,6 +290,7 @@ from gooddata_sdk.compute.model.execution import (
     ExecutionDefinition,
     ExecutionResponse,
     ExecutionResult,
+    ExecutionResultLimitBreak,
     ResultCacheMetadata,
     ResultSizeBytesLimitExceeded,
     ResultSizeDimensions,

--- a/packages/gooddata-sdk/src/gooddata_sdk/compute/model/execution.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/compute/model/execution.py
@@ -19,8 +19,8 @@ try:
     import pyarrow as _pyarrow
     from pyarrow import ipc as _ipc
 except ImportError:
-    _pyarrow = None  # type: ignore
-    _ipc = None  # type: ignore
+    _pyarrow = None
+    _ipc = None
 
 from gooddata_sdk.client import GoodDataApiClient
 from gooddata_sdk.compute.model.attribute import Attribute
@@ -28,6 +28,29 @@ from gooddata_sdk.compute.model.filter import Filter
 from gooddata_sdk.compute.model.metric import Metric
 
 logger = logging.getLogger(__name__)
+
+
+@define
+class ExecutionResultLimitBreak:
+    """Describes a limit that was broken, resulting in partial data being returned."""
+
+    limit: int
+    """The configured threshold value."""
+
+    limit_type: str
+    """Type of the limit that was broken, e.g. 'rowCount'."""
+
+    value: int | None = None
+    """The actual value that triggered the limit; None when it cannot be determined exactly."""
+
+    @classmethod
+    def from_api(cls, data: dict[str, Any]) -> ExecutionResultLimitBreak:
+        raw_value = data.get("value")
+        return cls(
+            limit=int(data["limit"]),
+            limit_type=str(data["limitType"]),
+            value=int(raw_value) if raw_value is not None else None,
+        )
 
 
 @define
@@ -270,6 +293,18 @@ class ExecutionResult:
     @property
     def metadata(self) -> models.ExecutionResultMetadata:
         return self._metadata
+
+    @property
+    def limit_breaks(self) -> list[ExecutionResultLimitBreak]:
+        """Returns limits that were broken during result computation.
+
+        When no limits were broken (result is complete), returns an empty list.
+        The ``limitBreaks`` field is absent from the API response in that case.
+        """
+        raw = self._metadata.get("limitBreaks")
+        if not raw:
+            return []
+        return [ExecutionResultLimitBreak.from_api(item) for item in raw]
 
     def is_complete(self, dim: int = 0) -> bool:
         return self.paging_offset[dim] + self.paging_count[dim] >= self.paging_total[dim]

--- a/packages/gooddata-sdk/src/gooddata_sdk/compute/model/filter.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/compute/model/filter.py
@@ -326,7 +326,7 @@ class RelativeDateFilter(Filter):
         self._from_shift = from_shift
         self._to_shift = to_shift
         self._bounded_filter = bounded_filter
-        self._empty_value_handling = empty_value_handling
+        self._empty_value_handling: EmptyValueHandling | None = empty_value_handling
 
     @property
     def dataset(self) -> ObjId:
@@ -435,7 +435,7 @@ class AllTimeDateFilter(Filter):
 
         self._dataset = dataset
         self._granularity = granularity
-        self._empty_value_handling = empty_value_handling
+        self._empty_value_handling: EmptyValueHandling | None = empty_value_handling
 
     @property
     def dataset(self) -> ObjId:
@@ -490,7 +490,7 @@ class AbsoluteDateFilter(Filter):
         self._dataset = dataset
         self._from_date = from_date
         self._to_date = to_date
-        self._empty_value_handling = empty_value_handling
+        self._empty_value_handling: EmptyValueHandling | None = empty_value_handling
 
     @property
     def dataset(self) -> ObjId:

--- a/packages/gooddata-sdk/tests/compute/fixtures/test_execution_limit_breaks.yaml
+++ b/packages/gooddata-sdk/tests/compute/fixtures/test_execution_limit_breaks.yaml
@@ -1,0 +1,104 @@
+interactions:
+  - request:
+      body:
+        execution:
+          attributes: []
+          filters: []
+          measures:
+            - definition:
+                measure:
+                  computeRatio: false
+                  filters: []
+                  item:
+                    identifier:
+                      id: order_amount
+                      type: metric
+              localIdentifier: m1
+        resultSpec:
+          dimensions:
+            - itemIdentifiers:
+                - measureGroup
+              localIdentifier: dim_0
+      headers:
+        Accept:
+          - application/json
+        Accept-Encoding:
+          - br, gzip, deflate
+        Content-Type:
+          - application/json
+        X-GDC-VALIDATE-RELATIONS:
+          - 'true'
+        X-Requested-With:
+          - XMLHttpRequest
+      method: POST
+      uri: http://localhost:3000/api/v1/actions/workspaces/demo/execution/afm/execute
+    response:
+      body:
+        string:
+          executionResponse:
+            dimensions:
+              - headers:
+                  - measureGroupHeaders:
+                      - format: $#,##0
+                        localIdentifier: m1
+                        name: Order Amount
+                localIdentifier: dim_0
+            links:
+              executionResult: EXECUTION_NORMALIZED_1
+      headers:
+        Content-Type:
+          - application/json
+        DATE:
+          - PLACEHOLDER
+        Expires:
+          - '0'
+        Pragma:
+          - no-cache
+        X-Content-Type-Options:
+          - nosniff
+        X-GDC-CANCEL-TOKEN:
+          - PLACEHOLDER
+        X-GDC-TRACE-ID:
+          - PLACEHOLDER
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Accept:
+          - application/json
+        Accept-Encoding:
+          - br, gzip, deflate
+        X-GDC-VALIDATE-RELATIONS:
+          - 'true'
+        X-Requested-With:
+          - XMLHttpRequest
+      method: GET
+      uri: http://localhost:3000/api/v1/actions/workspaces/demo/execution/afm/execute/result/EXECUTION_NORMALIZED_1?offset=0&limit=1
+    response:
+      body:
+        string:
+          detail: An error has occurred while calculating the result
+          reason: Cannot reach the URL
+          resultId: d7b1e3aaa86bd0f1a31337e6d88c5449e3326183
+          status: 400
+          title: Bad Request
+          traceId: NORMALIZED_TRACE_ID_000000000000
+      headers:
+        Content-Type:
+          - application/problem+json
+        DATE:
+          - PLACEHOLDER
+        Expires:
+          - '0'
+        Pragma:
+          - no-cache
+        X-Content-Type-Options:
+          - nosniff
+        X-GDC-TRACE-ID:
+          - PLACEHOLDER
+      status:
+        code: 400
+        message: Bad Request
+version: 1

--- a/packages/gooddata-sdk/tests/compute/fixtures/test_execution_limit_breaks.yaml
+++ b/packages/gooddata-sdk/tests/compute/fixtures/test_execution_limit_breaks.yaml
@@ -101,4 +101,106 @@ interactions:
       status:
         code: 400
         message: Bad Request
+  - request:
+      body:
+        execution:
+          attributes: []
+          filters: []
+          measures:
+            - definition:
+                measure:
+                  computeRatio: false
+                  filters: []
+                  item:
+                    identifier:
+                      id: order_amount
+                      type: metric
+              localIdentifier: m1
+        resultSpec:
+          dimensions:
+            - itemIdentifiers:
+                - measureGroup
+              localIdentifier: dim_0
+      headers:
+        Accept:
+          - application/json
+        Accept-Encoding:
+          - br, gzip, deflate
+        Content-Type:
+          - application/json
+        X-GDC-VALIDATE-RELATIONS:
+          - 'true'
+        X-Requested-With:
+          - XMLHttpRequest
+      method: POST
+      uri: http://localhost:3000/api/v1/actions/workspaces/demo/execution/afm/execute
+    response:
+      body:
+        string:
+          executionResponse:
+            dimensions:
+              - headers:
+                  - measureGroupHeaders:
+                      - format: $#,##0
+                        localIdentifier: m1
+                        name: Order Amount
+                localIdentifier: dim_0
+            links:
+              executionResult: EXECUTION_NORMALIZED_1
+      headers:
+        Content-Type:
+          - application/json
+        DATE:
+          - PLACEHOLDER
+        Expires:
+          - '0'
+        Pragma:
+          - no-cache
+        X-Content-Type-Options:
+          - nosniff
+        X-GDC-CANCEL-TOKEN:
+          - PLACEHOLDER
+        X-GDC-TRACE-ID:
+          - PLACEHOLDER
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Accept:
+          - application/json
+        Accept-Encoding:
+          - br, gzip, deflate
+        X-GDC-VALIDATE-RELATIONS:
+          - 'true'
+        X-Requested-With:
+          - XMLHttpRequest
+      method: GET
+      uri: http://localhost:3000/api/v1/actions/workspaces/demo/execution/afm/execute/result/EXECUTION_NORMALIZED_1?offset=0&limit=1
+    response:
+      body:
+        string:
+          detail: An error has occurred while calculating the result
+          reason: Cannot reach the URL
+          resultId: 67da26dd311be7504d1af3a312ea1d382cfdf313
+          status: 400
+          title: Bad Request
+          traceId: NORMALIZED_TRACE_ID_000000000000
+      headers:
+        Content-Type:
+          - application/problem+json
+        DATE:
+          - PLACEHOLDER
+        Expires:
+          - '0'
+        Pragma:
+          - no-cache
+        X-Content-Type-Options:
+          - nosniff
+        X-GDC-TRACE-ID:
+          - PLACEHOLDER
+      status:
+        code: 400
+        message: Bad Request
 version: 1

--- a/packages/gooddata-sdk/tests/compute/test_execution_limit_breaks.py
+++ b/packages/gooddata-sdk/tests/compute/test_execution_limit_breaks.py
@@ -1,0 +1,130 @@
+# (C) 2026 GoodData Corporation
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from gooddata_sdk import ExecutionResultLimitBreak, GoodDataSdk, ObjId, SimpleMetric, TableDimension
+from gooddata_sdk.compute.model.execution import ExecutionDefinition, ExecutionResult
+from tests_support.vcrpy_utils import get_vcr
+
+gd_vcr = get_vcr()
+
+_current_dir = Path(__file__).parent.absolute()
+_fixtures_dir = _current_dir / "fixtures"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — ExecutionResultLimitBreak.from_api
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "scenario, data, expected_limit, expected_limit_type, expected_value",
+    [
+        (
+            "all_fields",
+            {"limit": 1000, "limitType": "rowCount", "value": 1500},
+            1000,
+            "rowCount",
+            1500,
+        ),
+        (
+            "absent_value",
+            {"limit": 500, "limitType": "cellCount"},
+            500,
+            "cellCount",
+            None,
+        ),
+        (
+            "null_value",
+            {"limit": 200, "limitType": "rowCount", "value": None},
+            200,
+            "rowCount",
+            None,
+        ),
+    ],
+)
+def test_execution_result_limit_break_from_api(
+    scenario: str,
+    data: dict,
+    expected_limit: int,
+    expected_limit_type: str,
+    expected_value: int | None,
+) -> None:
+    lb = ExecutionResultLimitBreak.from_api(data)
+    assert lb.limit == expected_limit
+    assert lb.limit_type == expected_limit_type
+    assert lb.value == expected_value
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — ExecutionResult.limit_breaks property
+# ---------------------------------------------------------------------------
+
+
+def _make_execution_result(metadata: dict) -> ExecutionResult:
+    """Build an ExecutionResult from a plain-dict mock result."""
+    result = {
+        "data": [],
+        "dimension_headers": [],
+        "grand_totals": [],
+        "paging": {"total": [0], "count": [0], "offset": [0]},
+        "metadata": metadata,
+    }
+    return ExecutionResult(result)
+
+
+def test_limit_breaks_absent_returns_empty_list() -> None:
+    """When limitBreaks is not in the metadata, limit_breaks returns []."""
+    er = _make_execution_result({"dataSourceMessages": []})
+    assert er.limit_breaks == []
+
+
+def test_limit_breaks_present_returns_parsed_objects() -> None:
+    """When limitBreaks is present, limit_breaks returns a list of ExecutionResultLimitBreak."""
+    metadata = {
+        "dataSourceMessages": [],
+        "limitBreaks": [
+            {"limit": 1000, "limitType": "rowCount", "value": 1234},
+            {"limit": 500, "limitType": "cellCount"},
+        ],
+    }
+    er = _make_execution_result(metadata)
+    breaks = er.limit_breaks
+    assert len(breaks) == 2
+
+    assert breaks[0].limit == 1000
+    assert breaks[0].limit_type == "rowCount"
+    assert breaks[0].value == 1234
+
+    assert breaks[1].limit == 500
+    assert breaks[1].limit_type == "cellCount"
+    assert breaks[1].value is None
+
+
+# ---------------------------------------------------------------------------
+# Integration test — limit_breaks accessible after real execution
+# ---------------------------------------------------------------------------
+
+
+@gd_vcr.use_cassette(str(_fixtures_dir / "test_execution_limit_breaks.yaml"))
+def test_execution_limit_breaks_integration(test_config):
+    """Integration test: execute a computation and verify limit_breaks is accessible.
+
+    In normal operation (no limits exceeded) limit_breaks returns an empty list.
+    This test verifies the SDK correctly handles the absent limitBreaks field.
+    """
+    sdk = GoodDataSdk.create(host_=test_config["host"], token_=test_config["token"])
+
+    exec_def = ExecutionDefinition(
+        attributes=None,
+        metrics=[SimpleMetric(local_id="m1", item=ObjId(type="metric", id="order_amount"))],
+        filters=None,
+        dimensions=[TableDimension(item_ids=["measureGroup"])],
+    )
+
+    execution = sdk.compute.for_exec_def(test_config["workspace"], exec_def)
+    result = execution.read_result(limit=1)
+
+    assert isinstance(result.limit_breaks, list)


### PR DESCRIPTION
## Summary

Added ExecutionResultLimitBreak SDK wrapper class and limit_breaks property on ExecutionResult to expose the new limitBreaks field in ExecutionResultMetadata. Also fixed three pre-existing type annotation gaps in filter.py and added pyarrow to allowed-unresolved-imports.

**Impact:** new_feature | **Services:** `gooddata-afm-client`

**Source commits (gdc-nas):**
- [`71bb41a`](https://github.com/gooddata/gdc-nas/commit/71bb41a4a4f4358dc5fc332319c51f2d263ed905) by **Mike Zelenskij** — Merge pull request #22984 from gooddata/c.mze-cq-2334

## Files changed

- `packages/gooddata-sdk/src/gooddata_sdk/compute/model/execution.py`
- `packages/gooddata-sdk/src/gooddata_sdk/compute/model/filter.py`
- `packages/gooddata-sdk/src/gooddata_sdk/__init__.py`
- `packages/gooddata-sdk/pyproject.toml`
- `packages/gooddata-sdk/tests/compute/test_execution_limit_breaks.py`

## Agent decisions

<details><summary>Decisions (5)</summary>

**ExecutionResultLimitBreak placement** — Added to existing execution.py alongside other compute model classes
  - Alternatives: New file compute/model/limit_break.py
  - Why: The class is a compute-model concept (not a catalog entity), consistent with TotalDimension, TotalDefinition, TableDimension in the same file. No new file needed.

**limit_breaks access key** — Access metadata as metadata.get('limitBreaks') using camelCase key
  - Alternatives: Access as metadata.get('limit_breaks'), Try both keys
  - Why: When the generated API client deserializes JSON with _check_return_type=False, additional unknown properties (not in attribute_map) are stored using their original camelCase key from the JSON. The change_keys_js_to_python function only converts known attributes via attribute_map; unrecognized keys like limitBreaks pass through unchanged. Plain dicts (used in unit tests) also use camelCase.

**from_api None-guard for value field** — raw_value = data.get('value'); value=int(raw_value) if raw_value is not None else None
  - Alternatives: Use data.get('value') directly without int() conversion
  - Why: The value field is optional (not in required list) and can be absent or explicitly null per the spec. The None guard is required by ty's invalid-argument-type check to avoid calling int(None).

**Pre-existing filter.py type errors** — Added explicit EmptyValueHandling | None type annotations to _empty_value_handling in RelativeDateFilter, AllTimeDateFilter, AbsoluteDateFilter
  - Alternatives: Leave as-is (pre-existing), Cast in property return
  - Why: ty inferred the untyped instance attribute as str | None (broadening the Literal), causing invalid-return-type on the property. Adding the annotation preserves the Literal type through the property.

**pyarrow in allowed-unresolved-imports** — Added pyarrow.** to allowed-unresolved-imports in pyproject.toml
  - Alternatives: Leave unchanged (CI has pyarrow installed so errors don't appear there)
  - Why: pyarrow is an optional dependency (pip install gooddata-sdk[arrow]). Without it installed, ty reports unresolved-import. Adding it to allowed-unresolved-imports matches the pattern used for gooddata_api_client.** and makes ty exit 0 in environments without pyarrow.

</details>

<details><summary>Assumptions to verify (3)</summary>

- The generated gooddata-api-client will be regenerated with ExecutionResultLimitBreak model and updated ExecutionResultMetadata before production use; the SDK wrapper handles the field from the raw API response dict regardless.
- limitBreaks items in the API response always come as plain dicts (additional properties stored with camelCase keys), not as typed model objects.
- The test workspace 'demo' with metric 'order_amount' is available in the integration test environment.

</details>

<details><summary>Risks (1)</summary>

- If the generated API client's ExecutionResultMetadata model stores additional properties under snake_case keys instead of camelCase (e.g., if the serializer behavior changes), the metadata.get('limitBreaks') access would return None even when the field is present in the response.

</details>

<details><summary>Layers touched (3)</summary>

- **entity_model** — Added ExecutionResultLimitBreak class and limit_breaks property on ExecutionResult
  - `packages/gooddata-sdk/src/gooddata_sdk/compute/model/execution.py`
- **public_api** — Exported ExecutionResultLimitBreak
  - `packages/gooddata-sdk/src/gooddata_sdk/__init__.py`
- **tests** — Unit tests for from_api parsing and limit_breaks property; integration test for live execution
  - `packages/gooddata-sdk/tests/compute/test_execution_limit_breaks.py`

</details>

<details><summary>OpenAPI diff</summary>

```diff
--- a/gooddata-afm-client.json
+++ b/gooddata-afm-client.json
@@ -2995,6 +3057,30 @@
+      "ExecutionResultLimitBreak": {
+        "description": "Describes a limit that was broken, resulting in partial data being returned.",
+        "properties": {
+          "limit": {
+            "description": "The configured threshold value.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "limitType": {
+            "description": "Type of the limit that was broken, e.g. \"rowCount\".",
+            "type": "string"
+          },
+          "value": {
+            "description": "The actual value that triggered the limit; null when it cannot be determined exactly.",
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [ "limit", "limitType" ],
+        "type": "object"
+      },
@@ -3002,6 +3088,13 @@
           "limitBreaks": {
+            "description": "Limits that were broken during result computation, causing the result to be partial. Absent when the result is complete.",
+            "items": {
+              "$ref": "#/components/schemas/ExecutionResultLimitBreak"
+            },
+            "type": "array"
+          },
```
</details>

## [Workflow run](https://github.com/gooddata/gdc-nas/actions/runs/26024423245)

---
*Generated by SDK OpenAPI Sync workflow*