### PR TITLE
feat(gooddata-sdk): [AUTO] Remove LLM endpoint schemas and replace with 410 Gone

### DIFF
--- a/packages/gooddata-sdk/src/gooddata_sdk/__init__.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/__init__.py
@@ -127,6 +127,7 @@ from gooddata_sdk.catalog.organization.entity_model.llm_provider import (
     CatalogLlmProviderPatchDocument,
     CatalogOpenAiApiKeyAuth,
     CatalogOpenAiProviderConfig,
+    CatalogResolvedLlmProvider,
 )
 from gooddata_sdk.catalog.organization.entity_model.organization import CatalogOrganization
 from gooddata_sdk.catalog.organization.entity_model.setting import CatalogOrganizationSetting

--- a/packages/gooddata-sdk/src/gooddata_sdk/catalog/organization/entity_model/llm_provider.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/catalog/organization/entity_model/llm_provider.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any, Union
 
-from attr import define
+from attr import define, field
 from gooddata_api_client.model.aws_bedrock_provider_config import AwsBedrockProviderConfig
 from gooddata_api_client.model.azure_foundry_provider_auth import AzureFoundryProviderAuth
 from gooddata_api_client.model.azure_foundry_provider_config import AzureFoundryProviderConfig
@@ -337,3 +337,35 @@ class CatalogLlmProviderPatchAttributes(Base):
     @staticmethod
     def client_class() -> type[JsonApiLlmProviderInAttributes]:
         return JsonApiLlmProviderInAttributes
+
+
+# --- Resolved provider (read-only, returned by workspace-level resolution) ---
+
+
+@define(kw_only=True)
+class CatalogResolvedLlmProvider(Base):
+    """Active LLM provider resolved for a workspace.
+
+    Returned by :meth:`CatalogWorkspaceContentService.resolve_llm_providers`.
+    This is a read-only object — it represents the live configuration resolved
+    for the workspace, not the stored entity.
+    """
+
+    id: str
+    title: str
+    models: list[CatalogLlmProviderModel] = field(factory=list)
+
+    @classmethod
+    def from_api(cls, entity: dict[str, Any]) -> CatalogResolvedLlmProvider:
+        raw_models = safeget(entity, ["models"]) or []
+        return cls(
+            id=entity["id"],
+            title=entity["title"],
+            models=[
+                CatalogLlmProviderModel(
+                    id=safeget(m, ["id"]) or "",
+                    family=safeget(m, ["family"]) or "",
+                )
+                for m in raw_models
+            ],
+        )

--- a/packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/content_service.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/content_service.py
@@ -13,6 +13,7 @@ from gooddata_sdk.catalog.catalog_service_base import CatalogServiceBase
 from gooddata_sdk.catalog.data_source.validation.data_source import DataSourceValidator
 from gooddata_sdk.catalog.depends_on import CatalogDependsOn, CatalogDependsOnDateFilter
 from gooddata_sdk.catalog.filter_by import CatalogFilterBy
+from gooddata_sdk.catalog.organization.entity_model.llm_provider import CatalogResolvedLlmProvider
 from gooddata_sdk.catalog.types import ValidObjects
 from gooddata_sdk.catalog.validate_by_item import CatalogValidateByItem
 from gooddata_sdk.catalog.workspace.declarative_model.workspace.analytics_model.analytics_model import (
@@ -38,7 +39,7 @@ from gooddata_sdk.compute.model.base import ObjId
 from gooddata_sdk.compute.model.execution import ExecutionDefinition, compute_model_to_api_model
 from gooddata_sdk.compute.model.filter import Filter
 from gooddata_sdk.compute.model.metric import Metric
-from gooddata_sdk.utils import load_all_entities
+from gooddata_sdk.utils import load_all_entities, safeget
 
 ValidObjectTypes = Union[Attribute, Metric, Filter, CatalogLabel, CatalogFact, CatalogMetric]
 
@@ -685,3 +686,27 @@ class CatalogWorkspaceContentService(CatalogServiceBase):
             workspace_id, request, _check_return_type=False, **paging_params
         )
         return [v["title"] for v in values["elements"]]
+
+    def resolve_llm_providers(self, workspace_id: str) -> CatalogResolvedLlmProvider | None:
+        """Resolve the active LLM provider configuration for a workspace.
+
+        Calls ``GET /api/v1/actions/workspaces/{workspaceId}/ai/resolveLlmProviders``
+        and returns the resolved active LLM provider, or ``None`` when no LLM
+        provider is configured for the workspace.
+
+        This is the replacement for the now-removed ``resolveLlmEndpoints`` endpoint.
+
+        Args:
+            workspace_id (str):
+                Workspace identifier e.g. ``"demo"``.
+
+        Returns:
+            CatalogResolvedLlmProvider | None:
+                The resolved active LLM provider, or ``None`` if the workspace
+                has no LLM provider configured.
+        """
+        response = self._actions_api.resolve_llm_providers(workspace_id, _check_return_type=False)
+        data = safeget(response, ["data"])
+        if data is None:
+            return None
+        return CatalogResolvedLlmProvider.from_api(data)

