### PR TITLE
chore: bump requests to >= 2.33.0

### DIFF
--- a/packages/gooddata-dbt/pyproject.toml
+++ b/packages/gooddata-dbt/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "pyyaml>=6.0",
     "attrs>=21.4.0,<=24.2.0",
     "cattrs>=22.1.0,<=24.1.1",
-    "requests~=2.32.0",
+    "requests>=2.33.0,<3.0.0",
     "tabulate~=0.8.10",
 ]
 classifiers = [

--- a/packages/gooddata-sdk/pyproject.toml
+++ b/packages/gooddata-sdk/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "attrs>=21.4.0,<=24.2.0",
     "cattrs>=22.1.0,<=24.1.1",
     "brotli==1.2.0",
-    "requests~=2.32.0",
+    "requests>=2.33.0,<3.0.0",
     "python-dotenv>=1.0.0,<2.0.0",
     "gooddata-code-convertors>=11.35.0a2",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -823,7 +823,7 @@ requires-dist = [
     { name = "cattrs", specifier = ">=22.1.0,<=24.1.1" },
     { name = "gooddata-sdk", editable = "packages/gooddata-sdk" },
     { name = "pyyaml", specifier = ">=6.0" },
-    { name = "requests", specifier = "~=2.32.0" },
+    { name = "requests", specifier = ">=2.33.0,<3.0.0" },
     { name = "tabulate", specifier = "~=0.8.10" },
 ]
 
@@ -1250,7 +1250,7 @@ requires-dist = [
     { name = "python-dateutil", specifier = ">=2.5.3" },
     { name = "python-dotenv", specifier = ">=1.0.0,<2.0.0" },
     { name = "pyyaml", specifier = ">=6.0" },
-    { name = "requests", specifier = "~=2.32.0" },
+    { name = "requests", specifier = ">=2.33.0,<3.0.0" },
 ]
 provides-extras = ["arrow"]
 
@@ -2583,7 +2583,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -2591,9 +2591,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This version fixes CVE-2026-25645. Also loosen the version so that in the future users can update requests on their own.

risk: low

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Requests library compatibility range to support newer 2.x releases.
  * Applied the same dependency update across the dbt and SDK packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->