### PR TITLE
feat(gooddata-eval): report created metric/automation id from single-turn evaluators

### DIFF
--- a/packages/gooddata-eval/src/gooddata_eval/core/evaluators/alert_skill.py
+++ b/packages/gooddata-eval/src/gooddata_eval/core/evaluators/alert_skill.py
@@ -25,6 +25,19 @@ def _extract_metric_id(metric_str: str) -> str | None:
     return match.group(1) if match else None
 
 
+def _extract_automation_id(tool_event) -> str | None:
+    """Real server-assigned id of the automation this call created.
+
+    Mirrors ``core/agentic/alert_skill.py``'s ``_extract_alert_call`` — the id
+    lives in the tool *result* (what the server assigned), not the tool call
+    *arguments* (what the agent asked for).
+    """
+    result_data = tool_event.parsed_result()
+    if not isinstance(result_data, dict):
+        return None
+    return result_data.get("id") or (result_data.get("data") or {}).get("id")
+
+
 def _check_threshold(expected: dict, actual_args: dict) -> bool:
     operator = expected.get("Operator", "")
     if operator == "ANOMALY":
@@ -58,10 +71,11 @@ class AlertSkillEvaluator:
             return ItemEvaluation(
                 passed=False,
                 rank_key=(False,) * 7,
-                detail={"alert_created": False},
+                detail={"alert_created": False, "automation_id": None},
             )
 
         args = tool_event.parsed_arguments()
+        automation_id = _extract_automation_id(tool_event)
 
         operator_correct = True
         threshold_correct = True
@@ -126,5 +140,9 @@ class AlertSkillEvaluator:
                 "filters_correct": filters_correct,
                 "metric_correct": metric_correct,
                 "recipients_correct": recipients_correct,
+                # Real server-assigned id of the automation this run created —
+                # lets a caller (e.g. a cleanup step) delete the exact object
+                # created instead of diffing the workspace catalog before/after.
+                "automation_id": automation_id,
             },
         )

--- a/packages/gooddata-eval/src/gooddata_eval/core/evaluators/alert_skill.py
+++ b/packages/gooddata-eval/src/gooddata_eval/core/evaluators/alert_skill.py
@@ -35,7 +35,8 @@ def _extract_automation_id(tool_event) -> str | None:
     result_data = tool_event.parsed_result()
     if not isinstance(result_data, dict):
         return None
-    return result_data.get("id") or (result_data.get("data") or {}).get("id")
+    nested_data = result_data.get("data")
+    return result_data.get("id") or (nested_data.get("id") if isinstance(nested_data, dict) else None)
 
 
 def _check_threshold(expected: dict, actual_args: dict) -> bool:

--- a/packages/gooddata-eval/src/gooddata_eval/core/evaluators/metric_skill.py
+++ b/packages/gooddata-eval/src/gooddata_eval/core/evaluators/metric_skill.py
@@ -28,7 +28,7 @@ class MetricSkillEvaluator:
             return ItemEvaluation(
                 passed=False,
                 rank_key=(False, False, False),
-                detail={"metric_created": False, "maql_correct": False, "format_correct": False},
+                detail={"metric_created": False, "maql_correct": False, "format_correct": False, "metric_id": None},
             )
 
         result = tool_event.parsed_result()
@@ -54,5 +54,10 @@ class MetricSkillEvaluator:
                 "actual_maql": actual_maql,
                 "expected_format": expected_format,
                 "actual_format": actual_format,
+                # The real id of the metric this run created, straight from the
+                # create_metric tool result — lets a caller (e.g. a cleanup step)
+                # delete the exact object created instead of diffing the workspace
+                # catalog before/after and guessing by name.
+                "metric_id": payload.get("metric_id"),
             },
         )

--- a/packages/gooddata-eval/tests/test_alert_skill_evaluator.py
+++ b/packages/gooddata-eval/tests/test_alert_skill_evaluator.py
@@ -15,11 +15,15 @@ def _item(expected_output: dict) -> DatasetItem:
     )
 
 