--- a/packages/gooddata-sdk/tests/catalog/fixtures/workspace_content/test_resolve_llm_providers.yaml
+++ b/packages/gooddata-sdk/tests/catalog/fixtures/workspace_content/test_resolve_llm_providers.yaml
@@ -1,0 +1,34 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - application/json
+        Accept-Encoding:
+          - br, gzip, deflate
+        X-GDC-VALIDATE-RELATIONS:
+          - 'true'
+        X-Requested-With:
+          - XMLHttpRequest
+      method: GET
+      uri: http://localhost:3000/api/v1/actions/workspaces/demo/ai/resolveLlmProviders
+    response:
+      body:
+        string:
+          data: null
+      headers:
+        Content-Type:
+          - application/json
+        DATE: &id001
+          - PLACEHOLDER
+        Expires:
+          - '0'
+        Pragma:
+          - no-cache
+        X-Content-Type-Options:
+          - nosniff
+        X-GDC-TRACE-ID: *id001
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/packages/gooddata-sdk/tests/catalog/test_catalog_workspace_content.py
+++ b/packages/gooddata-sdk/tests/catalog/test_catalog_workspace_content.py
@@ -18,6 +18,7 @@ from gooddata_sdk import (
     CatalogDependsOn,
     CatalogDependsOnDateFilter,
     CatalogEntityIdentifier,
+    CatalogResolvedLlmProvider,
     CatalogValidateByItem,
     CatalogWorkspace,
     DataSourceValidator,
@@ -502,3 +503,21 @@ def test_export_definition_analytics_layout(test_config):
         assert deep_eq(analytics_o.analytics.export_definitions, analytics_e.analytics.export_definitions)
     finally:
         safe_delete(_refresh_workspaces, sdk)
+
+
+@gd_vcr.use_cassette(str(_fixtures_dir / "test_resolve_llm_providers.yaml"))
+def test_resolve_llm_providers_integration(test_config):
+    """Exercise the resolveLlmProviders action (replaces the removed resolveLlmEndpoints).
+
+    The endpoint returns the active LLM provider for the workspace, or None when
+    no LLM provider is configured.  Both outcomes are valid — the test just
+    verifies the SDK can call the endpoint without error and that the return
+    value is either None or a well-formed CatalogResolvedLlmProvider.
+    """
+    sdk = GoodDataSdk.create(host_=test_config["host"], token_=test_config["token"])
+    result = sdk.catalog_workspace_content.resolve_llm_providers(test_config["workspace"])
+    assert result is None or isinstance(result, CatalogResolvedLlmProvider)
+    if result is not None:
+        assert result.id
+        assert result.title
+        assert isinstance(result.models, list)


### PR DESCRIPTION
## Summary

Added CatalogResolvedLlmProvider model and resolve_llm_providers() method to CatalogWorkspaceContentService as the SDK-level replacement for the now-removed resolveLlmEndpoints endpoint (which now returns 410 Gone). The old LlmEndpoint-based endpoints were never wrapped in the SDK wrapper layer; this change adds the new resolveLlmProviders action wrapper and exports the result type publicly.

**Impact:** modification | **Services:** `gooddata-afm-client`

**Source commits (gdc-nas):**
- [`0d015ba`](https://github.com/gooddata/gdc-nas/commit/0d015bab7651e156160ce15de8ac4698d7445a56) by **Jan Kadlec** — Merge pull request #22495 from hkad98/jkd/llm-entity-removal

## Files changed

- `packages/gooddata-sdk/src/gooddata_sdk/catalog/organization/entity_model/llm_provider.py`
- `packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/content_service.py`
- `packages/gooddata-sdk/src/gooddata_sdk/__init__.py`
- `packages/gooddata-sdk/tests/catalog/test_catalog_workspace_content.py`

## Agent decisions

<details><summary>Decisions (3)</summary>

**where to add resolve_llm_providers method** — CatalogWorkspaceContentService in content_service.py
  - Alternatives: ComputeService (handles AI workspace actions), CatalogOrganizationService (handles LLM provider CRUD)
  - Why: resolve_llm_providers is a workspace-level configuration query. CatalogWorkspaceContentService already owns workspace-level action calls via _actions_api. ComputeService was the alternative but its AI methods are compute/inference operations, not configuration resolution.

**no_changes vs new_feature for removed endpoints** — Implement resolve_llm_providers as the replacement wrapper
  - Alternatives: status=no_changes (the removed endpoints were never in the SDK wrapper)
  - Why: The old resolveLlmEndpoints was never wrapped in the SDK. Per task instructions, when sdk_impact=modification but no integration test exists for the changed endpoint, treat as new_feature. The replacement resolveLlmProviders endpoint is the natural SDK addition.

**CatalogResolvedLlmProvider model placement** — Added to llm_provider.py in the organization entity_model directory
  - Alternatives: Separate file in workspace/entity_model/, Inline dict return from resolve_llm_providers
  - Why: The resolved provider is conceptually related to the LlmProvider domain. Co-locating it with other LLM provider models keeps the domain coherent. It reuses CatalogLlmProviderModel for the models list.

</details>

<details><summary>Assumptions to verify (3)</summary>

- The ty check errors in execution.py (pyarrow unresolved import) and filter.py (EmptyValueHandling return type) are pre-existing and not caused by this PR.
- resolve_llm_providers returns None when the workspace has no LLM provider configured (data field absent or null in response).
- CatalogLlmProviderModel.id and .family are always non-empty strings per the OpenAPI spec (both are required fields in LlmModel).

</details>

<details><summary>Risks (2)</summary>

- ResolvedLlms.data is a oneOf[ResolvedLlmEndpoint, ResolvedLlmProvider] in the current generated client. After the api-client is regenerated to match the new spec (removing ResolvedLlmEndpoint), the discriminator logic changes. The SDK's from_api uses safeget which is type-agnostic, so it should continue to work.
- The response field 'data' could be missing entirely when no provider is configured; the safeget None-guard handles this.

</details>

<details><summary>Layers touched (3)</summary>

- **entity_model** — Added CatalogResolvedLlmProvider read-only response model.
  - `packages/gooddata-sdk/src/gooddata_sdk/catalog/organization/entity_model/llm_provider.py`
- **public_api** — Added resolve_llm_providers() to CatalogWorkspaceContentService and exported CatalogResolvedLlmProvider from __init__.py.
  - `packages/gooddata-sdk/src/gooddata_sdk/__init__.py`
  - `packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/content_service.py`
- **tests** — Added test_resolve_llm_providers_integration integration test.
  - `packages/gooddata-sdk/tests/catalog/test_catalog_workspace_content.py`

</details>

<details><summary>OpenAPI diff</summary>

```diff
--- a/gooddata-afm-client.json
+++ b/gooddata-afm-client.json
@@ -5429,45 +5528,6 @@
-      "ResolvedLlmEndpoint": {
-        "allOf": [
-          { "$ref": "#/components/schemas/ResolvedLlm" },
-          {
-            "properties": {
-              "id": { "description": "Endpoint Id", "type": "string" },
-              "title": { "description": "Endpoint Title", "type": "string" }
-            },
-            "type": "object"
-          }
-        ],
-        "required": [ "id", "title" ],
-        "type": "object"
-      },
-      "ResolvedLlmEndpoints": {
-        "properties": {
-          "data": {
-            "items": { "$ref": "#/components/schemas/ResolvedLlmEndpoint" },
-            "type": "array"
-          }
-        },
-        "required": [ "data" ],
-        "type": "object"
-      },
-      "ValidateLLMEndpointByIdRequest": { ... },
-      "ValidateLLMEndpointRequest": { ... },
-      "ValidateLLMEndpointResponse": { ... },
@@ -6920,31 +6912,14 @@
     "/api/v1/actions/ai/llmEndpoint/test": {
       "post": {
         "deprecated": true,
-        "description": "Will be soon removed and replaced by testLlmProvider.",
+        "description": "Permanently removed. Use POST /api/v1/actions/ai/llmProvider/test instead. Always returns 410 Gone.",
         "responses": {
-          "200": { ... }
+          "410": { "description": "Gone" }
         },
-        "summary": "Validate LLM Endpoint",
+        "summary": "Validate LLM Endpoint (Removed)",
@@ -7654,7 +7613,7 @@
     "/api/v1/actions/workspaces/{workspaceId}/ai/resolveLlmEndpoints": {
       "get": {
         "deprecated": true,
-        "description": "Will be soon removed and replaced by LlmProvider-based resolution.",
+        "description": "Permanently removed. Use GET /api/v1/actions/workspaces/{workspaceId}/ai/resolveLlmProviders instead. Always returns 410 Gone.",
         "responses": {
-          "200": { ... }
+          "410": { "description": "Gone" }
         },
-        "summary": "Get Active LLM Endpoints for this workspace",
+        "summary": "Get Active LLM Endpoints for this workspace (Removed)",
```
</details>

## [Workflow run](https://github.com/gooddata/gdc-nas/actions/runs/26041025465)

---
*Generated by SDK OpenAPI Sync workflow*