### PR TITLE
feat(gooddata-sdk): report whether create_or_update created or updated

### DIFF
--- a/docs/content/en/latest/administration/organization/create_or_update_jwk.md
+++ b/docs/content/en/latest/administration/organization/create_or_update_jwk.md
@@ -6,7 +6,7 @@ weight: 100
 api_ref: "CatalogOrganizationService.create_or_update_jwk"
 ---
 
-``create_or_update_jwk( jwk: CatalogJwk ) -> None``
+``create_or_update_jwk( jwk: CatalogJwk ) -> UpsertOutcome``
 
 Create a new jwk or overwrite an existing jwk with the same id.
 
@@ -18,4 +18,6 @@ Create a new jwk or overwrite an existing jwk with the same id.
 
 ## Returns
 
-_None_
+| type | description |
+| -- | -- |
+| UpsertOutcome | CREATED if the jwk did not exist yet, UPDATED if it did. |

--- a/docs/content/en/latest/administration/user-groups/create_or_update_user_group.md
+++ b/docs/content/en/latest/administration/user-groups/create_or_update_user_group.md
@@ -19,7 +19,10 @@ User group entity object.
 {{< /parameter >}}
 {{% /parameters-block %}}
 
-{{% parameters-block title="Returns" None="yes" %}}
+{{% parameters-block title="Returns" %}}
+{{< parameter p_type="UpsertOutcome" >}}
+CREATED if the user group did not exist yet, UPDATED if it did.
+{{< /parameter >}}
 {{% /parameters-block %}}
 
 ## Example

--- a/docs/content/en/latest/administration/users/create_or_update_user.md
+++ b/docs/content/en/latest/administration/users/create_or_update_user.md
@@ -19,7 +19,10 @@ User entity object.
 {{< /parameter >}}
 {{% /parameters-block %}}
 
-{{% parameters-block title="Returns" None="yes" %}}
+{{% parameters-block title="Returns" %}}
+{{< parameter p_type="UpsertOutcome" >}}
+CREATED if the user did not exist yet, UPDATED if it did.
+{{< /parameter >}}
 {{% /parameters-block %}}
 
 ## Example

--- a/docs/content/en/latest/data/data-source/create_or_update_data_source.md
+++ b/docs/content/en/latest/data/data-source/create_or_update_data_source.md
@@ -20,7 +20,10 @@ Catalog data source object
 
 {{% /parameters-block %}}
 
-{{% parameters-block title="Returns" None="yes"%}}
+{{% parameters-block title="Returns" %}}
+{{< parameter p_type="UpsertOutcome" >}}
+CREATED if the data source did not exist yet, UPDATED if it did.
+{{< /parameter >}}
 {{% /parameters-block %}}
 
 ### Example

--- a/docs/content/en/latest/workspace/workspaces/create_or_update.md
+++ b/docs/content/en/latest/workspace/workspaces/create_or_update.md
@@ -15,7 +15,10 @@ Creates a new workspace or overwrite an existing workspace with the same id.
 Data source Object, including physical data model.
 {{< /parameter >}}
 {{% /parameters-block %}}
-{{% parameters-block title="Returns" None="yes" %}}
+{{% parameters-block title="Returns" %}}
+{{< parameter p_type="UpsertOutcome" >}}
+CREATED if the workspace did not exist yet, UPDATED if it did.
+{{< /parameter >}}
 {{% /parameters-block %}}
 {{% parameters-block title="Raises" %}}
 {{< parameter p_type="Value Error" >}}

--- a/packages/gooddata-sdk/src/gooddata_sdk/__init__.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/__init__.py
@@ -177,6 +177,7 @@ from gooddata_sdk.catalog.permission.declarative_model.permission import (
     CatalogOrganizationPermissionAssignment,
 )
 from gooddata_sdk.catalog.rule import CatalogAssigneeRule
+from gooddata_sdk.catalog.types import UpsertOutcome
 from gooddata_sdk.catalog.user.declarative_model.user import (
     CatalogDeclarativeUser,
     CatalogDeclarativeUserPermission,

--- a/packages/gooddata-sdk/src/gooddata_sdk/catalog/data_source/service.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/catalog/data_source/service.py
@@ -35,6 +35,7 @@ from gooddata_sdk.catalog.data_source.declarative_model.physical_model.pdm impor
 )
 from gooddata_sdk.catalog.data_source.entity_model.data_source import CatalogDataSource
 from gooddata_sdk.catalog.entity import ClientSecretCredentialsFromFile, TokenCredentialsFromFile
+from gooddata_sdk.catalog.types import UpsertOutcome
 from gooddata_sdk.catalog.workspace.declarative_model.workspace.logical_model.ldm import CatalogDeclarativeModel
 from gooddata_sdk.client import GoodDataApiClient
 from gooddata_sdk.utils import get_ds_credentials, load_all_entities_dict, read_layout_from_file
@@ -57,7 +58,7 @@ class CatalogDataSourceService(CatalogServiceBase):
     def create_or_update_data_source(
         self,
         data_source: CatalogDataSource,
-    ) -> None:
+    ) -> UpsertOutcome:
         """Pushes the Data Source to the GoodData environment.
 
         Automatically decides, whether to create or update.
@@ -67,7 +68,8 @@ class CatalogDataSourceService(CatalogServiceBase):
                 Catalog Data Source object
 
         Returns:
-            None
+            UpsertOutcome:
+                CREATED if the data source did not exist yet, UPDATED if it did.
         """
         try:
             self._entities_api.get_entity_data_sources(data_source.id)
@@ -77,6 +79,8 @@ class CatalogDataSourceService(CatalogServiceBase):
             )
         except NotFoundException:
             self._entities_api.create_entity_data_sources(data_source.to_api())
