### PR TITLE
fix(gooddata-eval): stop metric-skill simulated user from dropping MAQL clauses

### DIFF
--- a/packages/gooddata-eval/src/gooddata_eval/core/agentic/metric_skill.py
+++ b/packages/gooddata-eval/src/gooddata_eval/core/agentic/metric_skill.py
@@ -101,14 +101,17 @@ def generate_simulated_response(agent_message: str, expected_output: dict) -> st
     prompt = (
         f"You are simulating a user in a conversation with a BI assistant that creates metrics. "
         f"The assistant said: '{agent_message}'. "
-        f"The user originally asked to create a metric with MAQL: {expected_maql}. "
-        f"Reply briefly as the user, providing any clarification the assistant needs."
+        f"The user's ground-truth intended metric is exactly this MAQL: {expected_maql}. "
+        f"Reply as the user. You MUST ensure every clause of that MAQL (including any WHERE/filter "
+        f"conditions) is eventually satisfied, and quote field/label identifiers verbatim from it -- "
+        f"never paraphrase or drop a clause, even if the assistant's question doesn't explicitly ask "
+        f"about it. If the assistant's offered options omit a required filter, add it yourself."
     )
     try:
         response = client.chat.completions.create(
             model="gpt-4o-mini",
             messages=[{"role": "user", "content": prompt}],
-            max_tokens=150,
+            max_tokens=300,
             temperature=0,
         )
     except OpenAIError as exc:

--- a/packages/gooddata-eval/tests/test_agentic_metric_skill.py
+++ b/packages/gooddata-eval/tests/test_agentic_metric_skill.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: LicenseRef-GoodData-Enterprise
 import os
 import sys
+import types
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -23,6 +24,38 @@ def test_normalize_maql_strips_whitespace():
 
 def test_normalize_maql_removes_select_wrapper():
     assert _normalize_maql("(SELECT {metric/abc})") == "{metric/abc}"
+
+
+def test_generate_simulated_response_prompt_preserves_maql_fidelity(monkeypatch):
+    """Regression test for a live-reproduced bug: the old prompt ("reply briefly",
+    no instruction to cover clauses the assistant didn't ask about) let the
+    simulating LLM silently drop a MAQL's WHERE clause or paraphrase a label id --
+    confirmed via a 5x-repeated A/B test (1/5 vs 5/5 fidelity) that this was the
+    prompt, not the model (gpt-4o did not fix it under the old prompt either).
+    """
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock(message=MagicMock(content="ok"))]
+    mock_client.chat.completions.create.return_value = mock_response
+
+    # `openai` is an optional [llm-judge] extra, not installed in this test env --
+    # inject a fake module rather than patching a real one (mirrors how the source
+    # itself does `from openai import OpenAI` as a local, guarded import).
+    fake_openai_module = types.SimpleNamespace(OpenAI=MagicMock(return_value=mock_client))
+    monkeypatch.setitem(sys.modules, "openai", fake_openai_module)
+
+    expected_output = {"maql": 'SELECT {metric/spend_amount_-_cutcgco} WHERE {label/ecommerce_indicator_code} = "1"'}
+    generate_simulated_response("Which base metric should I use?", expected_output)
+
+    call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+    sent_prompt = call_kwargs["messages"][0]["content"]
+
+    assert "verbatim" in sent_prompt
+    assert "every clause" in sent_prompt
+    assert "WHERE" in sent_prompt or "filter" in sent_prompt.lower()
+    assert "reply briefly" not in sent_prompt.lower()
+    assert call_kwargs["max_tokens"] >= 300
 
 
 def test_metric_run_result_fields():

--- a/packages/gooddata-eval/tests/test_agentic_metric_skill.py
+++ b/packages/gooddata-eval/tests/test_agentic_metric_skill.py
@@ -42,7 +42,7 @@ def test_generate_simulated_response_prompt_preserves_maql_fidelity(monkeypatch)
     # `openai` is an optional [llm-judge] extra, not installed in this test env --
     # inject a fake module rather than patching a real one (mirrors how the source
     # itself does `from openai import OpenAI` as a local, guarded import).
-    fake_openai_module = types.SimpleNamespace(OpenAI=MagicMock(return_value=mock_client))
+    fake_openai_module = types.SimpleNamespace(OpenAI=MagicMock(return_value=mock_client), OpenAIError=Exception)
     monkeypatch.setitem(sys.modules, "openai", fake_openai_module)
 
     expected_output = {"maql": 'SELECT {metric/spend_amount_-_cutcgco} WHERE {label/ecommerce_indicator_code} = "1"'}
