### PR TITLE
feat(gooddata-sdk): [AUTO] Add treatNullValuesAs to range filter across three clients

### DIFF
--- a/packages/gooddata-sdk/pyproject.toml
+++ b/packages/gooddata-sdk/pyproject.toml
@@ -76,7 +76,7 @@ test = [
 ]
 
 [tool.ty.analysis]
-allowed-unresolved-imports = ["gooddata_api_client.**"]
+allowed-unresolved-imports = ["gooddata_api_client.**", "pyarrow", "pyarrow.**"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/gooddata_sdk"]

--- a/packages/gooddata-sdk/src/gooddata_sdk/compute/model/filter.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/compute/model/filter.py
@@ -326,7 +326,7 @@ class RelativeDateFilter(Filter):
         self._from_shift = from_shift
         self._to_shift = to_shift
         self._bounded_filter = bounded_filter
-        self._empty_value_handling = empty_value_handling
+        self._empty_value_handling: EmptyValueHandling | None = empty_value_handling
 
     @property
     def dataset(self) -> ObjId:
@@ -435,7 +435,7 @@ class AllTimeDateFilter(Filter):
 
         self._dataset = dataset
         self._granularity = granularity
-        self._empty_value_handling = empty_value_handling
+        self._empty_value_handling: EmptyValueHandling | None = empty_value_handling
 
     @property
     def dataset(self) -> ObjId:
@@ -490,7 +490,7 @@ class AbsoluteDateFilter(Filter):
         self._dataset = dataset
         self._from_date = from_date
         self._to_date = to_date
-        self._empty_value_handling = empty_value_handling
+        self._empty_value_handling: EmptyValueHandling | None = empty_value_handling
 
     @property
     def dataset(self) -> ObjId:


### PR DESCRIPTION
## Summary

The SDK wrapper already fully implemented treatNullValuesAs for RangeMeasureValueFilter (MetricValueFilter with range operators). Fixed two pre-existing ty check failures: added pyarrow to allowed-unresolved-imports in pyproject.toml, and annotated _empty_value_handling attributes in three date-filter classes with explicit EmptyValueHandling | None types.

**Impact:** modification | **Services:** `automation`, `export-controller`, `metadata-api`

**Source commits (gdc-nas):**
- [`9151514`](https://github.com/gooddata/gdc-nas/commit/915151466491766183c697d238535de546da600a) by **Mike Zelenskij** — Merge pull request #23218 from gooddata/c.mze-cq-2397-cont

## Files changed

- `packages/gooddata-sdk/pyproject.toml`
- `packages/gooddata-sdk/src/gooddata_sdk/compute/model/filter.py`

## Agent decisions

<details><summary>Decisions (4)</summary>

**SDK wrapper already handles treatNullValuesAs for range filter** — No feature code added; fixed pre-existing type check failures only
  - Alternatives: Add new code to SDK wrapper, Add integration test + cassette
  - Why: MetricValueFilter already accepts treat_nulls_as and passes treat_null_values_as to RangeMeasureValueFilterBody for range operators. The generated client (RangeMeasureValueFilterRangeMeasureValueFilter) already has treat_null_values_as. Unit tests test_range_measure_value_filter_conversion and the snapshot range_filter_with_treat_nulls_as.snapshot.json already cover both converter and serialisation directions.

**skipped integration test for range filter treatNullValuesAs** — Rely on existing unit tests in test_compute_to_sdk_converter.py and test_metric_value_filter.py
  - Alternatives: Add new integration test + VCR cassette, Extend existing integration test
  - Why: treat_nulls_as is a pure passthrough kwarg: no SDK-side validation, transformation, or branching is added beyond what already existed. The existing unit tests (test_range_measure_value_filter_conversion with treatNullValuesAs: 42, plus the parametrized snapshot test 'range filter with treat nulls as') fully exercise both the converter and the as_api_model() path.

**pyarrow allowed-unresolved-imports** — Add pyarrow and pyarrow.** to [tool.ty.analysis].allowed-unresolved-imports in pyproject.toml
  - Alternatives: Suppress with # type: ignore at each call site, Remove the try/except import entirely
  - Why: pyarrow is an optional dependency (in the arrow extras group) so it may not be installed in the type-check environment. The existing pattern with TYPE_CHECKING guard + try/except is correct; ty just needs to know the import may be missing.

**_empty_value_handling type annotation** — Add explicit EmptyValueHandling | None annotation at the point of self._empty_value_handling assignment in RelativeDateFilter, AllTimeDateFilter, and AbsoluteDateFilter
  - Alternatives: Cast in the property return, Change the attribute name to avoid collision with broader str inference
  - Why: ty infers the stored attribute as None | str because Literal types flow through assignment without narrowing. An explicit annotation at the assignment site is the minimal, idiomatic fix and matches the documented SDK convention.

</details>

<details><summary>Assumptions to verify (3)</summary>

- The generated gooddata-api-client already has treat_null_values_as in RangeMeasureValueFilterRangeMeasureValueFilter (confirmed by grep).
- The OpenAPI diff represents a spec change that has already been reflected in the generated client bundled in this workspace.
- The two warnings (unused type: ignore on execution.py lines 22-23) are pre-existing and do not affect exit code 0.

</details>

<details><summary>Layers touched (1)</summary>

- **entity_model** — Added explicit EmptyValueHandling | None type annotations to _empty_value_handling instance attributes; no functional change to the range filter feature itself.
  - `packages/gooddata-sdk/src/gooddata_sdk/compute/model/filter.py`

</details>

<details><summary>OpenAPI diff</summary>

```diff
--- a/gooddata-automation-client.json
+++ b/gooddata-automation-client.json
@@ -1472,6 +1472,10 @@
                 ],
                 "type": "string"
               },
+              "treatNullValuesAs": {
+                "format": "double",
+                "type": "number"
+              },
               "value": {
                 "format": "double",
                 "type": "number"
@@ -1516,6 +1520,10 @@
               "to": {
+                "format": "double",
+                "type": "number"
+              },
+              "treatNullValuesAs": {
                 "format": "double",
                 "type": "number"
               }
--- a/gooddata-export-client.json
+++ b/gooddata-export-client.json
@@ -926,6 +926,10 @@
+              "treatNullValuesAs": {
+                "format": "double",
+                "type": "number"
+              },
@@ -970,6 +974,10 @@
               "to": {
+                "format": "double",
+                "type": "number"
+              },
+              "treatNullValuesAs": {
                 "format": "double",
                 "type": "number"
               }
--- a/gooddata-metadata-client.json
+++ b/gooddata-metadata-client.json
@@ -1762,6 +1762,10 @@
+              "treatNullValuesAs": {
+                "format": "double",
+                "type": "number"
+              },
@@ -1806,6 +1810,10 @@
               "to": {
+                "format": "double",
+                "type": "number"
+              },
+              "treatNullValuesAs": {
                 "format": "double",
                 "type": "number"
               }
```
</details>

## [Workflow run](https://github.com/gooddata/gdc-nas/actions/runs/26368846494)

---
*Generated by SDK OpenAPI Sync workflow*