-def _chat_with_alert(args: dict) -> ChatResult:
+def _chat_with_alert(args: dict, result: dict | None = None) -> ChatResult:
     return ChatResult.model_validate(
         {
             "toolCallEvents": [
-                {"functionName": "create_metric_alert", "functionArguments": json.dumps(args), "result": "{}"}
+                {
+                    "functionName": "create_metric_alert",
+                    "functionArguments": json.dumps(args),
+                    "result": json.dumps(result if result is not None else {}),
+                }
             ]
         }
     )
@@ -81,3 +85,29 @@ def test_alert_evaluator_fails_when_no_tool_call():
     )
     assert result.passed is False
     assert result.detail["alert_created"] is False
+    assert result.detail["automation_id"] is None
+
+
+def test_alert_evaluator_extracts_automation_id_from_top_level_result():
+    expected = {"Operator": "LESS_THAN", "Threshold": "20000"}
+    actual_args = {"operator": "LESS_THAN", "threshold": 20000}
+    result = get_evaluator("alert_skill").evaluate(
+        _item(expected), _chat_with_alert(actual_args, result={"id": "automation-abc-123"})
+    )
+    assert result.detail["automation_id"] == "automation-abc-123"
+
+
+def test_alert_evaluator_extracts_automation_id_from_nested_data_result():
+    expected = {"Operator": "LESS_THAN", "Threshold": "20000"}
+    actual_args = {"operator": "LESS_THAN", "threshold": 20000}
+    result = get_evaluator("alert_skill").evaluate(
+        _item(expected), _chat_with_alert(actual_args, result={"data": {"id": "automation-xyz-789"}})
+    )
+    assert result.detail["automation_id"] == "automation-xyz-789"
+
+
+def test_alert_evaluator_automation_id_none_when_result_has_no_id():
+    expected = {"Operator": "LESS_THAN", "Threshold": "20000"}
+    actual_args = {"operator": "LESS_THAN", "threshold": 20000}
+    result = get_evaluator("alert_skill").evaluate(_item(expected), _chat_with_alert(actual_args, result={}))
+    assert result.detail["automation_id"] is None

--- a/packages/gooddata-eval/tests/test_alert_skill_evaluator.py
+++ b/packages/gooddata-eval/tests/test_alert_skill_evaluator.py
@@ -111,3 +111,14 @@ def test_alert_evaluator_automation_id_none_when_result_has_no_id():
     actual_args = {"operator": "LESS_THAN", "threshold": 20000}
     result = get_evaluator("alert_skill").evaluate(_item(expected), _chat_with_alert(actual_args, result={}))
     assert result.detail["automation_id"] is None
+
+
+def test_alert_evaluator_automation_id_none_when_nested_data_is_not_a_mapping():
+    # Malformed/unexpected payload shape: "data" present but not a dict -> must
+    # not crash, just report automation_id=None (CodeRabbit review on PR #1694).
+    expected = {"Operator": "LESS_THAN", "Threshold": "20000"}
+    actual_args = {"operator": "LESS_THAN", "threshold": 20000}
+    result = get_evaluator("alert_skill").evaluate(
+        _item(expected), _chat_with_alert(actual_args, result={"data": "not-a-mapping"})
+    )
+    assert result.detail["automation_id"] is None

--- a/packages/gooddata-eval/tests/test_metric_skill_evaluator.py
+++ b/packages/gooddata-eval/tests/test_metric_skill_evaluator.py
@@ -32,6 +32,7 @@ def test_metric_evaluator_passes_on_exact_match():
     assert result.passed is True
     assert result.detail["maql_correct"] is True
     assert result.detail["format_correct"] is True
+    assert result.detail["metric_id"] == "avg_order_value"
 
 
 def test_metric_evaluator_fails_wrong_maql():
@@ -48,3 +49,4 @@ def test_metric_evaluator_fails_when_no_tool_call():
     result = ev.evaluate(_item(), empty)
     assert result.passed is False
     assert result.detail["metric_created"] is False