+            return UpsertOutcome.CREATED
+        return UpsertOutcome.UPDATED
 
     def get_data_source(self, data_source_id: str) -> CatalogDataSource:
         """Retrieve Data Source entity using data source id.

--- a/packages/gooddata-sdk/src/gooddata_sdk/catalog/organization/service.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/catalog/organization/service.py
@@ -43,6 +43,7 @@ from gooddata_sdk.catalog.organization.entity_model.llm_provider import (
 from gooddata_sdk.catalog.organization.entity_model.setting import CatalogOrganizationSetting
 from gooddata_sdk.catalog.organization.layout.identity_provider import CatalogDeclarativeIdentityProvider
 from gooddata_sdk.catalog.organization.layout.notification_channel import CatalogDeclarativeNotificationChannel
+from gooddata_sdk.catalog.types import UpsertOutcome
 from gooddata_sdk.client import GoodDataApiClient
 from gooddata_sdk.utils import load_all_entities, load_all_entities_dict
 
@@ -107,7 +108,7 @@ class CatalogOrganizationService(CatalogServiceBase):
         patch_document = JsonApiOrganizationPatchDocument(data=patch_data)
         self._entities_api.patch_entity_organizations(organization.id, patch_document)
 
-    def create_or_update_jwk(self, jwk: CatalogJwk) -> None:
+    def create_or_update_jwk(self, jwk: CatalogJwk) -> UpsertOutcome:
         """Create a new jwk or overwrite an existing jwk with the same id.
 
         Args:
@@ -115,7 +116,8 @@ class CatalogOrganizationService(CatalogServiceBase):
                 Catalog Jwk object to be created or updated.
 
         Returns:
-            None
+            UpsertOutcome:
+                CREATED if the jwk did not exist yet, UPDATED if it did.
 
         Raises:
             ValueError: Jwk can not be updated.
@@ -126,6 +128,8 @@ class CatalogOrganizationService(CatalogServiceBase):
             self._entities_api.update_entity_jwks(id=jwk.id, json_api_jwk_in_document=jwk_document.to_api())
         except NotFoundException:
             self._entities_api.create_entity_jwks(json_api_jwk_in_document=jwk_document.to_api())
+            return UpsertOutcome.CREATED
+        return UpsertOutcome.UPDATED
 
     def get_jwk(self, jwk_id: str) -> CatalogJwk:
         """Get an individual jwk.
@@ -473,7 +477,7 @@ class CatalogOrganizationService(CatalogServiceBase):
             identity_provider_id, CatalogIdentityProvider.to_api_patch(identity_provider_id, attributes)
         )
 
-    def create_or_update_export_template(self, export_template: CatalogExportTemplate) -> None:
+    def create_or_update_export_template(self, export_template: CatalogExportTemplate) -> UpsertOutcome:
         """Create a new export template or overwrite an existing export template with the same id.
 
         Args:
@@ -481,7 +485,8 @@ class CatalogOrganizationService(CatalogServiceBase):
                 Catalog export template object to be created or updated.
 
         Returns:
-            None
+            UpsertOutcome:
+                CREATED if the export template did not exist yet, UPDATED if it did.
 
         Raises:
             ValueError: Export template cannot be updated.
@@ -500,6 +505,8 @@ class CatalogOrganizationService(CatalogServiceBase):
                     data=export_template.to_api()
                 )
             )
+            return UpsertOutcome.CREATED
+        return UpsertOutcome.UPDATED
 
     def get_export_template(self, export_template_id: str) -> CatalogExportTemplate:
         """Get an individual export template.

--- a/packages/gooddata-sdk/src/gooddata_sdk/catalog/types.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/catalog/types.py
@@ -18,3 +18,7 @@ class UpsertOutcome(str, Enum):
 
     CREATED = "created"
     UPDATED = "updated"
+
+    # Match StrEnum's str() (the value, not "UpsertOutcome.CREATED") so moving
+    # to StrEnum once py3.10 support is dropped is a no-op for callers.
+    __str__ = str.__str__

--- a/packages/gooddata-sdk/src/gooddata_sdk/catalog/types.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/catalog/types.py
@@ -1,5 +1,20 @@
 # (C) 2022 GoodData Corporation
 from __future__ import annotations
 
+from enum import Enum
+
 # Use typing collection types to support python < py3.9
 ValidObjects = dict[str, set[str]]
+
+
+class UpsertOutcome(str, Enum):
+    """Which branch a ``create_or_update*`` method took.
+
+    The outcome is best-effort: it reports the branch the SDK chose after its
+    existence check, and that check is not atomic with the write that follows.
+    A concurrent actor can create or delete the entity in between, so treat the
+    value as informational rather than as an authoritative audit record.
+    """
+
+    CREATED = "created"
+    UPDATED = "updated"

--- a/packages/gooddata-sdk/src/gooddata_sdk/catalog/user/service.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/catalog/user/service.py
@@ -9,6 +9,7 @@ from gooddata_api_client.model.json_api_api_token_in import JsonApiApiTokenIn
 from gooddata_api_client.model.json_api_api_token_in_document import JsonApiApiTokenInDocument
 
 from gooddata_sdk.catalog.catalog_service_base import CatalogServiceBase
+from gooddata_sdk.catalog.types import UpsertOutcome
 from gooddata_sdk.catalog.user.declarative_model.user import CatalogDeclarativeUsers
 from gooddata_sdk.catalog.user.declarative_model.user_and_user_groups import CatalogDeclarativeUsersUserGroups
 from gooddata_sdk.catalog.user.declarative_model.user_group import CatalogDeclarativeUserGroups
@@ -25,7 +26,7 @@ from gooddata_sdk.utils import load_all_entities, load_all_entities_dict
 class CatalogUserService(CatalogServiceBase):
     # Entity methods for users
 
-    def create_or_update_user(self, user: CatalogUser) -> None:
+    def create_or_update_user(self, user: CatalogUser) -> UpsertOutcome:
         """Creates a new user or overwrites an existing user.
 
 
@@ -34,7 +35,8 @@ class CatalogUserService(CatalogServiceBase):
                 User entity object.
 
         Returns:
