### PR TITLE
Return the per-turn detail subset from TurnResult

### DIFF
--- a/packages/gooddata-eval/src/gooddata_eval/core/agentic/conversation.py
+++ b/packages/gooddata-eval/src/gooddata_eval/core/agentic/conversation.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import json
 import re
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from typing import Literal
 
 from gooddata_sdk import GoodDataSdk
@@ -69,6 +69,17 @@ class TurnResult(BaseModel):
     @property
     def skill_success(self) -> bool:
         return self.skill_routing and self.output_present and self.no_error
+
+    def detail(self) -> dict:
+        """The subset of this result reported in detail["turns"] for one conversation turn."""
+        return {
+            "turn_id": self.turn_id,
+            "expected_skill": self.expected_skill,
+            "skill_routing": self.skill_routing,
+            "output_present": self.output_present,
+            "output_correct": self.output_correct,
+            "activated_skills": self.activated_skills,
+        }
 
 
 def _resolve_refs(
@@ -426,35 +437,11 @@ def run_agentic_conversation(
     )
 
 
-@dataclass
-class TurnDetail:
-    """The subset of a TurnResult reported in detail["turns"] for one conversation turn."""
-
-    turn_id: str
-    expected_skill: str
-    skill_routing: bool
-    output_present: bool
-    output_correct: bool | None
-    activated_skills: list[str]
-
-
 def _conversation_detail(result: ConversationResult) -> dict:
     return {
         "full_skill_coverage": result.full_skill_coverage,
         "total_clarification_turns": result.total_clarification_turns,
-        "turns": [
-            asdict(
-                TurnDetail(
-                    turn_id=tr.turn_id,
-                    expected_skill=tr.expected_skill,
-                    skill_routing=tr.skill_routing,
-                    output_present=tr.output_present,
-                    output_correct=tr.output_correct,
-                    activated_skills=tr.activated_skills,
-                )
-            )
-            for tr in result.turn_results
-        ],
+        "turns": [tr.detail() for tr in result.turn_results],
         "latency_breakdown": build_latency_breakdown(result.tool_call_events, result.reasoning_step_events),
     }
 

--- a/packages/gooddata-eval/src/gooddata_eval/core/agentic/conversation.py
+++ b/packages/gooddata-eval/src/gooddata_eval/core/agentic/conversation.py
@@ -78,7 +78,7 @@ class TurnResult(BaseModel):
             "skill_routing": self.skill_routing,
             "output_present": self.output_present,
             "output_correct": self.output_correct,
-            "activated_skills": self.activated_skills,
+            "activated_skills": list(self.activated_skills),
         }
 
 

--- a/packages/gooddata-eval/src/gooddata_eval/core/agentic/conversation.py
+++ b/packages/gooddata-eval/src/gooddata_eval/core/agentic/conversation.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import json
 import re
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import ClassVar, Literal
 
 from gooddata_sdk import GoodDataSdk
 from pydantic import BaseModel
@@ -70,16 +70,22 @@ class TurnResult(BaseModel):
     def skill_success(self) -> bool:
         return self.skill_routing and self.output_present and self.no_error
 
+    # Reported per turn in detail["turns"]. A name listed here that no longer exists on the
+    # model raises rather than silently emitting a stale key, which a hand-written dict
+    # literal of the same fields would not -- and model_dump deep-copies activated_skills,
+    # so a caller mutating the returned dict cannot reach back into this TurnResult.
+    _DETAIL_FIELDS: ClassVar[set[str]] = {
+        "turn_id",
+        "expected_skill",
+        "skill_routing",
+        "output_present",
+        "output_correct",
+        "activated_skills",
+    }
+
     def detail(self) -> dict:
         """The subset of this result reported in detail["turns"] for one conversation turn."""
