### PR TITLE
fix(catalog): Support NUMBER analytics parameters in declarative model

### DIFF
--- a/gooddata-api-client/docs/DeclarativeParameterContent.md
+++ b/gooddata-api-client/docs/DeclarativeParameterContent.md
@@ -4,9 +4,9 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**type** | **str** | The parameter type. | defaults to "STRING"
 **constraints** | [**StringConstraints**](StringConstraints.md) |  | [optional] 
 **default_value** | **str** |  | [optional] 
-**type** | **str** | The parameter type. | [optional]  if omitted the server will use the default value of "STRING"
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/gooddata-api-client/docs/JsonApiParameterInAttributesDefinition.md
+++ b/gooddata-api-client/docs/JsonApiParameterInAttributesDefinition.md
@@ -4,9 +4,9 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**type** | **str** | The parameter type. | defaults to "STRING"
 **constraints** | [**StringConstraints**](StringConstraints.md) |  | [optional] 
 **default_value** | **str** |  | [optional] 
-**type** | **str** | The parameter type. | [optional]  if omitted the server will use the default value of "STRING"
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/gooddata-api-client/docs/ParameterDefinition.md
+++ b/gooddata-api-client/docs/ParameterDefinition.md
@@ -5,9 +5,9 @@ Parameter content (type-discriminated).
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**type** | **str** | The parameter type. | defaults to "STRING"
 **constraints** | [**StringConstraints**](StringConstraints.md) |  | [optional] 
 **default_value** | **str** |  | [optional] 
-**type** | **str** | The parameter type. | [optional]  if omitted the server will use the default value of "STRING"
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/gooddata-api-client/gooddata_api_client/model/declarative_parameter_content.py
+++ b/gooddata-api-client/gooddata_api_client/model/declarative_parameter_content.py
@@ -95,20 +95,28 @@ class DeclarativeParameterContent(ModelComposed):
         """
         lazy_import()
         return {
+            'type': (str,),  # noqa: E501
             'constraints': (StringConstraints,),  # noqa: E501
             'default_value': (str,),  # noqa: E501
-            'type': (str,),  # noqa: E501
         }
 
     @cached_property
     def discriminator():
-        return None
-
+        lazy_import()
+        val = {
+            'NUMBER': NumberParameterDefinition,
+            'NumberParameterDefinition': NumberParameterDefinition,
+            'STRING': StringParameterDefinition,
+            'StringParameterDefinition': StringParameterDefinition,
+        }
+        if not val:
+            return None
+        return {'type': val}
 
     attribute_map = {
+        'type': 'type',  # noqa: E501
         'constraints': 'constraints',  # noqa: E501
         'default_value': 'defaultValue',  # noqa: E501
-        'type': 'type',  # noqa: E501
     }
 
     read_only_vars = {
@@ -120,6 +128,7 @@ class DeclarativeParameterContent(ModelComposed):
         """DeclarativeParameterContent - a model defined in OpenAPI
 
         Keyword Args:
+            type (str): The parameter type.. defaults to "STRING", must be one of ["STRING", ]  # noqa: E501
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.
@@ -152,9 +161,9 @@ class DeclarativeParameterContent(ModelComposed):
                                 _visited_composed_classes = (Animal,)
             constraints (StringConstraints): [optional]  # noqa: E501
             default_value (str): [optional]  # noqa: E501
-            type (str): The parameter type.. [optional] if omitted the server will use the default value of "STRING"  # noqa: E501
         """
 
+        type = kwargs.get('type', "STRING")
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
         _path_to_item = kwargs.pop('_path_to_item', ())
@@ -226,6 +235,7 @@ class DeclarativeParameterContent(ModelComposed):
         """DeclarativeParameterContent - a model defined in OpenAPI
 
         Keyword Args:
+            type (str): The parameter type.. defaults to "STRING", must be one of ["STRING", ]  # noqa: E501
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.
@@ -258,9 +268,9 @@ class DeclarativeParameterContent(ModelComposed):
                                 _visited_composed_classes = (Animal,)
             constraints (StringConstraints): [optional]  # noqa: E501
             default_value (str): [optional]  # noqa: E501
