### PR TITLE
Fix: accept internal_recipients as a bare string in agentic_alert_skill eval

### DIFF
--- a/packages/gooddata-eval/src/gooddata_eval/core/agentic/alert_skill.py
+++ b/packages/gooddata-eval/src/gooddata_eval/core/agentic/alert_skill.py
@@ -160,8 +160,18 @@ def _check_recipients(expected: CatalogMetricAlert, actual_args: dict, sdk: Good
         act_recip = []
     if set(expected.recipients) == set(act_recip or []):
         return True
-    act_internal = actual_args.get("internal_recipients")
-    if sdk is not None and isinstance(act_internal, list) and act_internal:
+    act_internal_raw = actual_args.get("internal_recipients")
+    # internal_recipients is declared `anyOf: [array of string, string, null]` in the
+    # create_metric_alert tool schema -- a single id as a bare string is schema-legal,
+    # not a malformed call, so it needs the same string/list normalization already
+    # applied to recipients/external_recipients above.
+    if isinstance(act_internal_raw, str):
+        act_internal = [act_internal_raw]
+    elif isinstance(act_internal_raw, list):
+        act_internal = act_internal_raw
+    else:
+        act_internal = []
+    if sdk is not None and act_internal:
         internal_recipient_ids = _resolve_internal_recipient_ids(sdk, expected.recipients)
         if internal_recipient_ids & set(act_internal):
             return True

--- a/packages/gooddata-eval/tests/test_agentic_alert_skill.py
+++ b/packages/gooddata-eval/tests/test_agentic_alert_skill.py
@@ -168,6 +168,19 @@ def test_check_recipients_matches_internal_recipients_via_resolved_user_id():
     mock_sdk._client.entities_api.get_all_entities_users.assert_called_once_with(filter="email=in=('user@example.com')")
 
 
+def test_check_recipients_matches_internal_recipients_as_a_bare_string():
+    # internal_recipients is declared `anyOf: [array of string, string, null]` in the
+    # create_metric_alert tool schema -- a single id as a bare string is schema-legal,
+    # not a malformed call. Confirmed live: gpt-5.5 passed a bare string for a
+    # single-recipient alert and this comparison silently failed before the fix.
+    expected = _normalize_expected_output({"Recipients": ["user@example.com"]})
+    mock_sdk = MagicMock()
+    mock_sdk._client.entities_api.get_all_entities_users.return_value.data = [
+        MagicMock(id="user.abc123"),
+    ]
+    assert _check_recipients(expected, {"internal_recipients": "user.abc123"}, sdk=mock_sdk) is True
+
+
 def test_check_recipients_escapes_apostrophe_in_email_for_rsql_filter():
     # o'hara@example.com must not break the RSQL filter string -- the apostrophe
     # has to be escaped before interpolation, same as the query engine requires.


### PR DESCRIPTION
## Summary
- `create_metric_alert`'s tool schema declares `internal_recipients` as `anyOf: [array of string, string, null]` — a single recipient id passed as a bare string is schema-legal, not a malformed tool call.
- `_check_recipients` only accepted a list for `internal_recipients`, so a correctly-created alert with exactly one internal recipient silently failed `recipients_correct` even though every other field matched.
- Normalizes `internal_recipients` the same way `recipients`/`external_recipients` are already normalized just above it in the same function.

## Evidence
Confirmed live against `agentic_alert_skill` (`alert-me-when-active-cards-top-of-wallet-exceeds`, gpt-5.5): `alert_created`, `operator_correct`, `threshold_correct`, `filters_correct`, `metric_correct` all `true`; `recipients_correct` was the sole failing field, with `internal_recipients` recorded as `"peter.tomko.342bf360-..."` (a string) instead of `["peter.tomko.342bf360-..."]` — the identical id appears as a list in every other passing run for the same recipient.

## Test plan
- [x] Added `test_check_recipients_matches_internal_recipients_as_a_bare_string` — passes.
- [x] `pytest packages/gooddata-eval/tests/test_agentic_alert_skill.py` — 46/46 pass.
- [x] Full package suite run; 9 unrelated pre-existing failures confirmed caused by `openai` not being installed locally (llm-judge extra), not by this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Alert recipient validation now correctly handles internal recipients provided as either a single email address or a list.
  - Ensures valid single-recipient alerts are resolved and matched correctly.

- **Tests**
  - Added regression coverage for single-string internal recipient values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->