@@ -51,6 +51,7 @@ def test_generate_simulated_response_prompt_preserves_maql_fidelity(monkeypatch)
     call_kwargs = mock_client.chat.completions.create.call_args.kwargs
     sent_prompt = call_kwargs["messages"][0]["content"]
 
+    assert expected_output["maql"] in sent_prompt
     assert "verbatim" in sent_prompt
     assert "every clause" in sent_prompt
     assert "WHERE" in sent_prompt or "filter" in sent_prompt.lower()


### PR DESCRIPTION
## Summary

`agentic_metric_skill`'s simulated-user step (`generate_simulated_response` in
`metric_skill.py`) is what keeps a multi-turn metric-creation conversation
going after the agent asks a clarifying question — it prompts an LLM to answer
as the user, using the fixture's `expected_output.maql` as its only source of
truth.

The prompt told it to "reply briefly," with no instruction to preserve the
MAQL's structure. In practice this let it silently drop a `WHERE`/filter
clause, or paraphrase a label id, whenever the agent's question didn't happen
to ask about that specific part — so a well-behaved agent, faithfully
following the (already-wrong) simulated answer, still failed the eval through
no fault of its own.

## Reproduced live (twice), against a real `gdc-mic-ai-evaluation` fixture

Question: *"Create a metric for total ecommerce spend"*
Expected: `SELECT {metric/spend_amount_-_cutcgco} WHERE {label/ecommerce_indicator_code} = "1"`

1. Simulated reply dropped `_code` off `ecommerce_indicator_code`, anchoring
   the agent on a sibling attribute that doesn't carry that filter — cascaded
   into a follow-up the agent's own clarification-detection didn't recognize
   as needing a reply (separate, related issue, not fixed in this PR — see
   `_is_asking_clarification`'s narrow keyword list).
2. Simulated reply picked one of 3 metric options the agent itself offered and
   said "please proceed with that" — never mentioning the `WHERE` clause
   `expected_output` required, even though it had the full MAQL in hand.

## Confirmed: prompt problem, not a model-capability problem

Ran the same `agent_message`/`expected_maql` pair through
`client.chat.completions.create` directly, 2×2, isolating model from prompt:

| Condition | Model | Prompt | Result |
|---|---|---|---|
| A | gpt-4o-mini | old | drops the filter |
| B | **gpt-4o** (stronger) | old | **still drops the filter** |
| C | gpt-4o-mini (unchanged) | new | **includes the filter** |
| D | gpt-4o | new | includes the filter |

Then repeated A and C 5× each to rule out luck: old prompt **1/5** preserved
the exact field (and was unstable even in *which base metric* it picked — 2/5
picked a different one entirely); new prompt **5/5**.

## The fix

- Instruct the simulating LLM to (a) ensure every clause of the expected MAQL
  is eventually satisfied even if the agent's question didn't ask about it,
  (b) quote field/label identifiers verbatim rather than paraphrase, (c)
  proactively add a filter the agent's own offered options omitted.
- Drop "reply briefly," raise `max_tokens` 150→300 — brevity was part of what
  squeezed the filter clause out.
- This brings `metric_skill.py`'s simulated-user prompt in line with
  `alert_skill.py`'s `generate_simulated_alert_response`, which already passes
  structured facts + explicit "proactively tell the agent X" instructions
  instead of one freely-paraphrased string — not a new pattern for this
  codebase, just extending an existing one to `metric_skill`.

## What this does NOT fix (tracked separately, not in scope here)

`_is_asking_clarification`'s narrow keyword match (`"?"`, `"could you"`,
`"please provide"`, `"clarif"`) can miss a legitimate open-ended fork/offer
from the agent and end the conversation early. Surfaced during the same
investigation, but a separate fix with its own risk profile — kept out of this
PR to keep the diff reviewable.

## Test plan

- [x] Added `test_generate_simulated_response_prompt_preserves_maql_fidelity` —
      asserts the sent prompt preserves clause-fidelity language and the
      raised `max_tokens`.
- [x] Full `gooddata-eval` suite: 272 passed. 9 pre-existing failures
      confirmed identical on clean `master` before this change (missing
      `openai` extra in this test env for `test_llm_judge.py`, unrelated
      failures in `test_runner.py`/`test_summary_evaluator.py`) — this change
      introduces zero new failures.
- [x] `ruff check` / `ruff format --check` clean on both changed files.
- [x] Live-reproduced the original bug against a real fixture, then confirmed
      the fix resolves it, on both the affected files' logic and via direct
      OpenAI API A/B testing (5× per condition).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved simulated metric responses to preserve complete query details, including filters and identifier formatting.
  * Ensured required query clauses are included in generated responses.
  * Increased the response limit to support more complete answers.

* **Tests**
  * Added regression coverage verifying query fidelity and complete clause preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->