### PR TITLE
feat(gooddata-eval): register knowledge_question evaluator

### DIFF
--- a/packages/gooddata-eval/src/gooddata_eval/core/evaluators/__init__.py
+++ b/packages/gooddata-eval/src/gooddata_eval/core/evaluators/__init__.py
@@ -20,18 +20,26 @@ _EAGER_EVALUATORS: dict[str, Evaluator] = {
     )
 }
 
-# LLM-judge evaluators (general_question, guardrail, dashboard_summary) require the
-# [llm-judge] extra. Their modules are imported lazily on first use so the CLI
+# LLM-judge evaluators (general_question, guardrail, dashboard_summary, knowledge_question)
+# require the [llm-judge] extra. Their modules are imported lazily on first use so the CLI
 # starts without openai.
+#
+# knowledge_question reuses GeneralQuestionEvaluator directly: both are free-text-rubric,
+# LLM-judged prose answers -- knowledge_question just covers platform/product/policy facts
+# instead of LDM-grounded ones. `ItemReport.test_kind` is tagged from the dataset item's own
+# `test_kind` field (see runner.py), not from the evaluator class, so sharing one class
+# across both kinds does not mislabel results.
 _LAZY_EVALUATOR_MODULES: dict[str, str] = {
     "general_question": "gooddata_eval.core.evaluators.general_question",
     "guardrail": "gooddata_eval.core.evaluators.guardrail",
     "dashboard_summary": "gooddata_eval.core.evaluators.summary",
+    "knowledge_question": "gooddata_eval.core.evaluators.general_question",
 }
 _LAZY_EVALUATOR_CLASSES: dict[str, str] = {
     "general_question": "GeneralQuestionEvaluator",
     "guardrail": "GuardrailEvaluator",
     "dashboard_summary": "DashboardSummaryEvaluator",
+    "knowledge_question": "GeneralQuestionEvaluator",
 }
 
 

--- a/packages/gooddata-eval/src/gooddata_eval/core/evaluators/__init__.py
+++ b/packages/gooddata-eval/src/gooddata_eval/core/evaluators/__init__.py
@@ -65,9 +65,9 @@ def _openai_available() -> bool:
 def supported_test_kinds() -> set[str]:
     """Return all supported test_kind values.
 
-    LLM-judge kinds (general_question, guardrail) are excluded when the
-    [llm-judge] extra (openai) is not installed — those items are skipped
-    rather than erroring out mid-run.
+    LLM-judge kinds (general_question, guardrail, dashboard_summary,
+    knowledge_question) are excluded when the [llm-judge] extra (openai) is
+    not installed — those items are skipped rather than erroring out mid-run.
     """
     kinds = set(_EAGER_EVALUATORS)
     if _openai_available():

--- a/packages/gooddata-eval/src/gooddata_eval/core/evaluators/general_question.py
+++ b/packages/gooddata-eval/src/gooddata_eval/core/evaluators/general_question.py
@@ -15,6 +15,10 @@ _EVALUATION_STEPS = [
 
 
 class GeneralQuestionEvaluator:
+    # Also registered under "knowledge_question" (core/evaluators/__init__.py) -- this
+    # attribute is unused by that registration (which keys off item.test_kind, not this
+    # class attribute, see the comment there), so it's harmless as-is, but don't derive
+    # an output label from it without accounting for the second kind it now backs.
     test_kind = "general_question"
 
     def __init__(self):

--- a/packages/gooddata-eval/tests/test_runner.py
+++ b/packages/gooddata-eval/tests/test_runner.py
@@ -122,6 +122,7 @@ def test_run_items_routes_all_supported_kinds():
         "general_question",
         "guardrail",
         "dashboard_summary",
+        "knowledge_question",
     }
     assert expected_kinds == supported_test_kinds()
 

--- a/packages/gooddata-eval/tests/test_text_evaluators.py
+++ b/packages/gooddata-eval/tests/test_text_evaluators.py
@@ -1,6 +1,7 @@
 # (C) 2026 GoodData Corporation
 from unittest.mock import MagicMock, patch
 
