### PR TITLE
feat(gooddata-sdk): [AUTO] Add IP allowlist policy CRUD endpoints to metadata API

### DIFF
--- a/packages/gooddata-sdk/src/gooddata_sdk/__init__.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/__init__.py
@@ -109,6 +109,10 @@ from gooddata_sdk.catalog.organization.entity_model.export_template import (
     CatalogExportTemplate,
     CatalogExportTemplateAttributes,
 )
+from gooddata_sdk.catalog.organization.entity_model.ip_allowlist_policy import (
+    CatalogIpAllowlistPolicy,
+    CatalogIpAllowlistPolicyTargets,
+)
 from gooddata_sdk.catalog.organization.entity_model.jwk import (
     CatalogJwk,
     CatalogJwkAttributes,

--- a/packages/gooddata-sdk/src/gooddata_sdk/catalog/organization/entity_model/ip_allowlist_policy.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/catalog/organization/entity_model/ip_allowlist_policy.py
@@ -1,0 +1,50 @@
+# (C) 2026 GoodData Corporation
+from __future__ import annotations
+
+from typing import Any
+
+import attrs
+
+from gooddata_sdk.catalog.base import Base
+from gooddata_sdk.catalog.identifier import CatalogAssigneeIdentifier
+
+
+@attrs.define(kw_only=True)
+class CatalogIpAllowlistPolicy(Base):
+    """Represents an IP allowlist policy entity.
+
+    Attributes:
+        id: Unique identifier for the policy.
+        allowed_sources: IP addresses or CIDR ranges that are allowed by this policy.
+        users: Users this policy applies to.
+        user_groups: User groups this policy applies to.
+    """
+
+    id: str
+    allowed_sources: list[str] = attrs.field(factory=list)
+    users: list[CatalogAssigneeIdentifier] = attrs.field(factory=list)
+    user_groups: list[CatalogAssigneeIdentifier] = attrs.field(factory=list)
+
+    @classmethod
+    def from_api(cls, entity: dict[str, Any]) -> CatalogIpAllowlistPolicy:
+        attrs_data = entity.get("attributes") or {}
+        relationships = entity.get("relationships") or {}
+        users_rel = (relationships.get("users") or {}).get("data") or []
+        groups_rel = (relationships.get("userGroups") or {}).get("data") or []
+        return cls(
+            id=entity["id"],
+            allowed_sources=list(attrs_data.get("allowedSources") or []),
+            users=[CatalogAssigneeIdentifier(id=u["id"], type=u["type"]) for u in users_rel],
+            user_groups=[CatalogAssigneeIdentifier(id=g["id"], type=g["type"]) for g in groups_rel],
+        )
+
+
+@attrs.define(kw_only=True)
+class CatalogIpAllowlistPolicyTargets(Base):
+    """Target payload for ``addTargets`` / ``removeTargets`` action endpoints.
+
+    Attributes:
+        targets: List of assignee identifiers (users or user-groups) to add or remove.
+    """
+
+    targets: list[CatalogAssigneeIdentifier] = attrs.field(factory=list)

--- a/packages/gooddata-sdk/src/gooddata_sdk/catalog/organization/service.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/catalog/organization/service.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 import functools
+import json
 from typing import Any, Literal
+from urllib.parse import urlparse
 
 from gooddata_api_client.exceptions import NotFoundException
 from gooddata_api_client.model.declarative_export_templates import DeclarativeExportTemplates
@@ -22,6 +24,10 @@ from gooddata_sdk import CatalogDeclarativeExportTemplate, CatalogExportTemplate
 from gooddata_sdk.catalog.catalog_service_base import CatalogServiceBase
 from gooddata_sdk.catalog.organization.entity_model.directive import CatalogCspDirective
 from gooddata_sdk.catalog.organization.entity_model.identity_provider import CatalogIdentityProvider
+from gooddata_sdk.catalog.organization.entity_model.ip_allowlist_policy import (
+    CatalogIpAllowlistPolicy,
+    CatalogIpAllowlistPolicyTargets,
+)
 from gooddata_sdk.catalog.organization.entity_model.jwk import CatalogJwk, CatalogJwkDocument
 from gooddata_sdk.catalog.organization.entity_model.llm_provider import (
     CatalogLlmProvider,
@@ -44,6 +50,10 @@ from gooddata_sdk.utils import load_all_entities, load_all_entities_dict
 HLLType = Literal["Native", "Presto"]
 HLL_TYPE_SETTING_ID = "hyperLogLogType"
 HLL_TYPE_SETTING_TYPE = "HLL_TYPE"
+
+_IP_ALLOWLIST_ENTITIES_BASE = "api/v1/entities/ipAllowlistPolicies"
+_IP_ALLOWLIST_ACTIONS_BASE = "api/v1/actions/ipAllowlistPolicies"
+_JSON_CONTENT_TYPE = "application/json"
 
 
 class CatalogOrganizationService(CatalogServiceBase):
@@ -627,6 +637,150 @@ class CatalogOrganizationService(CatalogServiceBase):
             id: LLM provider identifier
         """
         self._entities_api.delete_entity_llm_providers(id, _check_return_type=False)
+
+    # IP Allowlist Policy APIs
+
+    @staticmethod
+    def _ip_policy_to_body(policy: CatalogIpAllowlistPolicy) -> bytes:
+        """Serialize a policy to a JSON:API request body."""
+        data: dict[str, Any] = {
+            "type": "ipAllowlistPolicy",
+            "id": policy.id,
+            "attributes": {"allowedSources": policy.allowed_sources},
+        }
+        rels: dict[str, Any] = {}
+        if policy.users:
+            rels["users"] = {"data": [{"id": u.id, "type": u.type} for u in policy.users]}
+        if policy.user_groups:
+            rels["userGroups"] = {"data": [{"id": g.id, "type": g.type} for g in policy.user_groups]}
+        if rels:
+            data["relationships"] = rels
+        return json.dumps({"data": data}).encode("utf-8")
+
+    def get_ip_allowlist_policy(self, policy_id: str) -> CatalogIpAllowlistPolicy:
+        """Get an IP allowlist policy by ID.
+
+        Args:
+            policy_id (str): Policy identifier.
+
+        Returns:
+            CatalogIpAllowlistPolicy: Retrieved policy.
+
+        Raises:
+            NotFoundException: Policy does not exist.
+        """
+        response = self._client._do_get_request(f"{_IP_ALLOWLIST_ENTITIES_BASE}/{policy_id}")
+        if response.status_code == 404:
+            raise NotFoundException(status=404, reason=response.reason)
+        response.raise_for_status()
+        return CatalogIpAllowlistPolicy.from_api(response.json()["data"])
+
+    def list_ip_allowlist_policies(self) -> list[CatalogIpAllowlistPolicy]:
+        """Return all IP allowlist policies in the organization.
+
+        Follows JSON:API ``links.next`` pagination transparently.
+
+        Returns:
+            list[CatalogIpAllowlistPolicy]: All policies.
+        """
+        policies: list[CatalogIpAllowlistPolicy] = []
+        endpoint = _IP_ALLOWLIST_ENTITIES_BASE
+        while True:
+            response = self._client._do_get_request(endpoint)
+            response.raise_for_status()
+            body = response.json()
+            policies.extend(CatalogIpAllowlistPolicy.from_api(item) for item in body["data"])
+            next_url = (body.get("links") or {}).get("next")
+            if not next_url:
+                break
+            parsed = urlparse(str(next_url))
+            endpoint = parsed.path.lstrip("/")
+            if parsed.query:
+                endpoint = f"{endpoint}?{parsed.query}"
+        return policies
+
+    def create_ip_allowlist_policy(self, policy: CatalogIpAllowlistPolicy) -> CatalogIpAllowlistPolicy:
+        """Create a new IP allowlist policy.
+
+        Args:
+            policy (CatalogIpAllowlistPolicy): Policy to create.
+
+        Returns:
+            CatalogIpAllowlistPolicy: Newly created policy as returned by the server.
+        """
+        response = self._client._do_post_request(
+            data=self._ip_policy_to_body(policy),
+            endpoint=_IP_ALLOWLIST_ENTITIES_BASE,
+            content_type=_JSON_CONTENT_TYPE,
+        )
+        response.raise_for_status()
+        return CatalogIpAllowlistPolicy.from_api(response.json()["data"])
+
+    def update_ip_allowlist_policy(self, policy: CatalogIpAllowlistPolicy) -> CatalogIpAllowlistPolicy:
+        """Replace an existing IP allowlist policy (full PUT).
+
+        Args:
+            policy (CatalogIpAllowlistPolicy): Updated policy object.
+
+        Returns:
+            CatalogIpAllowlistPolicy: Policy as returned by the server after update.
+
+        Raises:
+            NotFoundException: Policy does not exist.
+        """
+        response = self._client._do_put_request(
+            data=self._ip_policy_to_body(policy),
+            endpoint=f"{_IP_ALLOWLIST_ENTITIES_BASE}/{policy.id}",
+            content_type=_JSON_CONTENT_TYPE,
+        )
+        if response.status_code == 404:
+            raise NotFoundException(status=404, reason=response.reason)
+        response.raise_for_status()
+        return CatalogIpAllowlistPolicy.from_api(response.json()["data"])
+
+    def delete_ip_allowlist_policy(self, policy_id: str) -> None:
+        """Delete an IP allowlist policy.
+
+        Args:
+            policy_id (str): Policy identifier.
+
+        Raises:
+            ValueError: Policy does not exist.
+        """
+        response = self._client._do_delete_request(f"{_IP_ALLOWLIST_ENTITIES_BASE}/{policy_id}")
+        if response.status_code == 404:
+            raise ValueError(f"Cannot delete IP allowlist policy {policy_id!r}. This policy does not exist.")
+        response.raise_for_status()
+
+    def add_targets_to_ip_allowlist_policy(self, policy_id: str, targets: CatalogIpAllowlistPolicyTargets) -> None:
+        """Add users or user-groups to an existing IP allowlist policy.
+
+        Args:
+            policy_id (str): Policy identifier.
+            targets (CatalogIpAllowlistPolicyTargets): Targets to add.
+        """
+        body = json.dumps({"targets": [{"id": t.id, "type": t.type} for t in targets.targets]}).encode("utf-8")
+        response = self._client._do_post_request(
+            data=body,
+            endpoint=f"{_IP_ALLOWLIST_ACTIONS_BASE}/{policy_id}/addTargets",
+            content_type=_JSON_CONTENT_TYPE,
+        )
+        response.raise_for_status()
+
+    def remove_targets_from_ip_allowlist_policy(self, policy_id: str, targets: CatalogIpAllowlistPolicyTargets) -> None:
+        """Remove users or user-groups from an existing IP allowlist policy.
+
+        Args:
+            policy_id (str): Policy identifier.
+            targets (CatalogIpAllowlistPolicyTargets): Targets to remove.
+        """
+        body = json.dumps({"targets": [{"id": t.id, "type": t.type} for t in targets.targets]}).encode("utf-8")
+        response = self._client._do_post_request(
+            data=body,
+            endpoint=f"{_IP_ALLOWLIST_ACTIONS_BASE}/{policy_id}/removeTargets",
+            content_type=_JSON_CONTENT_TYPE,
+        )
+        response.raise_for_status()
 
     # Layout APIs
 

--- a/packages/gooddata-sdk/src/gooddata_sdk/client.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/client.py
@@ -105,7 +105,7 @@ class GoodDataApiClient:
             content_type (str): The content type of the data being sent.
 
         Returns:
-            None
+            requests.Response
         """
         if not self._hostname.endswith("/"):
             endpoint = f"/{endpoint}"
@@ -120,6 +120,72 @@ class GoodDataApiClient:
         )
 
         return response
+
+    def _do_get_request(self, endpoint: str) -> requests.Response:
+        """Perform a GET request to a specified endpoint.
+
+        Args:
+            endpoint (str): The endpoint path (without leading slash) to call.
+
+        Returns:
+            requests.Response
+        """
+        if not self._hostname.endswith("/"):
+            endpoint = f"/{endpoint}"
+
+        return requests.get(
+            url=f"{self._hostname}{endpoint}",
+            headers={
+                "Authorization": f"Bearer {self._token}",
+            },
+        )
+
+    def _do_put_request(
+        self,
+        data: bytes,
+        endpoint: str,
+        content_type: str,
+    ) -> requests.Response:
+        """Perform a PUT request to a specified endpoint.
+
+        Args:
+            data (bytes): The data to be sent in the PUT request.
+            endpoint (str): The endpoint path (without leading slash) to call.
+            content_type (str): The content type of the data being sent.
+
+        Returns:
+            requests.Response
+        """
+        if not self._hostname.endswith("/"):
+            endpoint = f"/{endpoint}"
+
+        return requests.put(
+            url=f"{self._hostname}{endpoint}",
+            headers={
+                "Content-Type": content_type,
+                "Authorization": f"Bearer {self._token}",
+            },
+            data=data,
+        )
+
+    def _do_delete_request(self, endpoint: str) -> requests.Response:
+        """Perform a DELETE request to a specified endpoint.
+
+        Args:
+            endpoint (str): The endpoint path (without leading slash) to call.
+
+        Returns:
+            requests.Response
+        """
+        if not self._hostname.endswith("/"):
+            endpoint = f"/{endpoint}"
+
+        return requests.delete(
+            url=f"{self._hostname}{endpoint}",
+            headers={
+                "Authorization": f"Bearer {self._token}",
+            },
+        )
 
     def do_request(
         self,

--- a/packages/gooddata-sdk/tests/catalog/test_catalog_organization.py
+++ b/packages/gooddata-sdk/tests/catalog/test_catalog_organization.py
@@ -7,6 +7,7 @@ from gooddata_api_client.exceptions import NotFoundException
 from gooddata_sdk import (
     CatalogCspDirective,
     CatalogDeclarativeNotificationChannel,
+    CatalogIpAllowlistPolicy,
     CatalogJwk,
     CatalogOrganization,
     CatalogOrganizationSetting,
@@ -563,3 +564,39 @@ def test_layout_notification_channels(test_config, snapshot_notification_channel
 #         sdk.catalog_organization.put_declarative_identity_providers([])
 #         idps = sdk.catalog_organization.get_declarative_identity_providers()
 #         assert len(idps) == 0
+
+
+@gd_vcr.use_cassette(str(_fixtures_dir / "ip_allowlist_policy_crud.yaml"))
+def test_ip_allowlist_policy_crud(test_config):
+    """Integration test covering the full IP allowlist policy CRUD lifecycle."""
+    sdk = GoodDataSdk.create(host_=test_config["host"], token_=test_config["token"])
+    policy_id = "testIpPolicy"
+    policy = CatalogIpAllowlistPolicy(
+        id=policy_id,
+        allowed_sources=["192.168.0.0/16"],
+    )
+    updated_policy = CatalogIpAllowlistPolicy(
+        id=policy_id,
+        allowed_sources=["10.0.0.0/8", "192.168.0.0/16"],
+    )
+    try:
+        # Create
+        created = sdk.catalog_organization.create_ip_allowlist_policy(policy)
+        assert created.id == policy_id
+        assert created.allowed_sources == ["192.168.0.0/16"]
+
+        # Get
+        fetched = sdk.catalog_organization.get_ip_allowlist_policy(policy_id)
+        assert fetched.id == policy_id
+        assert fetched.allowed_sources == ["192.168.0.0/16"]
+
+        # List — policy must appear in the full list
+        policies = sdk.catalog_organization.list_ip_allowlist_policies()
+        assert any(p.id == policy_id for p in policies)
+
+        # Update
+        updated = sdk.catalog_organization.update_ip_allowlist_policy(updated_policy)
+        assert updated.id == policy_id
+        assert set(updated.allowed_sources) == {"10.0.0.0/8", "192.168.0.0/16"}
+    finally:
+        safe_delete(sdk.catalog_organization.delete_ip_allowlist_policy, policy_id)

--- a/packages/gooddata-sdk/tests/catalog/unit_tests/test_ip_allowlist_policy.py
+++ b/packages/gooddata-sdk/tests/catalog/unit_tests/test_ip_allowlist_policy.py
@@ -1,0 +1,76 @@
+# (C) 2026 GoodData Corporation
+"""Unit tests for CatalogIpAllowlistPolicy deserialization.
+
+The from_api classmethod has custom None-guard logic and nested relationship
+parsing that warrants direct testing.
+"""
+
+from __future__ import annotations
+
+import pytest
+from gooddata_sdk.catalog.identifier import CatalogAssigneeIdentifier
+from gooddata_sdk.catalog.organization.entity_model.ip_allowlist_policy import CatalogIpAllowlistPolicy
+
+
+@pytest.mark.parametrize(
+    "scenario, entity, expected_sources, expected_users, expected_groups",
+    [
+        (
+            "minimal — no relationships, no attributes",
+            {"id": "pol1", "type": "ipAllowlistPolicy"},
+            [],
+            [],
+            [],
+        ),
+        (
+            "with allowed_sources",
+            {
+                "id": "pol2",
+                "type": "ipAllowlistPolicy",
+                "attributes": {"allowedSources": ["10.0.0.0/8", "192.168.1.0/24"]},
+            },
+            ["10.0.0.0/8", "192.168.1.0/24"],
+            [],
+            [],
+        ),
+        (
+            "with users and user_groups relationships",
+            {
+                "id": "pol3",
+                "type": "ipAllowlistPolicy",
+                "attributes": {"allowedSources": ["172.16.0.0/12"]},
+                "relationships": {
+                    "users": {"data": [{"id": "alice", "type": "user"}]},
+                    "userGroups": {"data": [{"id": "admins", "type": "userGroup"}]},
+                },
+            },
+            ["172.16.0.0/12"],
+            [CatalogAssigneeIdentifier(id="alice", type="user")],
+            [CatalogAssigneeIdentifier(id="admins", type="userGroup")],
+        ),
+        (
+            "null attributes and relationships are safe",
+            {
+                "id": "pol4",
+                "type": "ipAllowlistPolicy",
+                "attributes": None,
+                "relationships": None,
+            },
+            [],
+            [],
+            [],
+        ),
+    ],
+)
+def test_ip_allowlist_policy_from_api(
+    scenario: str,
+    entity: dict,
+    expected_sources: list[str],
+    expected_users: list[CatalogAssigneeIdentifier],
+    expected_groups: list[CatalogAssigneeIdentifier],
+) -> None:
+    policy = CatalogIpAllowlistPolicy.from_api(entity)
+    assert policy.id == entity["id"], scenario
+    assert policy.allowed_sources == expected_sources, scenario
+    assert policy.users == expected_users, scenario
+    assert policy.user_groups == expected_groups, scenario


### PR DESCRIPTION
## Summary

Added IP allowlist policy CRUD endpoints to the Python SDK. Created entity model CatalogIpAllowlistPolicy and CatalogIpAllowlistPolicyTargets, extended GoodDataApiClient with _do_get_request/_do_put_request/_do_delete_request HTTP helpers, added 7 service methods to CatalogOrganizationService (get, list with pagination, create, update, delete, addTargets, removeTargets), exported new classes from gooddata_sdk.__init__, and added an integration test plus parametrized unit test for from_api deserialization.

**Impact:** new_feature | **Services:** `gooddata-metadata-client`

**Source commits (gdc-nas):**
- [`147ec88`](https://github.com/gooddata/gdc-nas/commit/147ec883e0edfb79818f076b13f4f40ca4842a5d) by **Peter Plocháň** — Merge pull request #22741 from gooddata/dnik/md-allowlist-crud

## Files changed

- `packages/gooddata-sdk/src/gooddata_sdk/catalog/organization/entity_model/ip_allowlist_policy.py`
- `packages/gooddata-sdk/src/gooddata_sdk/client.py`
- `packages/gooddata-sdk/src/gooddata_sdk/catalog/organization/service.py`
- `packages/gooddata-sdk/src/gooddata_sdk/__init__.py`
- `packages/gooddata-sdk/tests/catalog/test_catalog_organization.py`
- `packages/gooddata-sdk/tests/catalog/unit_tests/test_ip_allowlist_policy.py`

## Agent decisions

<details><summary>Decisions (4)</summary>

**raw HTTP vs waiting for api-client regeneration** — Wrap raw HTTP via new _do_get_request/_do_put_request/_do_delete_request helpers on GoodDataApiClient
  - Alternatives: Set status=error and wait for api-client regeneration cycle, Hand-write generated model files (blocked by security hook)
  - Why: The generated api-client has no JsonApiIpAllowlistPolicy* models or EntitiesApi methods yet. Per the instructions, wrapping raw HTTP is the preferred path for new endpoints when the generated client is missing symbols.

**reusing CatalogAssigneeIdentifier** — Import existing CatalogAssigneeIdentifier from catalog.identifier instead of creating a new class
  - Alternatives: Create a new CatalogIpAllowlistAssigneeIdentifier with a unique name, Use plain dicts for targets
  - Why: catalog.identifier already exports CatalogAssigneeIdentifier backed by the generated AssigneeIdentifier model with proper enum validation. Creating a duplicate class would shadow the existing export in __init__.py.

**pagination in list_ip_allowlist_policies** — Follow JSON:API links.next transparently in a while loop
  - Alternatives: Return only the first page (breaks consumer expectations), Expose page/size parameters
  - Why: Consistent with the SDK contract of returning all entities from list_* methods. Uses urlparse to extract the path from the next URL returned by the server.

**from_api signature override** — Override from_api with signature matching the base class pattern (entity: dict[str, Any]) returning the concrete type
  - Alternatives: Use cattrs.structure() with a custom converter, Flatten the entity structure
  - Why: The API response is raw JSON (camelCase keys), not a generated model object. Custom deserialization is needed for nested attributes and relationships.

</details>

<details><summary>Assumptions to verify (4)</summary>

- The JSON:API response for ipAllowlistPolicy entities uses camelCase keys (allowedSources, userGroups) as standard for GoodData APIs
- The addTargets/removeTargets endpoints return 204 No Content on success
- The create endpoint returns 201 with the created entity body
- Relationships in the entity response follow the JSON:API {data: [{id, type}]} format

</details>

<details><summary>Risks (3)</summary>

- The API may return relationships in a format other than standard JSON:API {data:[{id,type}]} shape — from_api would silently produce empty users/user_groups lists
- PUT update endpoint may require all relationship fields even if not originally set; policies without relationships may fail on update
- response.reason attribute on requests.Response may be None for some HTTP implementations, causing NotFoundException(reason=None)

</details>

<details><summary>Layers touched (3)</summary>

- **entity_model** — New entity model; reuses existing CatalogAssigneeIdentifier from catalog.identifier to avoid name collision
  - `packages/gooddata-sdk/src/gooddata_sdk/catalog/organization/entity_model/ip_allowlist_policy.py`
- **public_api** — HTTP helpers added to GoodDataApiClient; CRUD service methods added to CatalogOrganizationService
  - `packages/gooddata-sdk/src/gooddata_sdk/__init__.py`
  - `packages/gooddata-sdk/src/gooddata_sdk/client.py`
  - `packages/gooddata-sdk/src/gooddata_sdk/catalog/organization/service.py`
- **tests** — Integration test + parametrized unit test for from_api deserialization
  - `packages/gooddata-sdk/tests/catalog/test_catalog_organization.py`
  - `packages/gooddata-sdk/tests/catalog/unit_tests/test_ip_allowlist_policy.py`

</details>

<details><summary>OpenAPI diff</summary>

```diff
--- a/gooddata-metadata-client.json
+++ b/gooddata-metadata-client.json
@@ -7119,6 +7184,21 @@
+      "IpAllowlistPolicyTargets": {
+        "description": "Target delta for IP allowlist policy actions.",
+        "properties": {
+          "targets": {
+            "items": { "$ref": "#/components/schemas/AssigneeIdentifier" },
+            "type": "array"
+          }
+        },
+        "required": [ "targets" ],
+        "type": "object"
+      },
@@ -16067,6 +16147,230 @@
+      "JsonApiIpAllowlistPolicyIn": { ... },
+      "JsonApiIpAllowlistPolicyInDocument": { ... },
+      "JsonApiIpAllowlistPolicyOut": { ... },
+      "JsonApiIpAllowlistPolicyOutDocument": { ... },
+      "JsonApiIpAllowlistPolicyOutIncludes": { ... },
+      "JsonApiIpAllowlistPolicyOutList": { ... },
+      "JsonApiIpAllowlistPolicyOutWithLinks": { ... },
@@ -28269,6 +28549,76 @@
+    "/api/v1/actions/ipAllowlistPolicies/{id}/addTargets": {
+      "post": {
+        "operationId": "addTargets",
+        "requestBody": { "content": { "application/json": { "schema": { "$ref": "#/components/schemas/IpAllowlistPolicyTargets" } } }, "required": true },
+        "responses": { "204": { "description": "No Content" } },
+        "summary": "Add targets to IP allowlist policy"
+      }
+    },
+    "/api/v1/actions/ipAllowlistPolicies/{id}/removeTargets": {
+      "post": {
+        "operationId": "removeTargets",
+        "requestBody": { "content": { "application/json": { "schema": { "$ref": "#/components/schemas/IpAllowlistPolicyTargets" } } }, "required": true },
+        "responses": { "204": { "description": "No Content" } },
+        "summary": "Remove targets from IP allowlist policy"
+      }
+    },
@@ -33206,6 +33556,345 @@
+    "/api/v1/entities/ipAllowlistPolicies": {
+      "get": { "operationId": "getAllEntities@IpAllowlistPolicies", "summary": "Get all IpAllowlistPolicy entities", ... },
+      "post": { "operationId": "createEntity@IpAllowlistPolicies", "summary": "Post IpAllowlistPolicy entities", ... }
+    },
+    "/api/v1/entities/ipAllowlistPolicies/{id}": {
+      "delete": { "operationId": "deleteEntity@IpAllowlistPolicies", "summary": "Delete IpAllowlistPolicy entity" },
+      "get": { "operationId": "getEntity@IpAllowlistPolicies", "summary": "Get IpAllowlistPolicy entity" },
+      "put": { "operationId": "updateEntity@IpAllowlistPolicies", "summary": "Put IpAllowlistPolicy entity" }
+    },
```
</details>

## [Workflow run](https://github.com/gooddata/gdc-nas/actions/runs/26041025465)

---
*Generated by SDK OpenAPI Sync workflow*