-            type (str): The parameter type.. [optional] if omitted the server will use the default value of "STRING"  # noqa: E501
         """
 
+        type = kwargs.get('type', "STRING")
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
         _path_to_item = kwargs.pop('_path_to_item', ())

--- a/gooddata-api-client/gooddata_api_client/model/json_api_parameter_in_attributes_definition.py
+++ b/gooddata-api-client/gooddata_api_client/model/json_api_parameter_in_attributes_definition.py
@@ -95,20 +95,28 @@ class JsonApiParameterInAttributesDefinition(ModelComposed):
         """
         lazy_import()
         return {
+            'type': (str,),  # noqa: E501
             'constraints': (StringConstraints,),  # noqa: E501
             'default_value': (str,),  # noqa: E501
-            'type': (str,),  # noqa: E501
         }
 
     @cached_property
     def discriminator():
-        return None
-
+        lazy_import()
+        val = {
+            'NUMBER': NumberParameterDefinition,
+            'NumberParameterDefinition': NumberParameterDefinition,
+            'STRING': StringParameterDefinition,
+            'StringParameterDefinition': StringParameterDefinition,
+        }
+        if not val:
+            return None
+        return {'type': val}
 
     attribute_map = {
+        'type': 'type',  # noqa: E501
         'constraints': 'constraints',  # noqa: E501
         'default_value': 'defaultValue',  # noqa: E501
-        'type': 'type',  # noqa: E501
     }
 
     read_only_vars = {
@@ -120,6 +128,7 @@ class JsonApiParameterInAttributesDefinition(ModelComposed):
         """JsonApiParameterInAttributesDefinition - a model defined in OpenAPI
 
         Keyword Args:
+            type (str): The parameter type.. defaults to "STRING", must be one of ["STRING", ]  # noqa: E501
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.
@@ -152,9 +161,9 @@ class JsonApiParameterInAttributesDefinition(ModelComposed):
                                 _visited_composed_classes = (Animal,)
             constraints (StringConstraints): [optional]  # noqa: E501
             default_value (str): [optional]  # noqa: E501
-            type (str): The parameter type.. [optional] if omitted the server will use the default value of "STRING"  # noqa: E501
         """
 
+        type = kwargs.get('type', "STRING")
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
         _path_to_item = kwargs.pop('_path_to_item', ())
@@ -226,6 +235,7 @@ class JsonApiParameterInAttributesDefinition(ModelComposed):
         """JsonApiParameterInAttributesDefinition - a model defined in OpenAPI
 
         Keyword Args:
+            type (str): The parameter type.. defaults to "STRING", must be one of ["STRING", ]  # noqa: E501
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.
@@ -258,9 +268,9 @@ class JsonApiParameterInAttributesDefinition(ModelComposed):
                                 _visited_composed_classes = (Animal,)
             constraints (StringConstraints): [optional]  # noqa: E501
             default_value (str): [optional]  # noqa: E501
-            type (str): The parameter type.. [optional] if omitted the server will use the default value of "STRING"  # noqa: E501
         """
 
+        type = kwargs.get('type', "STRING")
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
         _path_to_item = kwargs.pop('_path_to_item', ())

--- a/gooddata-api-client/gooddata_api_client/model/parameter_definition.py
+++ b/gooddata-api-client/gooddata_api_client/model/parameter_definition.py
@@ -95,20 +95,28 @@ class ParameterDefinition(ModelComposed):
         """
         lazy_import()
         return {
+            'type': (str,),  # noqa: E501
             'constraints': (StringConstraints,),  # noqa: E501
             'default_value': (str,),  # noqa: E501
-            'type': (str,),  # noqa: E501
         }
 
     @cached_property
     def discriminator():
-        return None
-
+        lazy_import()
+        val = {
+            'NUMBER': NumberParameterDefinition,
+            'NumberParameterDefinition': NumberParameterDefinition,
+            'STRING': StringParameterDefinition,
+            'StringParameterDefinition': StringParameterDefinition,
+        }
+        if not val:
+            return None
+        return {'type': val}
 
     attribute_map = {
+        'type': 'type',  # noqa: E501
         'constraints': 'constraints',  # noqa: E501
         'default_value': 'defaultValue',  # noqa: E501
-        'type': 'type',  # noqa: E501
     }
 
     read_only_vars = {
@@ -120,6 +128,7 @@ class ParameterDefinition(ModelComposed):
         """ParameterDefinition - a model defined in OpenAPI
 
         Keyword Args:
+            type (str): The parameter type.. defaults to "STRING", must be one of ["STRING", ]  # noqa: E501
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.
@@ -152,9 +161,9 @@ class ParameterDefinition(ModelComposed):
                                 _visited_composed_classes = (Animal,)
             constraints (StringConstraints): [optional]  # noqa: E501
             default_value (str): [optional]  # noqa: E501
-            type (str): The parameter type.. [optional] if omitted the server will use the default value of "STRING"  # noqa: E501
         """
 
+        type = kwargs.get('type', "STRING")
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
         _path_to_item = kwargs.pop('_path_to_item', ())
@@ -226,6 +235,7 @@ class ParameterDefinition(ModelComposed):
         """ParameterDefinition - a model defined in OpenAPI
 
         Keyword Args:
+            type (str): The parameter type.. defaults to "STRING", must be one of ["STRING", ]  # noqa: E501
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.
@@ -258,9 +268,9 @@ class ParameterDefinition(ModelComposed):
                                 _visited_composed_classes = (Animal,)
             constraints (StringConstraints): [optional]  # noqa: E501
             default_value (str): [optional]  # noqa: E501
-            type (str): The parameter type.. [optional] if omitted the server will use the default value of "STRING"  # noqa: E501
         """
 
+        type = kwargs.get('type', "STRING")
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
         _path_to_item = kwargs.pop('_path_to_item', ())

--- a/packages/gooddata-sdk/src/gooddata_sdk/__init__.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/__init__.py
@@ -221,6 +221,7 @@ from gooddata_sdk.catalog.workspace.declarative_model.workspace.analytics_model.
     CatalogDeclarativeAnalytics,
     CatalogDeclarativeMemoryItem,
     CatalogDeclarativeMetric,
+    CatalogDeclarativeParameter,
 )
 from gooddata_sdk.catalog.workspace.declarative_model.workspace.analytics_model.export_definition import (
     CatalogDeclarativeExportDefinition,

--- a/packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/declarative_model/workspace/analytics_model/analytics_model.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/declarative_model/workspace/analytics_model/analytics_model.py
@@ -15,10 +15,10 @@ from gooddata_api_client.model.declarative_dashboard_plugin import DeclarativeDa
 from gooddata_api_client.model.declarative_filter_context import DeclarativeFilterContext
 from gooddata_api_client.model.declarative_memory_item import DeclarativeMemoryItem
 from gooddata_api_client.model.declarative_metric import DeclarativeMetric
+from gooddata_api_client.model.declarative_parameter import DeclarativeParameter
 from gooddata_api_client.model.declarative_visualization_object import DeclarativeVisualizationObject
 
 from gooddata_sdk.catalog.base import Base
-from gooddata_sdk.catalog.parameter import CatalogParameter
 from gooddata_sdk.catalog.permission.declarative_model.permission import (
     CatalogDeclarativeDashboardPermissionsForAssignee,
     CatalogDeclarativeDashboardPermissionsForAssigneeRule,
@@ -51,6 +51,7 @@ LAYOUT_VISUALIZATION_OBJECTS_DIR = "visualization_objects"
 ATTRIBUTE_HIERARCHY_OBJECTS_DIR = "attribute_hierarchy_objects"
 EXPORT_DEFINITION_DIR = "export_definitions"
 MEMORY_ITEMS_DIR = "memory_items"
+PARAMETERS_DIR = "parameters"
 
 
 @define(kw_only=True)
@@ -82,7 +83,7 @@ class CatalogDeclarativeAnalyticsLayer(Base):
     visualization_objects: list[CatalogDeclarativeVisualizationObject] = field(factory=list)
     export_definitions: list[CatalogDeclarativeExportDefinition] = field(factory=list)
     memory_items: list[CatalogDeclarativeMemoryItem] = field(factory=list)
-    parameters: list[CatalogParameter] = field(factory=list)
+    parameters: list[CatalogDeclarativeParameter] = field(factory=list)
 
     @staticmethod
     def client_class() -> type[DeclarativeAnalyticsLayer]:
@@ -148,6 +149,12 @@ class CatalogDeclarativeAnalyticsLayer(Base):
         create_directory(folder)
         return folder
 
+    @staticmethod
+    def get_parameters_folder(analytics_model_folder: Path) -> Path:
+        folder = analytics_model_folder / PARAMETERS_DIR
+        create_directory(folder)
+        return folder
+
     def store_to_disk(self, workspace_folder: Path, sort: bool = False) -> None:
         analytics_model_folder = self.get_analytics_model_folder(workspace_folder)
 
@@ -160,6 +167,7 @@ class CatalogDeclarativeAnalyticsLayer(Base):
         attribute_hierarchy_folder = self.get_attribute_hierarchy_folder(analytics_model_folder)
         export_definition_folder = self.get_export_definition_folder(analytical_dashboards_folder)
         memory_item_folder = self.get_memory_item_folder(analytics_model_folder)
+        parameters_folder = self.get_parameters_folder(analytics_model_folder)
 
         for analytical_dashboard in self.analytical_dashboards:
             analytical_dashboard.store_to_disk(analytical_dashboards_folder, sort=sort)
@@ -188,6 +196,9 @@ class CatalogDeclarativeAnalyticsLayer(Base):
         for memory_item in self.memory_items:
             memory_item.store_to_disk(memory_item_folder, sort=sort)
 
+        for parameter in self.parameters:
+            parameter.store_to_disk(parameters_folder, sort=sort)
+
     @classmethod
     def load_from_disk(cls, workspace_folder: Path) -> CatalogDeclarativeAnalyticsLayer:
         analytics_model_folder = cls.get_analytics_model_folder(workspace_folder)
@@ -200,6 +211,7 @@ class CatalogDeclarativeAnalyticsLayer(Base):
         attribute_hierarchy_folder = cls.get_attribute_hierarchy_folder(analytics_model_folder)
         export_definition_folder = cls.get_export_definition_folder(analytical_dashboards_folder)
         memory_item_folder = cls.get_memory_item_folder(analytics_model_folder)
+        parameters_folder = cls.get_parameters_folder(analytics_model_folder)
 
         analytical_dashboard_files = get_sorted_yaml_files(analytical_dashboards_folder)
         analytical_dashboard_extension_files = get_sorted_yaml_files(analytical_dashboard_extensions_folder)
@@ -210,6 +222,7 @@ class CatalogDeclarativeAnalyticsLayer(Base):
         attribute_hierarchy_files = get_sorted_yaml_files(attribute_hierarchy_folder)
         export_definition_files = get_sorted_yaml_files(export_definition_folder)
         memory_item_files = get_sorted_yaml_files(memory_item_folder)
+        parameter_files = get_sorted_yaml_files(parameters_folder)
 
         analytical_dashboards = [
             CatalogDeclarativeAnalyticalDashboard.load_from_disk(analytical_dashboard_file)
@@ -243,6 +256,7 @@ class CatalogDeclarativeAnalyticsLayer(Base):
         memory_items = [
             CatalogDeclarativeMemoryItem.load_from_disk(memory_item_file) for memory_item_file in memory_item_files
         ]
+        parameters = [CatalogDeclarativeParameter.load_from_disk(parameter_file) for parameter_file in parameter_files]
         return cls(
             analytical_dashboards=analytical_dashboards,
             analytical_dashboard_extensions=analytical_dashboard_extensions,
@@ -253,6 +267,7 @@ class CatalogDeclarativeAnalyticsLayer(Base):
             visualization_objects=visualization_objects,
             export_definitions=export_definitions,
             memory_items=memory_items,
+            parameters=parameters,
         )
 
 
@@ -348,3 +363,10 @@ class CatalogDeclarativeMemoryItem(CatalogAnalyticsBaseMeta):
     @staticmethod
     def client_class() -> type[DeclarativeMemoryItem]:
         return DeclarativeMemoryItem
+
+
+@define(kw_only=True)
+class CatalogDeclarativeParameter(CatalogAnalyticsBase):
+    @staticmethod
+    def client_class() -> type[DeclarativeParameter]:
+        return DeclarativeParameter

--- a/packages/gooddata-sdk/tests/catalog/unit_tests/test_declarative_analytics_parameters.py
+++ b/packages/gooddata-sdk/tests/catalog/unit_tests/test_declarative_analytics_parameters.py
@@ -1,0 +1,52 @@
+# (C) 2026 GoodData Corporation
+"""Unit test: analytics-layer ``parameters`` survive the declarative round-trip.
+
+Regression test. The ``parameters`` field on ``CatalogDeclarativeAnalyticsLayer``
+was bound to the data-source ``CatalogParameter`` ({name, value}) instead of a
+declarative parameter wrapper ({id, title, content}). That dropped the field
+silently on older SDKs and raised ``ClassValidationError`` once the generated
+model gained ``parameters``. This pins the correct behaviour: a parameter that
+goes in must come back out unchanged.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from gooddata_sdk import CatalogDeclarativeAnalytics
+from gooddata_sdk.catalog.workspace.declarative_model.workspace.analytics_model.analytics_model import (
+    CatalogDeclarativeAnalyticsLayer,
+)
+
+_PARAMETER = {
+    "id": "discount-rate",
+    "title": "Discount Rate",
+    "content": {"type": "NUMBER", "defaultValue": 0.5},
+}
+_LAYOUT = {"analytics": {"parameters": [_PARAMETER]}}
+
+
+def test_declarative_analytics_parameters_survive_round_trip() -> None:
+    analytics = CatalogDeclarativeAnalytics.from_dict(_LAYOUT)
+
+    # The typed wrapper must actually capture the parameter as a declarative
+    # parameter (id/title/content), not the data-source name/value shape.
+    params = analytics.analytics.parameters
+    assert len(params) == 1
+    assert params[0].id == "discount-rate"
+    assert params[0].title == "Discount Rate"
+    assert params[0].content["type"] == "NUMBER"
+
+    # The api round-trip must preserve it verbatim - neither dropped nor mangled.
+    round_tripped = analytics.to_api().to_dict(camel_case=True)
+    assert round_tripped["analytics"]["parameters"] == [_PARAMETER]
+
+
+def test_declarative_analytics_parameters_survive_disk_round_trip(tmp_path: Path) -> None:
+    layer = CatalogDeclarativeAnalyticsLayer.from_dict({"parameters": [_PARAMETER]})
+
+    layer.store_to_disk(tmp_path)
+    reloaded = CatalogDeclarativeAnalyticsLayer.load_from_disk(tmp_path)
+
+    assert [p.id for p in reloaded.parameters] == ["discount-rate"]
+    assert reloaded.parameters[0].content["type"] == "NUMBER"

--- a/schemas/gooddata-api-client.json
+++ b/schemas/gooddata-api-client.json
@@ -7630,6 +7630,13 @@
       "DeclarativeParameter": {
         "properties": {
           "content": {
+            "discriminator": {
+              "mapping": {
+                "NUMBER": "#/components/schemas/NumberParameterDefinition",
+                "STRING": "#/components/schemas/StringParameterDefinition"
+              },
+              "propertyName": "type"
+            },
             "oneOf": [
               {
                 "$ref": "#/components/schemas/NumberParameterDefinition"
@@ -24806,6 +24813,13 @@
                 "type": "boolean"
               },
               "definition": {
+                "discriminator": {
+                  "mapping": {
+                    "NUMBER": "#/components/schemas/NumberParameterDefinition",
+                    "STRING": "#/components/schemas/StringParameterDefinition"
+                  },
+                  "propertyName": "type"
+                },
                 "oneOf": [
                   {
                     "$ref": "#/components/schemas/NumberParameterDefinition"
@@ -24905,6 +24919,13 @@
                 "type": "string"
               },
               "definition": {
+                "discriminator": {
+                  "mapping": {
+                    "NUMBER": "#/components/schemas/NumberParameterDefinition",
+                    "STRING": "#/components/schemas/StringParameterDefinition"
+                  },
+                  "propertyName": "type"
+                },
                 "oneOf": [
                   {
                     "$ref": "#/components/schemas/NumberParameterDefinition"
@@ -25094,6 +25115,13 @@
                 "type": "boolean"
               },
               "definition": {
+                "discriminator": {
+                  "mapping": {
+                    "NUMBER": "#/components/schemas/NumberParameterDefinition",
+                    "STRING": "#/components/schemas/StringParameterDefinition"
+                  },
+                  "propertyName": "type"
+                },
                 "oneOf": [
                   {
                     "$ref": "#/components/schemas/NumberParameterDefinition"
@@ -25163,6 +25191,13 @@
                 "type": "boolean"
               },
               "definition": {
+                "discriminator": {
+                  "mapping": {
+                    "NUMBER": "#/components/schemas/NumberParameterDefinition",
+                    "STRING": "#/components/schemas/StringParameterDefinition"
+                  },
+                  "propertyName": "type"
+                },
                 "oneOf": [
                   {
                     "$ref": "#/components/schemas/NumberParameterDefinition"
@@ -31202,6 +31237,13 @@
       },
       "ParameterDefinition": {
         "description": "Parameter content (type-discriminated).",
+        "discriminator": {
+          "mapping": {
+            "NUMBER": "#/components/schemas/NumberParameterDefinition",
+            "STRING": "#/components/schemas/StringParameterDefinition"
+          },
+          "propertyName": "type"
+        },
         "oneOf": [
           {
             "$ref": "#/components/schemas/NumberParameterDefinition"

--- a/schemas/gooddata-metadata-client.json
+++ b/schemas/gooddata-metadata-client.json
@@ -5140,6 +5140,13 @@
       "DeclarativeParameter": {
         "properties": {
           "content": {
+            "discriminator": {
+              "mapping": {
+                "NUMBER": "#/components/schemas/NumberParameterDefinition",
+                "STRING": "#/components/schemas/StringParameterDefinition"
+              },
+              "propertyName": "type"
+            },
             "oneOf": [
               {
                 "$ref": "#/components/schemas/NumberParameterDefinition"
@@ -20575,6 +20582,13 @@
                 "type": "boolean"
               },
               "definition": {
+                "discriminator": {
+                  "mapping": {
+                    "NUMBER": "#/components/schemas/NumberParameterDefinition",
+                    "STRING": "#/components/schemas/StringParameterDefinition"
+                  },
+                  "propertyName": "type"
+                },
                 "oneOf": [
                   {
                     "$ref": "#/components/schemas/NumberParameterDefinition"
@@ -20674,6 +20688,13 @@
                 "type": "string"
               },
               "definition": {
+                "discriminator": {
+                  "mapping": {
+                    "NUMBER": "#/components/schemas/NumberParameterDefinition",
+                    "STRING": "#/components/schemas/StringParameterDefinition"
+                  },
+                  "propertyName": "type"
+                },
                 "oneOf": [
                   {
                     "$ref": "#/components/schemas/NumberParameterDefinition"
@@ -20863,6 +20884,13 @@
                 "type": "boolean"
               },
               "definition": {
+                "discriminator": {
+                  "mapping": {
+                    "NUMBER": "#/components/schemas/NumberParameterDefinition",
+                    "STRING": "#/components/schemas/StringParameterDefinition"
+                  },
+                  "propertyName": "type"
+                },
                 "oneOf": [
                   {
                     "$ref": "#/components/schemas/NumberParameterDefinition"
@@ -20932,6 +20960,13 @@
                 "type": "boolean"
               },
               "definition": {
+                "discriminator": {
+                  "mapping": {
+                    "NUMBER": "#/components/schemas/NumberParameterDefinition",
+                    "STRING": "#/components/schemas/StringParameterDefinition"
+                  },
+                  "propertyName": "type"
+                },
                 "oneOf": [
                   {
                     "$ref": "#/components/schemas/NumberParameterDefinition"
@@ -26001,6 +26036,13 @@
       },
       "ParameterDefinition": {
         "description": "Parameter content (type-discriminated).",
+        "discriminator": {
+          "mapping": {
+            "NUMBER": "#/components/schemas/NumberParameterDefinition",
+            "STRING": "#/components/schemas/StringParameterDefinition"
+          },
+          "propertyName": "type"
+        },
         "oneOf": [
           {
             "$ref": "#/components/schemas/NumberParameterDefinition"


### PR DESCRIPTION
## Summary

`CatalogDeclarativeAnalyticsLayer.parameters` was typed as the data-source `CatalogParameter` (`{name, value}`) instead of the declarative parameter shape (`{id, title, content}`), so the field was dropped silently on older SDKs and raised `ClassValidationError` once the generated model gained `parameters`.

- Retype the field to a new `CatalogDeclarativeParameter`, a thin wrapper over the generated `DeclarativeParameter` (subclasses `CatalogAnalyticsBase`, same pattern as `CatalogDeclarativeMetric`).
- Add disk persistence under a `parameters/` folder in `store_to_disk`/`load_from_disk`, mirroring the other declarative objects.
- Regenerate the API client and schemas to add the `NUMBER`/`STRING` discriminator on `DeclarativeParameterContent`.
- Export `CatalogDeclarativeParameter` from `gooddata_sdk`.

No SDK code read `layer.parameters` with the old `{name, value}` shape, so the type change has no downstream consumers to break.

## Test plan

New unit test `packages/gooddata-sdk/tests/catalog/unit_tests/test_declarative_analytics_parameters.py` covers the API and disk round-trips for a `NUMBER` parameter.

`pytest packages/gooddata-sdk/tests/catalog/unit_tests/test_declarative_analytics_parameters.py`

risk: low