-            None
+            UpsertOutcome:
+                CREATED if the user did not exist yet, UPDATED if it did.
         """
         try:
             self.get_user(user_id=user.id)
@@ -43,6 +45,8 @@ class CatalogUserService(CatalogServiceBase):
         except NotFoundException:
             user_document = CatalogUserDocument(data=user)
             self._entities_api.create_entity_users(json_api_user_in_document=user_document.to_api())
+            return UpsertOutcome.CREATED
+        return UpsertOutcome.UPDATED
 
     def get_user(self, user_id: str) -> CatalogUser:
         """Get an individual user using User id.
@@ -89,7 +93,7 @@ class CatalogUserService(CatalogServiceBase):
 
     # Entity methods for user groups
 
-    def create_or_update_user_group(self, user_group: CatalogUserGroup) -> None:
+    def create_or_update_user_group(self, user_group: CatalogUserGroup) -> UpsertOutcome:
         """Create a new user group or overwrite an existing user group.
 
         Args:
@@ -97,7 +101,8 @@ class CatalogUserService(CatalogServiceBase):
                 UserGroup entity object.
 
         Returns:
-            None
+            UpsertOutcome:
+                CREATED if the user group did not exist yet, UPDATED if it did.
         """
         try:
             self.get_user_group(user_group_id=user_group.id)
@@ -108,6 +113,8 @@ class CatalogUserService(CatalogServiceBase):
         except NotFoundException:
             user_group_document = CatalogUserGroupDocument(data=user_group)
             self._entities_api.create_entity_user_groups(user_group_document.to_api())
+            return UpsertOutcome.CREATED
+        return UpsertOutcome.UPDATED
 
     def get_user_group(self, user_group_id: str) -> CatalogUserGroup:
         """Get an individual user group using user group id.

--- a/packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/service.py
+++ b/packages/gooddata-sdk/src/gooddata_sdk/catalog/workspace/service.py
@@ -20,6 +20,7 @@ from gooddata_api_client.model.resolve_settings_request import ResolveSettingsRe
 from gooddata_sdk import CatalogDeclarativeAutomation
 from gooddata_sdk.catalog.catalog_service_base import CatalogServiceBase
 from gooddata_sdk.catalog.permission.service import CatalogPermissionService
+from gooddata_sdk.catalog.types import UpsertOutcome
 from gooddata_sdk.catalog.workspace.aac import load_aac_workspace_from_disk, store_aac_workspace_to_disk
 from gooddata_sdk.catalog.workspace.declarative_model.workspace.workspace import (
     CatalogDeclarativeFilterView,
@@ -60,7 +61,7 @@ class CatalogWorkspaceService(CatalogServiceBase):
 
     # Entities methods
 
-    def create_or_update(self, workspace: CatalogWorkspace) -> None:
+    def create_or_update(self, workspace: CatalogWorkspace) -> UpsertOutcome:
         """Create a new workspace or overwrite an existing workspace with the same id.
 
         Args:
@@ -68,7 +69,8 @@ class CatalogWorkspaceService(CatalogServiceBase):
                 Catalog Workspace object to be created or updated.
 
         Returns:
-            None
+            UpsertOutcome:
+                CREATED if the workspace did not exist yet, UPDATED if it did.
 
         Raises:
             ValueError: Workspace parent can not be updated.
@@ -88,6 +90,8 @@ class CatalogWorkspaceService(CatalogServiceBase):
                 )
         except NotFoundException:
             self._entities_api.create_entity_workspaces(workspace.to_api())
+            return UpsertOutcome.CREATED
+        return UpsertOutcome.UPDATED
 
     def get_workspace(self, workspace_id: str) -> CatalogWorkspace:
         """Get an individual workspace.
@@ -146,7 +150,9 @@ class CatalogWorkspaceService(CatalogServiceBase):
         workspaces = load_all_entities(get_workspaces)
         return [CatalogWorkspace.from_api(w) for w in workspaces.data]
 
-    def create_or_update_workspace_setting(self, workspace_id: str, workspace_setting: CatalogWorkspaceSetting) -> None:
+    def create_or_update_workspace_setting(
+        self, workspace_id: str, workspace_setting: CatalogWorkspaceSetting
+    ) -> UpsertOutcome:
         """Create a new workspace setting or overwrite an existing workspace setting with the same id.
 
         Args:
@@ -156,20 +162,27 @@ class CatalogWorkspaceService(CatalogServiceBase):
                 Catalog Workspace Setting object to be created or updated.
 
         Returns:
-            None
+            UpsertOutcome:
+                CREATED if the setting did not exist yet, UPDATED if it did.
+
+        Note:
+            A setting with no id takes the create branch, but that path currently
+            fails in the generated client, which rejects a None id.
         """
         if workspace_setting.id is None:
             self._entities_api.create_entity_workspace_settings(workspace_id, workspace_setting.to_api(True))
-        else:
-            try:
-                self.get_workspace_setting(workspace_id, workspace_setting.id)
-                self._entities_api.update_entity_workspace_settings(
-                    workspace_id,
-                    workspace_setting.id,
-                    workspace_setting.to_api(),
-                )
-            except NotFoundException:
-                self._entities_api.create_entity_workspace_settings(workspace_id, workspace_setting.to_api(True))
+            return UpsertOutcome.CREATED
+        try:
+            self.get_workspace_setting(workspace_id, workspace_setting.id)
+            self._entities_api.update_entity_workspace_settings(
+                workspace_id,
+                workspace_setting.id,
+                workspace_setting.to_api(),
+            )
+        except NotFoundException:
+            self._entities_api.create_entity_workspace_settings(workspace_id, workspace_setting.to_api(True))
+            return UpsertOutcome.CREATED
+        return UpsertOutcome.UPDATED
 
     def delete_workspace_setting(self, workspace_id: str, workspace_setting_id: str) -> None:
         try:
@@ -1207,7 +1220,9 @@ class CatalogWorkspaceService(CatalogServiceBase):
         user_data_filters = load_all_entities_dict(get_user_data_filters, camel_case=False)
         return [CatalogUserDataFilter.from_dict(v, camel_case=False) for v in user_data_filters["data"]]
 
-    def create_or_update_user_data_filter(self, workspace_id: str, user_data_filter: CatalogUserDataFilter) -> None:
+    def create_or_update_user_data_filter(
+        self, workspace_id: str, user_data_filter: CatalogUserDataFilter
+    ) -> UpsertOutcome:
         """Create a new user data filter or overwrite an existing one.
 
         Args:
@@ -1217,7 +1232,12 @@ class CatalogWorkspaceService(CatalogServiceBase):
                 UserDataFilter entity object.
 
         Returns:
-            None
+            UpsertOutcome:
+                CREATED if the filter did not exist yet, UPDATED if it did.
+
+        Note:
+            A filter with no id takes the create branch, but that path currently
+            fails in the generated client, which rejects a None id.
         """
         user_data_filter_document = CatalogUserDataFilterDocument(data=user_data_filter)
         if user_data_filter.id is None:
@@ -1225,19 +1245,21 @@ class CatalogWorkspaceService(CatalogServiceBase):
                 workspace_id=workspace_id,
                 json_api_user_data_filter_post_optional_id_document=user_data_filter_document.to_api(True),
             )
-        else:
-            try:
-                self.get_user_data_filter(workspace_id=workspace_id, user_data_filter_id=user_data_filter.id)
-                self._entities_api.update_entity_user_data_filters(
-                    workspace_id=workspace_id,
-                    object_id=user_data_filter.id,
-                    json_api_user_data_filter_in_document=user_data_filter_document.to_api(),
-                )
-            except NotFoundException:
-                self._entities_api.create_entity_user_data_filters(
-                    workspace_id=workspace_id,
-                    json_api_user_data_filter_post_optional_id_document=user_data_filter_document.to_api(True),
-                )
+            return UpsertOutcome.CREATED
+        try:
+            self.get_user_data_filter(workspace_id=workspace_id, user_data_filter_id=user_data_filter.id)
+            self._entities_api.update_entity_user_data_filters(
+                workspace_id=workspace_id,
+                object_id=user_data_filter.id,
+                json_api_user_data_filter_in_document=user_data_filter_document.to_api(),
+            )
+        except NotFoundException:
+            self._entities_api.create_entity_user_data_filters(
+                workspace_id=workspace_id,
+                json_api_user_data_filter_post_optional_id_document=user_data_filter_document.to_api(True),
+            )
+            return UpsertOutcome.CREATED
+        return UpsertOutcome.UPDATED
 
     def get_user_data_filter(self, workspace_id: str, user_data_filter_id: str) -> CatalogUserDataFilter:
         """Get user data filter by its id.
@@ -1410,7 +1432,7 @@ class CatalogWorkspaceService(CatalogServiceBase):
         filter_views = load_all_entities_dict(get_filter_views, camel_case=False)
         return [CatalogFilterView.from_dict(v, camel_case=False) for v in filter_views["data"]]
 
-    def create_or_update_filter_view(self, workspace_id: str, filter_view: CatalogFilterView) -> None:
+    def create_or_update_filter_view(self, workspace_id: str, filter_view: CatalogFilterView) -> UpsertOutcome:
         """Create a new filter view or overwrite an existing one.
 
         Args:
@@ -1420,7 +1442,12 @@ class CatalogWorkspaceService(CatalogServiceBase):
                 FilterView entity object.
 
         Returns:
-            None
+            UpsertOutcome:
+                CREATED if the filter view did not exist yet, UPDATED if it did.
+
+        Note:
+            A filter view with no id takes the create branch, but that path
+            currently fails in the generated client, which rejects a None id.
         """
         filter_view_document = CatalogFilterViewDocument(data=filter_view)
         if filter_view.id is None:
@@ -1428,19 +1455,21 @@ class CatalogWorkspaceService(CatalogServiceBase):
                 workspace_id=workspace_id,
                 json_api_filter_view_in_document=filter_view_document.to_api(),
             )
