### PR TITLE
fix(eval): fix search_tool correctness always scoring 0%

### DIFF
--- a/packages/gooddata-eval/src/gooddata_eval/core/evaluators/search_tool.py
+++ b/packages/gooddata-eval/src/gooddata_eval/core/evaluators/search_tool.py
@@ -6,9 +6,12 @@ from gooddata_eval.core.models import ChatResult, DatasetItem
 
 
 def _normalize_str_list(value: object, *, lowercase: bool = False) -> list[str]:
-    # Arguments come from raw model-emitted JSON, so a malformed tool call may
-    # contain non-string entries. Drop them defensively so bad input scores as a
-    # mismatch instead of raising and aborting the whole evaluation.
+    # Arguments come from raw model-emitted JSON. The search_objects schema
+    # declares keywords/object_types as list[str], but a malformed tool call may
+    # send a non-list or non-string entries. Drop the offending entries defensively
+    # so bad input can't raise (.lower()/sorted() on a non-str) and abort the whole
+    # evaluation run; a non-list collapses to [] and the surviving strings are
+    # still compared normally.
     if not isinstance(value, list):
         return []
     items = [item for item in value if isinstance(item, str)]
@@ -23,6 +26,9 @@ def _args_match(actual_args: dict, expected_args: dict) -> bool:
     expected_kw = _normalize_str_list(expected_args.get("keywords"), lowercase=True)
     if actual_kw != expected_kw:
         return False
+    # object_types is compared case-sensitively (no lowercase=True): they are
+    # controlled ObjectType StrEnum values the model emits verbatim ("metric",
+    # "dashboard"), so a case mismatch is a genuine error, not a formatting quirk.
     return _normalize_str_list(actual_args.get("object_types")) == _normalize_str_list(
         expected_args.get("object_types")
     )

--- a/packages/gooddata-eval/src/gooddata_eval/core/evaluators/search_tool.py
+++ b/packages/gooddata-eval/src/gooddata_eval/core/evaluators/search_tool.py
@@ -6,13 +6,14 @@ from gooddata_eval.core.models import ChatResult, DatasetItem
 
 
 def _args_match(actual_args: dict, expected_args: dict) -> bool:
-    if sorted(actual_args.get("keywords") or []) != sorted(expected_args.get("keywords") or []):
+    # Only keywords and object_types determine semantic correctness.
+    # limit is optional with a server-side default; emit_widget was renamed to
+    # user_requested_search in the tool schema — neither affects search quality.
+    actual_kw = sorted(k.lower() for k in (actual_args.get("keywords") or []))
+    expected_kw = sorted(k.lower() for k in (expected_args.get("keywords") or []))
+    if actual_kw != expected_kw:
         return False
-    if sorted(actual_args.get("object_types") or []) != sorted(expected_args.get("object_types") or []):
-        return False
-    if actual_args.get("limit") != expected_args.get("limit"):
-        return False
-    return actual_args.get("emit_widget") == expected_args.get("emit_widget")
+    return sorted(actual_args.get("object_types") or []) == sorted(expected_args.get("object_types") or [])
 
 
 class SearchToolEvaluator:

--- a/packages/gooddata-eval/src/gooddata_eval/core/evaluators/search_tool.py
+++ b/packages/gooddata-eval/src/gooddata_eval/core/evaluators/search_tool.py
@@ -5,15 +5,27 @@ from gooddata_eval.core.evaluators.base import ItemEvaluation
 from gooddata_eval.core.models import ChatResult, DatasetItem
 
 
+def _normalize_str_list(value: object, *, lowercase: bool = False) -> list[str]:
+    # Arguments come from raw model-emitted JSON, so a malformed tool call may
+    # contain non-string entries. Drop them defensively so bad input scores as a
+    # mismatch instead of raising and aborting the whole evaluation.
+    if not isinstance(value, list):
+        return []
+    items = [item for item in value if isinstance(item, str)]
+    return sorted(item.lower() if lowercase else item for item in items)
+
+
 def _args_match(actual_args: dict, expected_args: dict) -> bool:
     # Only keywords and object_types determine semantic correctness.
     # limit is optional with a server-side default; emit_widget was renamed to
     # user_requested_search in the tool schema — neither affects search quality.
-    actual_kw = sorted(k.lower() for k in (actual_args.get("keywords") or []))
-    expected_kw = sorted(k.lower() for k in (expected_args.get("keywords") or []))
+    actual_kw = _normalize_str_list(actual_args.get("keywords"), lowercase=True)
+    expected_kw = _normalize_str_list(expected_args.get("keywords"), lowercase=True)
     if actual_kw != expected_kw:
         return False
-    return sorted(actual_args.get("object_types") or []) == sorted(expected_args.get("object_types") or [])
+    return _normalize_str_list(actual_args.get("object_types")) == _normalize_str_list(
+        expected_args.get("object_types")
+    )
 
 
 class SearchToolEvaluator:


### PR DESCRIPTION
## Summary

The `tool_correctness` metric in `search_tool` evaluations was always `False` (0%), making the dashboard metric useless.

**Root cause:** `_args_match` checked two fields that never matched real model calls:
- `emit_widget` — this parameter was renamed to `user_requested_search` in the tool schema; the model never sends `emit_widget`, so `actual_args.get("emit_widget")` was always `None` vs the expected `false`
- `limit` — declared as optional (`int | None`) in the schema; the model omits it and relies on the server default, while fixtures hardcode `10`

**Fix:** Only check `keywords` (case-insensitive) and `object_types` — the two fields that determine whether the search was semantically correct. `limit` and the widget display flag are not part of search correctness.

## Test Plan

- [ ] Run `uv run pytest tests/ -x -q` in `packages/gooddata-eval`
- [ ] Re-run search_tool eval items and verify `tool_correctness` now reflects actual model behaviour (models that call with the right keywords and object types should score True)

## Risk

Low — single function change in the evaluator, no effect on eval runner or production code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved matching of search tool calls to judge correctness using the most relevant inputs.
  * Search keywords are now compared case-insensitively, and object types are normalized for more reliable matching.
  * Search options such as limit and widget emission are no longer required to match exactly, reducing false mismatches.
  * Malformed or non-string keyword/object type inputs are handled defensively, preventing matching-time errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->