+    assert result.detail["metric_id"] is None


### PR DESCRIPTION
## Problem

`MetricSkillEvaluator` and `AlertSkillEvaluator` (`packages/gooddata-eval/src/gooddata_eval/core/evaluators/{metric_skill,alert_skill}.py`) already parse the `create_metric` / `create_metric_alert` tool call's result to grade a run (MAQL/format match, operator/threshold/trigger/filters/metric/recipients match), but discard the real server-assigned id of whatever object the agent created.

This matters for any consumer running these single-turn kinds against a persistent/shared workspace: there is currently no way to identify the exact object a run created from `gd-eval`'s own `--json` report. The agentic counterparts (`agentic_metric_skill`/`agentic_alert_skill`, `core/agentic/{metric_skill,alert_skill}.py`) already extract this same id from the identical tool-call-result payload to self-clean via `entities_api.delete_entity_metrics`/`delete_entity_automations` in a `finally` block — the single-turn path has the same data in hand and simply never surfaces it.

Concretely: a caller orchestrating single-turn `metric_skill`/`alert_skill` runs against a shared eval workspace (e.g. a scheduled CI job) has no choice today but to diff the workspace's metric/automation catalog before and after each call and guess which new object belongs to which run — fragile under any concurrent activity, and for `alert_skill` there's no deterministic field to cross-check the guess against at all.

## Change

- `MetricSkillEvaluator.evaluate()`: adds `detail["metric_id"]`, read from the already-unwrapped `create_metric` tool result (`payload.get("metric_id")`). `null` when no tool call fired.
- `AlertSkillEvaluator.evaluate()`: adds `detail["automation_id"]`, extracted from the `create_metric_alert` tool call's **result** (not its arguments — the id is server-assigned, the agent's requested arguments don't carry it) via a new `_extract_automation_id()` helper, mirroring `core/agentic/alert_skill.py`'s `_extract_alert_call`'s `result_data.get("id") or (result_data.get("data") or {}).get("id")` unwrap shape. `null` when no tool call fired.
- No changes to control flow, scoring, `passed`/`rank_key` computation, or the JSON report's shape/schema beyond the two new `detail` keys — `json_report.py`'s `_build_run_dict` already serializes `item.best_detail` verbatim, so both new fields flow through to `--json` output with no further changes needed there.
- No cleanup/deletion behavior added to the single-turn path — this PR is reporting-only. (Whether the single-turn evaluators should also self-clean like their agentic counterparts is a separate question, deliberately out of scope here.)

## Testing

- `tests/test_metric_skill_evaluator.py`: asserts `detail["metric_id"]` on the existing exact-match fixture (already encoded `"metric_id": "avg_order_value"` in its tool-result JSON, previously unused by any assertion) and asserts `None` on the no-tool-call path.
- `tests/test_alert_skill_evaluator.py`: extends `_chat_with_alert()` to accept an optional `result` payload (previously hardcoded to `"{}"`), adds three new cases — top-level `{"id": ...}`, nested `{"data": {"id": ...}}`, and no-id-present — plus a `None` assertion on the no-tool-call path.
- Full package suite: `pytest packages/gooddata-eval/tests` — 242 passed (245 with the 3 new cases in this PR).
- End-to-end sanity check: ran this branch's editable build against a live workspace via `gd-eval run --dataset <single metric_skill item> --json report.json` and confirmed `report["runs"][...]["items"][...]["detail"]["metric_id"]` is present in the actual CLI output (`null` in that particular run, since the agent didn't call `create_metric` that time — confirms the field wires through end-to-end regardless of outcome).

## Compatibility

Purely additive — two new keys in each evaluator's `detail` dict. No existing key removed, renamed, or changed in meaning; no public function signatures changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Evaluation results now include the created metric’s ID.
  * Alert evaluation results now include the created automation’s ID when available.
  * Missing tool results clearly report these IDs as unavailable.

* **Tests**
  * Added coverage for IDs returned in multiple alert result formats.
  * Expanded metric evaluation tests to verify ID reporting in success and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->