-        return {
-            "turn_id": self.turn_id,
-            "expected_skill": self.expected_skill,
-            "skill_routing": self.skill_routing,
-            "output_present": self.output_present,
-            "output_correct": self.output_correct,
-            "activated_skills": list(self.activated_skills),
-        }
+        return self.model_dump(include=self._DETAIL_FIELDS)
 
 
 def _resolve_refs(

--- a/packages/gooddata-eval/src/gooddata_eval/core/agentic/conversation.py
+++ b/packages/gooddata-eval/src/gooddata_eval/core/agentic/conversation.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import json
 import re
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from typing import Literal
 
 from gooddata_sdk import GoodDataSdk
@@ -426,19 +426,33 @@ def run_agentic_conversation(
     )
 
 
+@dataclass
+class TurnDetail:
+    """The subset of a TurnResult reported in detail["turns"] for one conversation turn."""
+
+    turn_id: str
+    expected_skill: str
+    skill_routing: bool
+    output_present: bool
+    output_correct: bool | None
+    activated_skills: list[str]
+
+
 def _conversation_detail(result: ConversationResult) -> dict:
     return {
         "full_skill_coverage": result.full_skill_coverage,
         "total_clarification_turns": result.total_clarification_turns,
         "turns": [
-            {
-                "turn_id": tr.turn_id,
-                "expected_skill": tr.expected_skill,
-                "skill_routing": tr.skill_routing,
-                "output_present": tr.output_present,
-                "output_correct": tr.output_correct,
-                "activated_skills": tr.activated_skills,
-            }
+            asdict(
+                TurnDetail(
+                    turn_id=tr.turn_id,
+                    expected_skill=tr.expected_skill,
+                    skill_routing=tr.skill_routing,
+                    output_present=tr.output_present,
+                    output_correct=tr.output_correct,
+                    activated_skills=tr.activated_skills,
+                )
+            )
             for tr in result.turn_results
         ],
         "latency_breakdown": build_latency_breakdown(result.tool_call_events, result.reasoning_step_events),

--- a/packages/gooddata-eval/tests/test_agentic_conversation.py
+++ b/packages/gooddata-eval/tests/test_agentic_conversation.py
@@ -97,6 +97,25 @@ def test_turn_result_skill_success():
     assert r.skill_success is True
 
 
+def test_turn_result_detail_returns_independent_activated_skills_list():
+    """Regression: detail()'s activated_skills must be a copy -- a caller mutating the
+    returned dict must not be able to mutate the TurnResult it came from.
+    """
+    r = TurnResult(
+        turn_id="t1",
+        expected_skill="visualization",
+        skill_routing=True,
+        output_present=True,
+        no_error=True,
+        activated_skills=["visualization"],
+        clarification_turns_used=0,
+        output_correct=None,
+    )
+    d = r.detail()
+    d["activated_skills"].append("mutated")
+    assert r.activated_skills == ["visualization"]
+
+
 def test_resolve_refs_no_refs():
     assert _resolve_refs({"key": "value"}, {}) == {"key": "value"}
 

--- a/packages/gooddata-eval/tests/test_agentic_conversation.py
+++ b/packages/gooddata-eval/tests/test_agentic_conversation.py
@@ -97,11 +97,8 @@ def test_turn_result_skill_success():
     assert r.skill_success is True
 
 
-def test_turn_result_detail_returns_independent_activated_skills_list():
-    """Regression: detail()'s activated_skills must be a copy -- a caller mutating the
-    returned dict must not be able to mutate the TurnResult it came from.
-    """
-    r = TurnResult(
+def _turn_result() -> TurnResult:
+    return TurnResult(
         turn_id="t1",
         expected_skill="visualization",
         skill_routing=True,
@@ -111,9 +108,21 @@ def test_turn_result_detail_returns_independent_activated_skills_list():
         clarification_turns_used=0,
         output_correct=None,
     )
+
+
+def test_turn_result_detail_copies_activated_skills():
+    """A caller mutating the returned dict must not reach back into the TurnResult."""
+    r = _turn_result()
     d = r.detail()
     d["activated_skills"].append("mutated")
     assert r.activated_skills == ["visualization"]
+
+
+def test_turn_result_detail_fields_all_exist_on_the_model():
+    """_DETAIL_FIELDS is a hand-listed subset, so a renamed field must fail here rather
+    than silently drop a key from every report."""
+    assert set(TurnResult.model_fields) >= TurnResult._DETAIL_FIELDS
+    assert set(_turn_result().detail()) == TurnResult._DETAIL_FIELDS
 
 
 def test_resolve_refs_no_refs():


### PR DESCRIPTION
Follow-up to @hkad98's review comment on #1750 (https://github.com/gooddata/gooddata-python-sdk/pull/1750#discussion_r3841169759): the per-turn subset reported in `detail["turns"]` was built as a bare dict literal inside `_conversation_detail`.

`TurnResult` already owns every field being reported, so the subset is now derived from the model rather than restated:

```python
def detail(self) -> dict:
    return self.model_dump(include=self._DETAIL_FIELDS)
```

`_conversation_detail` becomes `"turns": [tr.detail() for tr in result.turn_results]`. Output shape and the `detail: dict` contract are unchanged.

Two properties come from doing it this way rather than with a hand-written key list:

- A renamed field can't leave `detail()` emitting a stale key silently — `include=` raises on a name the model doesn't have, and a test asserts `_DETAIL_FIELDS` is a subset of `model_fields`.
- `model_dump` deep-copies `activated_skills`, so a caller mutating the returned dict can't reach back into the `TurnResult` ([CodeRabbit finding](https://github.com/gooddata/gooddata-python-sdk/pull/1757#discussion_r3851187704)) — no explicit `list()` wrapper needed.

Verified: 465 passed, including the existing exact-dict assertions on `outcome.detail["turns"]`, unchanged. `ruff check` / `format --check` clean.

**Revision history, since the earlier title/body described something else:** the first attempt added a separate `TurnDetail` dataclass with `asdict()` at the boundary; that was replaced with a method on `TurnResult` per [review](https://github.com/gooddata/gooddata-python-sdk/pull/1757#discussion_r3851037451), and then with `model_dump(include=...)` per the follow-up review — which answers the original "dataclass instead of dict" ask better than either, since the subset is now a derived view of the model instead of a second hand-maintained copy of its field names.

**Ordering note:** #1762 changes what `skill_routing` means relative to `activated_skills`, and this method is what serializes both. #1762 resolves the resulting `{"skill_routing": true, "activated_skills": []}` shape by adding an `active_skills` field carrying the set the credit was drawn from. Whichever lands second should carry that through — if this one lands first, #1762's `TurnResult` change will come back through `_DETAIL_FIELDS`.
