### PR TITLE
ci: enforce make lint and fix the three violations it was hiding

### DIFF
--- a/.github/workflows/rw-python-tests.yaml
+++ b/.github/workflows/rw-python-tests.yaml
@@ -44,6 +44,9 @@ jobs:
       - name: pep8 and formatting check
         run: |
           make format
+      - name: lint check
+        run: |
+          make lint
   docs-scripts-tests:
     runs-on: ubuntu-latest
     if: ${{inputs.changed-python-modules == 'true'}}

--- a/packages/gooddata-eval/src/gooddata_eval/core/chat/sse_client.py
+++ b/packages/gooddata-eval/src/gooddata_eval/core/chat/sse_client.py
@@ -89,13 +89,11 @@ def _is_retryable_exc(exc: Exception) -> bool:
         return True
     if isinstance(exc, httpx.HTTPStatusError):
         return exc.response.status_code in _RETRYABLE_STATUS_CODES
-    if isinstance(exc, httpx.RemoteProtocolError):
-        # Mid-stream disconnect ("peer closed connection without sending complete
-        # message body") -- pure network flake, not a real agent/content failure.
-        # Confirmed live: contaminated ~1-4% of visualization runs with a hard
-        # fail and zero retry attempts.
-        return True
-    return False
+    # Mid-stream disconnect ("peer closed connection without sending complete
+    # message body") -- pure network flake, not a real agent/content failure.
+    # Confirmed live: contaminated ~1-4% of visualization runs with a hard
+    # fail and zero retry attempts.
+    return isinstance(exc, httpx.RemoteProtocolError)
 
 
 def _retry_transient(operation: Callable[[], T], *, is_retryable: Callable[[Exception], bool]) -> T:

--- a/packages/gooddata-eval/tests/test_agentic_runner.py
+++ b/packages/gooddata-eval/tests/test_agentic_runner.py
@@ -3,7 +3,7 @@
 from unittest.mock import patch
 
 import pytest
-from gooddata_eval.cli.agentic_runner import _dispatch_agentic, run_agentic_items
+from gooddata_eval.cli.agentic_runner import AGENTIC_TEST_KINDS, _dispatch_agentic, run_agentic_items
 from gooddata_eval.core.agentic.alert_skill import AlertSkillAssertionError
 from gooddata_eval.core.models import AgenticEvalOutcome, DatasetItem
 
@@ -81,8 +81,6 @@ def test_all_agentic_kind_cases_covers_every_registered_kind():
     """Guards the two parametrized tests below against silently going stale: a kind added
     to AGENTIC_TEST_KINDS without a matching case here would otherwise just not get tested,
     not fail loudly."""
-    from gooddata_eval.cli.agentic_runner import AGENTIC_TEST_KINDS
-
     covered = {kind for kind, _, _ in _ALL_AGENTIC_KIND_CASES}
     assert covered == set(AGENTIC_TEST_KINDS)
 
@@ -194,8 +192,6 @@ def test_dispatch_agentic_returns_a_real_outcome_for_every_kind(kind, expected_o
     evaluator produced -- not None, not the outcome's reasoning_steps list alone, not any
     other bare value the old `isinstance(outcome, tuple)`/`isinstance(outcome, AgenticEvalOutcome)`
     fallback could silently swallow."""
-    from gooddata_eval.core.models import AgenticEvalOutcome
-
     item = DatasetItem(
         id="q1",
         dataset_name="ds",


### PR DESCRIPTION
The job named `lint-and-format-check` (`rw-python-tests.yaml`) only ever ran `make format`. Ruff's **linter** was therefore never enforced in CI — only by pre-commit, which runs on changed files. Three violations reached master as a result, and `make lint` fails on a clean checkout of master today:

```
SIM103   packages/gooddata-eval/src/gooddata_eval/core/chat/sse_client.py:92   Return the condition directly
PLC0415  packages/gooddata-eval/tests/test_agentic_runner.py:84                import should be at top-level
PLC0415  packages/gooddata-eval/tests/test_agentic_runner.py:197               import should be at top-level
```

This fixes all three, then adds the missing step so the job does what its name says.

## The fixes

**`SIM103`** — `_is_retryable_exc` ended with an `if isinstance(...): return True` / `return False` pair. Collapsed to returning the `isinstance` directly. The comment explaining *why* `RemoteProtocolError` is retryable is preserved verbatim, moved above the return.

**`PLC0415` ×2** — both function-level imports named symbols **already imported at module top**: `AgenticEvalOutcome` identically (`from gooddata_eval.core.models import AgenticEvalOutcome, DatasetItem`), and `AGENTIC_TEST_KINDS` from `gooddata_eval.cli.agentic_runner`, a module the file already imports from. So these were redundant, not deliberate deferrals for a cycle or an expensive import. Removed, with `AGENTIC_TEST_KINDS` added to the existing top-level import.

No behaviour change: the `isinstance` chain returns the same value for every input, and the moved imports resolve to the same objects.

## Verification

| Check | Result |
|---|---|
| `make lint` | **All checks passed** — first time on a clean checkout |
| `make format` | 569 files, clean |
| `make test` — gooddata-eval, py314, full suite | 473 passed |
| `make test` — gooddata-eval, `-k 'agentic_runner or sse'` | 111 passed, 362 deselected |
| CI job simulated exactly (`rm -rf .venv && uv sync --only-group lint --locked` → `make format` → `make lint`) | 1 package installed (ruff 0.15.20), both clean |

The last row matters: the job installs only the `lint` group, and `make lint` invokes `.venv/bin/ruff` directly, so no extra dependency is needed for the new step.

## Note

I deliberately targeted the two tests whose imports moved — the `AGENTIC_TEST_KINDS` one is a staleness guard asserting the parametrized case list covers every registered kind, so it would fail loudly if the import change had broken its resolution. It passes.

Related: #1768 (uv workspace hardening) is independent — no overlapping files — and among other things makes a bare `uv sync` actually install ruff, so `make lint` works locally without `--all-groups`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test setup and coverage checks for agentic evaluation scenarios.
* **Chores**
  * Linting now runs as part of the automated formatting verification.
* **Refactor**
  * Simplified internal retryability handling without changing retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->