+from gooddata_eval.core.evaluators import get_evaluator
 from gooddata_eval.core.evaluators._llm_judge import JudgeResponseError
 from gooddata_eval.core.evaluators.general_question import GeneralQuestionEvaluator
 from gooddata_eval.core.evaluators.guardrail import GuardrailEvaluator
@@ -14,6 +15,16 @@ def _gq_item() -> DatasetItem:
         test_kind="general_question",
         question="How do I share a dashboard?",
         expected_output="A correct answer explains clicking Share and adding recipients.",
+    )
+
+
+def _kq_item() -> DatasetItem:
+    return DatasetItem(
+        id="kq-001",
+        dataset_name="d",
+        test_kind="knowledge_question",
+        question="How can I get access to more ICAs?",
+        expected_output="Must explain the process for requesting additional ICAs, e.g. contacting an account manager.",
     )
 
 
@@ -57,6 +68,23 @@ def test_general_question_passes_when_judge_scores_1():
 def test_general_question_fails_when_judge_scores_0():
     with patch("gooddata_eval.core.evaluators.general_question.LLMJudge", return_value=_make_judge(False)):
         result = GeneralQuestionEvaluator().evaluate(_gq_item(), _chat_text("I don't know."))
+    assert result.passed is False
+
+
+def test_knowledge_question_dispatches_to_general_question_evaluator():
+    with patch("gooddata_eval.core.evaluators.general_question.LLMJudge", return_value=_make_judge(True)):
+        assert isinstance(get_evaluator("knowledge_question"), GeneralQuestionEvaluator)
+
+
+def test_knowledge_question_passes_when_judge_scores_1():
+    with patch("gooddata_eval.core.evaluators.general_question.LLMJudge", return_value=_make_judge(True)):
+        result = GeneralQuestionEvaluator().evaluate(_kq_item(), _chat_text("Contact your account manager."))
+    assert result.passed is True
+
+
+def test_knowledge_question_fails_when_judge_scores_0():
+    with patch("gooddata_eval.core.evaluators.general_question.LLMJudge", return_value=_make_judge(False)):
+        result = GeneralQuestionEvaluator().evaluate(_kq_item(), _chat_text("I don't know."))
     assert result.passed is False
 
 


### PR DESCRIPTION
## Summary
- `knowledge_question` fixtures were reclassified out of `general_question` (platform/product/policy Q&A that isn't LDM-grounded) but no evaluator was ever registered for the kind, so `get_evaluator("knowledge_question")` raised `KeyError` and every item was silently `skipped` — the downstream repo has kept `knowledge_question: false` in its test-kind config as a result.
- Registers `knowledge_question` in the lazy-evaluator registry, reusing `GeneralQuestionEvaluator` directly rather than adding a new class: both are free-text-rubric, LLM-judged prose answers, differing only in subject matter (LDM facts vs. platform/policy facts).
- `ItemReport.test_kind` is tagged from the dataset item's own `test_kind` field (`runner.py`), not from the evaluator class's `test_kind` attribute, so sharing one evaluator class across both kinds does not mislabel results in reports/dashboards.

## Review follow-ups
Two of @hkad98's three nits are addressed:
- `GeneralQuestionEvaluator.test_kind` is now inaccurate for half its registrations — added a pointer to the registry comment explaining why it's harmless, so nothing derives an output label from it unaware.
- `supported_test_kinds()`'s docstring listed only `(general_question, guardrail)`; now lists all four LLM-judge kinds.

The third (no `agentic_knowledge_question` dispatch branch, so the kind is single-turn only) is left as scope per the review — likely its own follow-up.

## Test plan
- [x] `uv run pytest packages/gooddata-eval/tests/` — 702 passed (rebased onto #1771, which grew the suite)
- [x] New coverage: `get_evaluator("knowledge_question")` resolves to `GeneralQuestionEvaluator`; pass/fail dispatch through the reused evaluator (`test_text_evaluators.py`)
- [x] Updated `test_run_items_routes_all_supported_kinds`'s exact-set assertion to include `knowledge_question`
- [x] `ruff check` / `ruff format --check` clean

## Rebase note
Rebased onto `45892f79` after #1771 landed and put this into conflict. The only clash was an import collision in `test_text_evaluators.py` (#1771 added `JudgeResponseError`, this PR added `get_evaluator`) — both kept, nothing semantic.