-        else:
-            try:
-                self.get_filter_view(workspace_id=workspace_id, filter_view_id=filter_view.id)
-                self._entities_api.update_entity_filter_views(
-                    workspace_id=workspace_id,
-                    object_id=filter_view.id,
-                    json_api_filter_view_in_document=filter_view_document.to_api(),
-                )
-            except NotFoundException:
-                self._entities_api.create_entity_filter_views(
-                    workspace_id=workspace_id,
-                    json_api_filter_view_in_document=filter_view_document.to_api(),
-                )
+            return UpsertOutcome.CREATED
+        try:
+            self.get_filter_view(workspace_id=workspace_id, filter_view_id=filter_view.id)
+            self._entities_api.update_entity_filter_views(
+                workspace_id=workspace_id,
+                object_id=filter_view.id,
+                json_api_filter_view_in_document=filter_view_document.to_api(),
+            )
+        except NotFoundException:
+            self._entities_api.create_entity_filter_views(
+                workspace_id=workspace_id,
+                json_api_filter_view_in_document=filter_view_document.to_api(),
+            )
+            return UpsertOutcome.CREATED
+        return UpsertOutcome.UPDATED
 
     def get_filter_view(self, workspace_id: str, filter_view_id: str) -> CatalogFilterView:
         """Get filter view by its id.

--- a/packages/gooddata-sdk/tests/catalog/test_catalog_data_source.py
+++ b/packages/gooddata-sdk/tests/catalog/test_catalog_data_source.py
@@ -40,6 +40,7 @@ from gooddata_sdk import (
     SqlColumn,
     TableDimension,
     TokenCredentialsFromFile,
+    UpsertOutcome,
     VerticaAttributes,
 )
 from gooddata_sdk.catalog.data_source.entity_model.data_source import DatabaseAttributes
@@ -283,7 +284,7 @@ def test_catalog_create_update_list_data_source(test_config):
             ),
             url_params=[("autosave", "false"), ("sslmode", "prefer")],
         )
-        sdk.catalog_data_source.create_or_update_data_source(updated_data_source)
+        assert sdk.catalog_data_source.create_or_update_data_source(updated_data_source) == UpsertOutcome.UPDATED
 
         data_sources = sdk.catalog_data_source.list_data_sources()
         assert len(data_sources) == 2
@@ -299,7 +300,7 @@ def test_catalog_create_update_list_data_source(test_config):
 
 def _create_delete_ds(sdk, data_source: CatalogDataSource):
     try:
-        sdk.catalog_data_source.create_or_update_data_source(data_source)
+        assert sdk.catalog_data_source.create_or_update_data_source(data_source) == UpsertOutcome.CREATED
         created_ds = sdk.catalog_data_source.get_data_source(data_source.id)
         assert data_source == created_ds
     finally:

--- a/packages/gooddata-sdk/tests/catalog/test_catalog_organization.py
+++ b/packages/gooddata-sdk/tests/catalog/test_catalog_organization.py
@@ -13,6 +13,7 @@ from gooddata_sdk import (
     CatalogRsaSpecification,
     CatalogWebhook,
     GoodDataSdk,
+    UpsertOutcome,
 )
 from tests_support.vcrpy_utils import get_vcr
 
@@ -93,7 +94,7 @@ def test_create_jwk(test_config):
     sdk = GoodDataSdk.create(host_=test_config["host"], token_=test_config["token"])
     new_jwk = _default_jwk()
     try:
-        sdk.catalog_organization.create_or_update_jwk(new_jwk)
+        assert sdk.catalog_organization.create_or_update_jwk(new_jwk) == UpsertOutcome.CREATED
         created_jwk = sdk.catalog_organization.get_jwk("demoJwk")
         assert new_jwk.id == created_jwk.id
         assert new_jwk.attributes == created_jwk.attributes
@@ -107,8 +108,8 @@ def test_update_jwk(test_config):
     new_jwk = _default_jwk()
     update_jwk = _default_jwk(alg="RS384")
     try:
-        sdk.catalog_organization.create_or_update_jwk(new_jwk)
-        sdk.catalog_organization.create_or_update_jwk(update_jwk)
+        assert sdk.catalog_organization.create_or_update_jwk(new_jwk) == UpsertOutcome.CREATED
+        assert sdk.catalog_organization.create_or_update_jwk(update_jwk) == UpsertOutcome.UPDATED
         updated_jwk = sdk.catalog_organization.get_jwk("demoJwk")
         assert update_jwk.attributes.content.alg == updated_jwk.attributes.content.alg
     finally:

--- a/packages/gooddata-sdk/tests/catalog/test_catalog_user_service.py
+++ b/packages/gooddata-sdk/tests/catalog/test_catalog_user_service.py
@@ -36,6 +36,7 @@ from gooddata_sdk import (
     CatalogUserGroup,
     GoodDataApiClient,
     GoodDataSdk,
+    UpsertOutcome,
 )
 from gooddata_sdk.catalog.permission.declarative_model.permission import CatalogDeclarativeWorkspacePermissions
 from gooddata_sdk.utils import recreate_directory
@@ -89,7 +90,7 @@ def test_create_delete_user(test_config):
             authentication_id=authentication_id,
             user_group_ids=user_group_ids,
         )
-        sdk.catalog_user.create_or_update_user(user_e)
+        assert sdk.catalog_user.create_or_update_user(user_e) == UpsertOutcome.CREATED
         user = sdk.catalog_user.get_user(user_id)
         assert len(sdk.catalog_user.list_users()) == initial_count + 1
         assert user.id == user_id
@@ -150,7 +151,7 @@ def test_update_user(test_config):
             authentication_id=initial_auth_id,
             user_group_ids=initial_user_group_ids,
         )
-        sdk.catalog_user.create_or_update_user(initial_user)
+        assert sdk.catalog_user.create_or_update_user(initial_user) == UpsertOutcome.CREATED
         assert len(sdk.catalog_user.list_users()) == initial_user_count + 1
 
         # Update the user
@@ -162,7 +163,7 @@ def test_update_user(test_config):
             authentication_id=new_auth_id,
             user_group_ids=new_user_group_ids,
         )
-        sdk.catalog_user.create_or_update_user(updated_user_request)
+        assert sdk.catalog_user.create_or_update_user(updated_user_request) == UpsertOutcome.UPDATED
 
         # Verify updates
         updated_user = sdk.catalog_user.get_user(temp_user_id)
@@ -245,7 +246,7 @@ def test_create_delete_user_group(test_config):
             user_group_name=user_group_id.upper(),
             user_group_parent_ids=user_group_parent_ids,
         )
-        sdk.catalog_user.create_or_update_user_group(user_group_e)
+        assert sdk.catalog_user.create_or_update_user_group(user_group_e) == UpsertOutcome.CREATED
         user_group = sdk.catalog_user.get_user_group(user_group_id)
         assert len(sdk.catalog_user.list_user_groups()) == initial_count + 1
         assert user_group.id == user_group_id
@@ -269,7 +270,7 @@ def test_update_user_group(test_config):
             user_group_name=new_user_group_name,
             user_group_parent_ids=user_group_parent_ids,
         )
-        sdk.catalog_user.create_or_update_user_group(user_group_e)
+        assert sdk.catalog_user.create_or_update_user_group(user_group_e) == UpsertOutcome.UPDATED
         updated_user_group = sdk.catalog_user.get_user_group(user_group_id)
         assert user_group.id == updated_user_group.id
         assert updated_user_group.name == new_user_group_name

--- a/packages/gooddata-sdk/tests/catalog/test_catalog_workspace.py
+++ b/packages/gooddata-sdk/tests/catalog/test_catalog_workspace.py
@@ -23,6 +23,7 @@ from gooddata_sdk import (
     GoodDataApiClient,
     GoodDataSdk,
     PostgresAttributes,
+    UpsertOutcome,
 )
 from gooddata_sdk.catalog.identifier import (
     CatalogDeclarativeAnalyticalDashboardIdentifier,
@@ -232,7 +233,7 @@ def test_update_workspace_valid(test_config):
 
     try:
         # Updating only name.
-        sdk.catalog_workspace.create_or_update(new_workspace)
+        assert sdk.catalog_workspace.create_or_update(new_workspace) == UpsertOutcome.UPDATED
         workspaces = sdk.catalog_workspace.list_workspaces()
         workspace_o = sdk.catalog_workspace.get_workspace(workspace.id)
         assert len(workspaces) == initial_count
@@ -304,7 +305,7 @@ def test_create_workspace(test_config):
     assert workspace_id not in [w.id for w in workspaces]
 
     try:
-        sdk.catalog_workspace.create_or_update(workspace)
+        assert sdk.catalog_workspace.create_or_update(workspace) == UpsertOutcome.CREATED
         workspaces = sdk.catalog_workspace.list_workspaces()
         workspace_o = sdk.catalog_workspace.get_workspace(workspace_id)
         assert len(workspaces) == initial_count + 1
@@ -435,9 +436,10 @@ def test_user_data_filters_life_cycle(test_config):
             title="test_new_user_data_filter",
             user_id=test_config["demo_user"],
         )
-        sdk.catalog_workspace.create_or_update_user_data_filter(
+        outcome = sdk.catalog_workspace.create_or_update_user_data_filter(
             workspace_id=test_config["workspace"], user_data_filter=user_data_filter
         )
+        assert outcome == UpsertOutcome.CREATED
         user_data_filters = sdk.catalog_workspace.list_user_data_filters(test_config["workspace"])
         assert len(user_data_filters) == 1
         assert user_data_filters[0].id == user_data_filter.id
@@ -784,7 +786,8 @@ def test_create_workspace_setting(test_config):
     setting = CatalogWorkspaceSetting(id=setting_id, setting_type=setting_type, content=content)
 
     try:
-        sdk.catalog_workspace.create_or_update_workspace_setting(test_config["workspace"], setting)
+        outcome = sdk.catalog_workspace.create_or_update_workspace_setting(test_config["workspace"], setting)
+        assert outcome == UpsertOutcome.CREATED
         setting_o = sdk.catalog_workspace.get_workspace_setting(test_config["workspace"], setting_id)
         assert setting_o == setting
     finally:
@@ -845,12 +848,14 @@ def test_update_workspace_setting(test_config):
     setting = CatalogWorkspaceSetting(id=setting_id, setting_type=setting_type, content=content)
 
     try:
-        sdk.catalog_workspace.create_or_update_workspace_setting(test_config["workspace"], setting)
+        outcome = sdk.catalog_workspace.create_or_update_workspace_setting(test_config["workspace"], setting)
+        assert outcome == UpsertOutcome.CREATED
         setting_o = sdk.catalog_workspace.get_workspace_setting(test_config["workspace"], setting_id)
         assert setting_o == setting
         content = {"value": "en-US"}
         setting = CatalogWorkspaceSetting(id=setting_id, setting_type=setting_type, content=content)
-        sdk.catalog_workspace.create_or_update_workspace_setting(test_config["workspace"], setting)
+        outcome = sdk.catalog_workspace.create_or_update_workspace_setting(test_config["workspace"], setting)
+        assert outcome == UpsertOutcome.UPDATED
         setting_o = sdk.catalog_workspace.get_workspace_setting(test_config["workspace"], setting_id)
         assert setting_o == setting
     finally:

--- a/packages/gooddata-sdk/tests/catalog/test_upsert_outcome.py
+++ b/packages/gooddata-sdk/tests/catalog/test_upsert_outcome.py
@@ -1,0 +1,141 @@
+# (C) 2026 GoodData Corporation
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from attrs import evolve
+from gooddata_api_client.exceptions import ApiTypeError, NotFoundException
+from gooddata_sdk import (
+    CatalogExportTemplate,
+    CatalogWorkspaceSetting,
+    UpsertOutcome,
+)
+from gooddata_sdk.catalog.organization.entity_model.export_template import CatalogExportTemplateAttributes
+from gooddata_sdk.catalog.organization.service import CatalogOrganizationService
+from gooddata_sdk.catalog.workspace.entity_model.filter_view import CatalogFilterView
+from gooddata_sdk.catalog.workspace.entity_model.user_data_filter import CatalogUserDataFilter
+from gooddata_sdk.catalog.workspace.service import CatalogWorkspaceService
+
+# The create/update branch is decided by whether the preceding entity GET raises
+# NotFoundException, so these stub that getter instead of replaying a cassette.
+# They cover what no cassette covers upstream: filter views, export templates,
+# and the update branch of user data filters.
+
+
+def _service(cls, getter: str, *, found: bool):
+    """Service whose branch-deciding getter either succeeds or raises 404."""
+    service = cls(MagicMock())
+    service._entities_api = MagicMock()
+    setattr(service, getter, MagicMock(side_effect=None if found else NotFoundException(status=404)))
+    return service
+
+
+def _filter_view(filter_view_id: str | None = "fv") -> CatalogFilterView:
+    # init() builds the relationships the generated model requires; it insists on
+    # an id, so the id-less variant is derived from a valid instance.
+    view = CatalogFilterView.init(filter_view_id="fv", content={}, title="Test filter view", user_id="demo_user")
+    return evolve(view, id=filter_view_id)
+
+
+def _user_data_filter(user_data_filter_id: str | None = "udf") -> CatalogUserDataFilter:
+    udf = CatalogUserDataFilter.init(
+        user_data_filter_id="udf",
+        maql='{label/order_status} IN ("returned")',
+        user_id="demo_user",
+    )
+    return evolve(udf, id=user_data_filter_id)
+
+
+def _export_template() -> CatalogExportTemplate:
+    return CatalogExportTemplate(
+        id="test_template",
+        attributes=CatalogExportTemplateAttributes(name="Test template"),
+    )
+
+
+class TestFilterViewOutcome:
+    def test_created_when_absent(self):
+        service = _service(CatalogWorkspaceService, "get_filter_view", found=False)
+        assert service.create_or_update_filter_view("demo", _filter_view()) == UpsertOutcome.CREATED
+        service._entities_api.create_entity_filter_views.assert_called_once()
+
+    def test_updated_when_present(self):
+        service = _service(CatalogWorkspaceService, "get_filter_view", found=True)
+        assert service.create_or_update_filter_view("demo", _filter_view()) == UpsertOutcome.UPDATED
+        service._entities_api.update_entity_filter_views.assert_called_once()
+        service._entities_api.create_entity_filter_views.assert_not_called()
+
+
+class TestUserDataFilterOutcome:
+    def test_created_when_absent(self):
+        service = _service(CatalogWorkspaceService, "get_user_data_filter", found=False)
+        assert service.create_or_update_user_data_filter("demo", _user_data_filter()) == UpsertOutcome.CREATED
+        service._entities_api.create_entity_user_data_filters.assert_called_once()
+
+    def test_updated_when_present(self):
+        service = _service(CatalogWorkspaceService, "get_user_data_filter", found=True)
+        assert service.create_or_update_user_data_filter("demo", _user_data_filter()) == UpsertOutcome.UPDATED
+        service._entities_api.update_entity_user_data_filters.assert_called_once()
+
+
+class TestWorkspaceSettingOutcome:
+    def test_created_when_absent(self):
+        service = _service(CatalogWorkspaceService, "get_workspace_setting", found=False)
+        setting = CatalogWorkspaceSetting(id="locale", setting_type="LOCALE", content={"value": "fr-FR"})
+        assert service.create_or_update_workspace_setting("demo", setting) == UpsertOutcome.CREATED
+        service._entities_api.create_entity_workspace_settings.assert_called_once()
+
+    def test_updated_when_present(self):
+        service = _service(CatalogWorkspaceService, "get_workspace_setting", found=True)
+        setting = CatalogWorkspaceSetting(id="locale", setting_type="LOCALE", content={"value": "fr-FR"})
+        assert service.create_or_update_workspace_setting("demo", setting) == UpsertOutcome.UPDATED
+        service._entities_api.update_entity_workspace_settings.assert_called_once()
+
+
+class TestExportTemplateOutcome:
+    def test_created_when_absent(self):
+        service = _service(CatalogOrganizationService, "get_export_template", found=False)
+        assert service.create_or_update_export_template(_export_template()) == UpsertOutcome.CREATED
+        service._entities_api.create_entity_export_templates.assert_called_once()
+
+    def test_updated_when_present(self):
+        service = _service(CatalogOrganizationService, "get_export_template", found=True)
+        assert service.create_or_update_export_template(_export_template()) == UpsertOutcome.UPDATED
+        service._entities_api.update_entity_export_templates.assert_called_once()
+        service._entities_api.create_entity_export_templates.assert_not_called()
+
+
+class TestIdLessCreateIsUnreachable:
+    """The `id is None` create branches cannot currently run.
+
+    Each one serializes through a generated model that requires a `str` id;
+    passing None fails type validation before any request is made -- true of the
+    `PostOptionalId` variants too, where "optional" means "omit the key", not
+    "accept None". These are strict xfails so that fixing the generated client
+    (or the entity models) trips them and this file gets revisited, rather than
+    the outcome contract silently claiming to cover a dead path.
+    """
+
+    @pytest.mark.xfail(raises=ApiTypeError, strict=True, reason="generated client rejects a None id")
+    def test_filter_view(self):
+        service = _service(CatalogWorkspaceService, "get_filter_view", found=False)
+        assert service.create_or_update_filter_view("demo", _filter_view(None)) == UpsertOutcome.CREATED
+
+    @pytest.mark.xfail(raises=ApiTypeError, strict=True, reason="generated client rejects a None id")
+    def test_user_data_filter(self):
+        service = _service(CatalogWorkspaceService, "get_user_data_filter", found=False)
+        assert service.create_or_update_user_data_filter("demo", _user_data_filter(None)) == UpsertOutcome.CREATED
+
+    @pytest.mark.xfail(raises=ApiTypeError, strict=True, reason="generated client rejects a None id")
+    def test_workspace_setting(self):
+        service = _service(CatalogWorkspaceService, "get_workspace_setting", found=False)
+        setting = CatalogWorkspaceSetting(setting_type="LOCALE", content={"value": "fr-FR"})
+        assert service.create_or_update_workspace_setting("demo", setting) == UpsertOutcome.CREATED
+
+
+@pytest.mark.parametrize("outcome", list(UpsertOutcome))
+def test_outcome_is_a_plain_string(outcome):
+    """The str mixin keeps the value usable in logs and comparisons on py3.10."""
+    assert isinstance(outcome, str)
+    assert outcome == outcome.value

--- a/packages/gooddata-sdk/tests/catalog/test_upsert_outcome.py
+++ b/packages/gooddata-sdk/tests/catalog/test_upsert_outcome.py
@@ -136,6 +136,12 @@ class TestIdLessCreateIsUnreachable:
 
 @pytest.mark.parametrize("outcome", list(UpsertOutcome))
 def test_outcome_is_a_plain_string(outcome):
-    """The str mixin keeps the value usable in logs and comparisons on py3.10."""
+    """The str mixin keeps the value usable in logs and comparisons on py3.10.
+
+    The str()/format() assertions pin the `__str__ = str.__str__` override, so
+    swapping the base for StrEnum once py3.10 is dropped stays a no-op.
+    """
     assert isinstance(outcome, str)
     assert outcome == outcome.value
+    assert str(outcome) == outcome.value
+    assert f"{outcome}" == outcome.value


### PR DESCRIPTION
## What

Adds `UpsertOutcome` (`CREATED` / `UPDATED`) and returns it from all nine `create_or_update*` methods:

| service | method |
| -- | -- |
| `catalog_workspace` | `create_or_update`, `create_or_update_workspace_setting`, `create_or_update_user_data_filter`, `create_or_update_filter_view` |
| `catalog_user` | `create_or_update_user`, `create_or_update_user_group` |
| `catalog_organization` | `create_or_update_jwk`, `create_or_update_export_template` |
| `catalog_data_source` | `create_or_update_data_source` |

## Why

Each of these already does an existence check and branches on it, then discards the answer:

```python
try:
    found_workspace = self.get_workspace(workspace.id)
    ...update...
except NotFoundException:
    ...create...
```

A caller that needs to know which happened — to log accurately, count creations, or skip follow-up work — has to repeat the GET the SDK just made, because `create_entity_*` / `update_entity_*` are reachable only through the private `_entities_api`. This returns information the SDK has already computed.

The concrete case that prompted it: a deploy tool logging `"Workspace %s created successfully"` after every `create_or_update`, reporting a creation on every re-upload of an existing workspace. The only public-API fix is a duplicate `get_workspace()` call.

## Should this be in the SDK at all?

I genuinely don't know, and I'd rather surface the trade-off than argue one side. **Happy to close this if the answer is no** — the workaround (an extra GET in the caller) is cheap.

**Reasons to take it**

- The information exists and is thrown away. No new I/O, no new failure mode.
- It removes a duplicate round-trip from every consumer that currently needs the answer.
- Backward compatible in practice: every in-repo caller (`gooddata-pipelines`, `gooddata-dbt`, `gooddata-eval`) ignores the return value, and adding a return to a `-> None` method breaks no caller or type checker.
- There's recent precedent for surfacing already-computed results — #1694 (*report created metric/automation id from single-turn evaluators*).

**Reasons to reject it**

- **It may be a deliberate API-surface choice.** Void upserts keep "the entity now looks like this" as the whole contract. Returning the branch invites callers to depend on a distinction the HTTP API itself doesn't promise.
- **The outcome is best-effort, not authoritative.** The existence check is not atomic with the write that follows, so a concurrent create/delete can make the reported branch wrong. The enum docstring says so, but a returned value tends to get trusted more than a docstring caveat. If anyone treats it as an audit record, that's a footgun the current `None` doesn't have.
- **It widens the public API by nine signatures plus a new exported symbol**, to serve a fairly narrow need — arguably the caller's own `get_*` probe is the honest place to pay for that knowledge.
- **Nine methods change shape at once.** Doing only the one I needed would be worse (arbitrary inconsistency), but the all-or-nothing framing makes the smallest useful version of this change fairly wide.
- A future true-upsert endpoint (single PUT, no pre-GET) would make the pre-check — and this return value — obsolete or harder to compute.

For what it's worth on intent: I could find no recorded rationale for `-> None` here. `Returns: None` is a blanket docstring template across ~80 catalog methods including plain voids like `delete_workspace`; there's no comment or doc note explaining it; and `-> None` dates to the original `NAS-3058` implementation rather than a later removal. The closest relative, `set_hll_type`, documents its idempotency but is silent on the outcome. That's absence of evidence, not evidence of absence — the deliberate-choice reading above is still entirely possible, and you'd know better than the history does.

## Notes on the implementation

- `UpsertOutcome(str, Enum)` rather than `enum.StrEnum` — `requires-python` is `>=3.10` and `StrEnum` landed in 3.11. Matches the existing `SortDirection(str, Enum)` precedent.
- An enum rather than a `bool`: for an "or update" operation the bool *is* the entire return value, so `if sdk.catalog_workspace.create_or_update(ws):` reads as nonsense. It also leaves room for `UNCHANGED` later.
- The three methods with an "id is `None`" path (`workspace_setting`, `user_data_filter`, `filter_view`) return `CREATED` on that branch, but see the pre-existing defect below — that branch cannot currently execute, so the docstrings describe it as unreachable rather than promising a creation.

## Testing

- Assertions on **both** branches added to the existing cassette tests (workspace, workspace setting, user data filter, jwk, user, user group, data source). **No cassette needed re-recording** — the outcome is derived from the already-recorded interactions, so the assertions double as a check that `CREATED`/`UPDATED` matches what the server actually did.
- New `tests/catalog/test_upsert_outcome.py` adds mock-based unit tests for what no cassette reaches: filter views, export templates, and the update branch of user data filters. These stub only the branch-deciding getter, since the branch is chosen by whether that GET raises `NotFoundException`.
- `ruff` 0.15.1 (the pinned pre-commit version) check + format clean; `packages/gooddata-sdk`: **498 passed, 2 skipped, 3 xfailed**.

## A pre-existing defect this turned up

Writing those tests showed that the `id is None` create branches **cannot run at all** — in `create_or_update_filter_view`, `create_or_update_user_data_filter`, and `create_or_update_workspace_setting`.

Each serializes through a generated model that requires a `str` id, and passing `None` fails type validation before any request is made:

```
ApiTypeError: Invalid type for variable 'id'. Required value type is str and passed type was NoneType at ['id']
```

This holds for the `PostOptionalId` variants too, where "optional" means *omit the key*, not *accept None*. It predates this PR — the branches were already unreachable; this change only added a `return` to them.

I have **not** fixed it here, as it's a separate concern in the entity models / generated client. It's pinned by strict `xfail` tests so that fixing it trips them and prompts a revisit, and the docstrings no longer claim those paths create anything. Happy to split it into its own issue or PR if you'd like.

## Docs

Five `create_or_update*` pages had a hardcoded `Returns: None` and are updated (two different legacy formats in use). The remaining four methods have no docs pages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create-or-update operations now report whether an item was **created** or **updated**.
  * Added the public `UpsertOutcome` type with `CREATED` and `UPDATED` values.
  * Applies across data sources, users, user groups, workspaces, settings, filters, views, JWKs, and export templates.

* **Documentation**
  * Updated SDK documentation to describe the new return values and possible outcomes.

* **Tests**
  * Added and updated coverage verifying created and updated results across supported operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->