### PR TITLE
Master-orchestrated release with LTS patch support

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -9,10 +9,21 @@
 
 name: Build Python Package and Create Release
 
+# Dispatched by the Release workflow (bump-version.yaml) after it tags a release,
+# so this always runs from master's definition (single source of truth) while
+# building the tagged code. Can also be dispatched manually to re-run a release.
 on:
-  push:
-    tags:
-      - v*.*.*
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to build (e.g. v1.2.3)'
+        required: true
+        type: string
+      make_latest:
+        description: 'Mark the GitHub release as latest (true/false)'
+        required: false
+        default: 'false'
+        type: string
 
 env:
   COMPONENTS: '["gooddata-api-client","gooddata-pandas","gooddata-fdw","gooddata-sdk","gooddata-dbt","gooddata-flight-server","gooddata-flexconnect","gooddata-pipelines"]'
@@ -39,6 +50,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
+      with:
+        ref: ${{ inputs.tag }}
+        persist-credentials: false
     - name: Install uv
       uses: astral-sh/setup-uv@v7
     - name: Build ${{ matrix.component }}
@@ -63,6 +77,12 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tag }}
+          fetch-depth: 0
+          persist-credentials: false
       - name: Obtain artifacts
         uses: actions/download-artifact@v6
         with:
@@ -72,18 +92,21 @@ jobs:
         uses: requarks/changelog-action@v1
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
-          tag: ${{ github.ref_name }}
+          tag: ${{ inputs.tag }}
           writeToFile: false
           includeRefIssues: false
           useGitmojis: false
       - name: Create GitHub release
         uses: "softprops/action-gh-release@v2"
         with:
+          tag_name: ${{ inputs.tag }}
           body: ${{ steps.changelog.outputs.changes }}
           token: "${{ secrets.GITHUB_TOKEN }}"
           draft: false
           prerelease: false
-          make_latest: true
+          # accepts the strings "true"/"false"/"legacy"; the Release workflow
+          # passes "true"/"false" from scripts/is_latest_tag.sh
+          make_latest: ${{ inputs.make_latest }}
           files: |
             dist/**/*.whl
             dist/**/*.tar.gz
@@ -120,4 +143,4 @@ jobs:
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             channel: "#releases"
-            text: "The release of *gooddata-python-sdk@${{ github.ref_name }}*, has been successful. :tada:"
+            text: "The release of *gooddata-python-sdk@${{ inputs.tag }}*, has been successful. :tada:"

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -1,6 +1,13 @@
 # (C) 2023 GoodData Corporation
-name: Bump version & trigger release
+name: Release (bump version, publish packages & docs)
 
+# Single source of truth: always run this workflow from master ("Use workflow
+# from: master"). Major/minor releases use base_branch=master and create the
+# line anchor rel/X.Y.0. Patch releases for an LTS line set base_branch to that
+# anchor rel/X.Y.0; the workflow builds from the line's highest existing
+# rel/X.Y.* branch and creates a new rel/X.Y.Z branch for the patch. The
+# workflow definition is always master's; only the code it operates on comes
+# from the resolved source branch.
 on:
   workflow_dispatch:
     inputs:
@@ -13,10 +20,21 @@ on:
           - major
           - minor
           - patch
+      base_branch:
+        description: 'Branch to release from. Use master for major/minor; use the line anchor rel/X.Y.0 for a patch (the latest rel/X.Y.* is auto-selected).'
+        type: string
+        required: true
+        default: 'master'
 
 permissions:
   contents: write
   pull-requests: write
+
+# Serialize releases so overlapping runs cannot race the is_latest computation
+# or contend on the master/tag pushes.
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 jobs:
     bump-version:
@@ -24,9 +42,51 @@ jobs:
       outputs:
         new_version: ${{ steps.bump.outputs.new_version }}
       steps:
+        - name: Validate bump type and base branch
+          env:
+            BASE: ${{ inputs.base_branch }}
+            BUMP: ${{ inputs.bump_type }}
+          run: |
+            if [ "$BUMP" = "patch" ]; then
+              if [[ ! "$BASE" =~ ^rel/[0-9]+\.[0-9]+\.0$ ]]; then
+                echo "::error::patch releases require base_branch to be a rel/X.Y.0 maintenance branch (got: $BASE)."
+                exit 1
+              fi
+            else
+              if [ "$BASE" != "master" ]; then
+                echo "::error::$BUMP releases must use base_branch=master (got: $BASE)."
+                exit 1
+              fi
+            fi
+
+        - name: Resolve source branch
+          id: resolve
+          env:
+            GH_TOKEN: ${{ secrets.TOKEN_GITHUB_YENKINS_ADMIN }}
+            BASE: ${{ inputs.base_branch }}
+            BUMP: ${{ inputs.bump_type }}
+          run: |
+            if [ "$BUMP" = "patch" ]; then
+              # base_branch is the line anchor rel/X.Y.0; build the next patch from
+              # the line's highest existing rel/X.Y.* branch so patches chain.
+              MINOR="${BASE%.*}" # rel/1.2.0 -> rel/1.2
+              SOURCE=$(gh api "repos/${GITHUB_REPOSITORY}/git/matching-refs/heads/${MINOR}." --jq '.[].ref' \
+                | sed 's|refs/heads/||' | grep -E '^rel/[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
+              if [ -z "$SOURCE" ]; then
+                echo "::error::No ${MINOR}.* maintenance branch found. Create the line's rel/X.Y.0 branch first."
+                exit 1
+              fi
+            else
+              SOURCE="$BASE"
+            fi
+            echo "Resolved source branch: $SOURCE"
+            echo "source_branch=$SOURCE" >> "$GITHUB_OUTPUT"
+
         - name: Checkout
           uses: actions/checkout@v5
           with:
+            ref: ${{ steps.resolve.outputs.source_branch }}
+            fetch-depth: 0 # need full history and tags for is_latest_tag.sh
             token: ${{ secrets.TOKEN_GITHUB_YENKINS_ADMIN }} # needed to push to the protected branch
 
         - name: Install uv
@@ -38,52 +98,58 @@ jobs:
 
         - name: Bump version
           id: bump
+          env:
+            BUMP: ${{ inputs.bump_type }}
           run: |
-            NEW_VERSION=$(uv run python ./scripts/bump_version.py ${{ github.event.inputs.bump_type }})
-            echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+            NEW_VERSION=$(uv run python ./scripts/bump_version.py "$BUMP")
+            echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
         - name: Bump version in documentation
+          env:
+            NEW_VERSION: ${{ steps.bump.outputs.new_version }}
           run: |
-            uv run python ./scripts/bump_doc_dependencies.py ${{ steps.bump.outputs.new_version }}
+            uv run python ./scripts/bump_doc_dependencies.py "$NEW_VERSION"
 
         - name: Bump version in codebase
+          env:
+            NEW_VERSION: ${{ steps.bump.outputs.new_version }}
           run: |
-            make release-ci VERSION=${{ steps.bump.outputs.new_version }}
+            make release-ci VERSION="$NEW_VERSION"
 
-        - name: Specify release branch
-          id: branch
-          run: |
-            if [ "${{ github.event.inputs.bump_type }}" == "patch" ]; then
-              RELEASE_BRANCH="patch/${{ steps.bump.outputs.new_version }}"
-            else
-              RELEASE_BRANCH="rel/${{ steps.bump.outputs.new_version }}"
-            fi
-            echo "release_branch=$RELEASE_BRANCH" >> $GITHUB_OUTPUT
-
-        - name: Create and push the new version ${{steps.bump.outputs.new_version}}
+        - name: Commit, tag and push the new version ${{steps.bump.outputs.new_version}}
+          env:
+            NEW_VERSION: ${{ steps.bump.outputs.new_version }}
+            BASE: ${{ inputs.base_branch }}
           run: |
             git config user.name github-actions
             git config user.email github-actions@github.com
-            git checkout -b ${{ steps.branch.outputs.release_branch }}
+            NEW_BRANCH="rel/${NEW_VERSION}"
+            # A matching rel/X.Y.Z branch means this version was already released.
+            if git ls-remote --exit-code --heads origin "$NEW_BRANCH" >/dev/null 2>&1; then
+              echo "::error::v${NEW_VERSION} appears already released ($NEW_BRANCH exists). To rebuild, dispatch build-release.yaml directly."
+              exit 1
+            fi
             git add -A
-            git commit -m "Release ${{steps.bump.outputs.new_version}}"
-            git push origin ${{ steps.branch.outputs.release_branch }}
-            git checkout master
-            git merge ${{ steps.branch.outputs.release_branch }}
-            git push origin master
+            git commit -m "Release ${NEW_VERSION}"
+            git tag "v${NEW_VERSION}"
+            # Create the version's own rel/X.Y.Z branch; for a master release also
+            # advance master. Push atomically -- all refs land or none do.
+            REFSPECS=("refs/tags/v${NEW_VERSION}" "HEAD:refs/heads/${NEW_BRANCH}")
+            if [ "$BASE" = "master" ]; then
+              REFSPECS+=("HEAD:master")
+            fi
+            git push --atomic origin "${REFSPECS[@]}"
 
-# TODO: this part waits for docs build and publish optimization it takes too long (~15 minutes)
-#    trigger-release:
-#      needs:
-#        - bump-version
-#        - create-release-branch
-#      runs-on: ubuntu-latest
-#      steps:
-#        - name: Checkout
-#          uses: actions/checkout@v5
-#        - name: Push new tag – v${{ needs.bump-version.outputs.new_version }}
-#          run: |
-#            git config user.name GitHub Actions
-#            git config user.email github-actions@github.com
-#            git tag v${{ needs.bump-version.outputs.new_version }}
-#            git push origin v${{ needs.bump-version.outputs.new_version }}
+        - name: Dispatch build, publish and docs
+          env:
+            GH_TOKEN: ${{ secrets.TOKEN_GITHUB_YENKINS_ADMIN }} # GITHUB_TOKEN cannot trigger downstream workflow_dispatch
+            NEW_VERSION: ${{ steps.bump.outputs.new_version }}
+          run: |
+            git fetch --tags origin # ensure the comparison sees the freshest remote tag set
+            TAG="v${NEW_VERSION}"
+            IS_LATEST=$(bash scripts/is_latest_tag.sh "$TAG")
+            echo "Tag $TAG is_latest=$IS_LATEST"
+            gh workflow run build-release.yaml --ref master -f tag="$TAG" -f make_latest="$IS_LATEST"
+            if [ "$IS_LATEST" = "true" ]; then
+              gh workflow run netlify-deploy.yaml --ref master
+            fi

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -1,13 +1,45 @@
 # Repository maintenance and release
 
 ## How to release
-* manually run [Bump version & trigger release](.github/workflows/bump-version.yaml) workflow
-* after the previous workflow finishes, dispatch the GitHub workflow [Netlify Deploy](.github/workflows/netlify-deploy.yaml) on the `master` branch (takes ~15 minutes)
-  * The styling of the documentation is taken from the `master` branch. For more details see [generate.sh](scripts/generate.sh).
-* after the previous workflow finishes, push tag
-  * the version should be the same as the one in [Bump version & trigger release](.github/workflows/bump-version.yaml) workflow log
-  * checkout latest master branch and tag it `vX.Y.Z`
-  * push the tag to the gooddata/gooddata-python-sdk repository (e.g. `git push <remote> vX.Y.Z`)
+
+Releases are fully automated by a single workflow dispatch. **Always run the
+[Release](.github/workflows/bump-version.yaml) workflow from `master`** ("Use
+workflow from: master") — the workflow definition is always master's (single
+source of truth); the `base_branch` input selects which line's code it acts on.
+
+> The Release workflow dispatches `build-release.yaml` and `netlify-deploy.yaml`
+> from `master`, so those workflows must already exist on `master`. The first
+> orchestrated release therefore has to run after this change is merged, not from
+> a feature branch.
+
+### Standard release (major / minor)
+1. Run the [Release](.github/workflows/bump-version.yaml) workflow from `master` with `bump_type = major` or `minor` and `base_branch = master` (the default).
+2. The run bumps the version, commits onto `master`, creates the long-lived `rel/X.Y.0` maintenance branch (for later patching), and pushes the `vX.Y.0` tag.
+3. It then dispatches — from `master` — the downstream workflows:
+   * [Build Python Package and Create Release](.github/workflows/build-release.yaml) builds all components, publishes them to PyPI, creates the GitHub release (marked latest), and notifies Slack.
+   * [Netlify Deploy](.github/workflows/netlify-deploy.yaml) rebuilds and deploys the documentation (styling is taken from the `master` branch; see [generate.sh](scripts/generate.sh)).
+
+> `patch` is intentionally rejected when `base_branch = master` — patches come from a `rel/X.Y.Z` maintenance branch (see below).
+
+### Releasing an LTS patch (patching an old version)
+Each version has its own maintenance branch `rel/X.Y.Z`. A minor/major release creates the line anchor `rel/X.Y.0`; each patch creates the next `rel/X.Y.(n+1)` from the line's latest branch, so all patch branches persist.
+
+> If the line predates this release scheme it has no `rel/X.Y.0` branch yet — create it once from that line's tag before patching: `git branch rel/X.Y.0 vX.Y.0 && git push origin rel/X.Y.0`.
+
+1. Merge the fix to `master` via a normal PR.
+2. **Cherry-pick the fix onto the line's _latest_ `rel/X.Y.*` branch** (e.g. `rel/1.5.2`, not the anchor `rel/1.5.0`) and push it. This is what the next patch builds on — cherry-picking onto an older branch would silently drop the fix.
+3. Run the [Release](.github/workflows/bump-version.yaml) workflow **from `master`** with `bump_type = patch` and `base_branch = rel/X.Y.0` (the anchor; the workflow auto-selects the line's highest `rel/X.Y.*` to build from).
+4. The workflow builds from that latest branch, bumps the patch (e.g. `1.5.2` → `1.5.3`), and creates a new `rel/1.5.3` branch plus the `v1.5.3` tag. It does **not** touch `master` or the source branch.
+5. It dispatches `build-release.yaml` from `master`, which publishes every component to PyPI and creates the GitHub release. Because the tag is not the highest semver, the release is marked **non-latest** and documentation is **not** redeployed. (Patching the current latest line is the exception — that tag *is* the highest, so it is marked latest and docs deploy.)
+
+Subsequent patches repeat steps 1-4; each creates the next `rel/X.Y.Z` branch from the previous one, so patches chain and accumulate.
+
+### Re-running a release (escape hatch)
+To rebuild/republish an existing tag without bumping again, dispatch the build workflow directly from `master`:
+
+```shell
+gh workflow run build-release.yaml --ref master -f tag=vX.Y.Z -f make_latest=false
+```
 
 
 ### How-to dev release

--- a/scripts/is_latest_tag.sh
+++ b/scripts/is_latest_tag.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# (C) 2026 GoodData Corporation
+# Prints "true" if the given tag is the highest semver among all v*.*.* tags,
+# otherwise "false". Requires the repository's tags to be present locally
+# (callers should checkout with fetch-depth: 0).
+# Usage: is_latest_tag.sh vX.Y.Z
+set -e
+
+tag="$1"
+if [ -z "$tag" ]; then
+    echo "Usage: is_latest_tag.sh vX.Y.Z" >&2
+    exit 1
+fi
+
+highest=$(git tag -l 'v*.*.*' | sort -V | tail -1)
+if [ "$tag" = "$highest" ]; then
+    echo "true"
+else
+    echo "false"
+fi


### PR DESCRIPTION
## Summary

Reworks releasing into a single **master-orchestrated** workflow with one source of truth, and adds support for patching old (LTS) versions — needed now that we offer LTS support for CN / on-prem deployments.

Previously releasing took three manual steps, and the earlier consolidation still relied on dispatching from a branch and on tag-push triggers. Both run the workflow file **as it exists on that ref**, so old `rel/*` branches would run stale release logic. This PR fixes that: the release workflow always runs from `master`.

## How it works

**Release workflow (`bump-version.yaml`) — always run from `master`:**
- Inputs: `bump_type` (major/minor/patch) + `base_branch` (default `master`).
- `major`/`minor` require `base_branch=master`; `patch` requires a `rel/X.Y.Z` branch (validated, fails fast otherwise).
- Checks out `base_branch`, bumps, commits, and tags on it. For `master` releases it also creates the long-lived `rel/X.Y.0` maintenance branch.
- Computes whether the new tag is the highest semver (`scripts/is_latest_tag.sh`) and dispatches the downstream workflows **from master** via `gh workflow run --ref master`, passing `tag` and `make_latest`.

Because the workflow definition is always master's while `checkout` `ref:` selects the code, the logic is centralized but can act on any line.

**LTS patching:** merge the fix to master → cherry-pick onto `rel/X.Y.0` → run the Release workflow from master with `bump_type=patch`, `base_branch=rel/X.Y.0`. Patches accumulate on the same branch (`bump_version.py` increments from the branch's current version). Old-line patches publish to PyPI but produce a **non-latest** GitHub release and skip docs; patching the current latest line is correctly marked latest and deploys docs.

**`build-release.yaml`:** switches from a tag-push trigger to `workflow_dispatch` with `tag` + `make_latest` inputs, building the tagged code. Filename unchanged → **PyPI trusted publishing (OIDC) needs no reconfiguration**. Also usable as a manual re-run escape hatch.

**`netlify-deploy.yaml`:** plain `workflow_dispatch`; the orchestrator only dispatches it for the latest release.

**`MAINTENANCE.md`:** documents the master-orchestrated flow, LTS patch process, and the re-run escape hatch.

## Notes

- **Fire-and-forget:** the orchestrator dispatches build/publish/docs and returns; success means "bumped, tagged, dispatched", not "published" (same effective semantics as the old tag-push fan-out).
- Downstream dispatch uses the `TOKEN_GITHUB_YENKINS_ADMIN` PAT (the default `GITHUB_TOKEN` cannot trigger `workflow_dispatch`).
- Pre-existing old lines still need a `rel/X.Y.0` branch created once from their last tag before they can be patched — but the logic that runs is always master's.
- Behavior verified locally via YAML parsing and shell dry-runs of the validation, commit/tag/push, and dispatch logic for all release scenarios. The actual cross-workflow dispatch can only be fully confirmed by a run on GitHub.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release workflows can now be started manually with a chosen version tag and an option to control whether the GitHub Release is marked as latest.
  * Added an automated release flow supporting standard releases and LTS patch releases on the correct maintenance branch.

* **Bug Fixes**
  * Improved consistency by basing changelog generation and notifications on the selected tag, with validation of version/branch compatibility.

* **Documentation**
  * Updated the release guide to describe the workflow-based process, including LTS patch procedures and a re-run/escape-hatch for existing tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->