### PR TITLE
feat(gooddata-api-client): add the CREATE_METRIC workspace permission

### DIFF
--- a/gooddata-api-client/gooddata_api_client/model/declarative_single_workspace_permission.py
+++ b/gooddata-api-client/gooddata_api_client/model/declarative_single_workspace_permission.py
@@ -71,6 +71,7 @@ class DeclarativeSingleWorkspacePermission(ModelNormal):
             'WRITE_KNOWLEDGE_DOCUMENTS': "WRITE_KNOWLEDGE_DOCUMENTS",
             'READ_KNOWLEDGE_DOCUMENTS': "READ_KNOWLEDGE_DOCUMENTS",
             'CREATE_FILTER_VIEW': "CREATE_FILTER_VIEW",
+            'CREATE_METRIC': "CREATE_METRIC",
             'VIEW': "VIEW",
         },
     }

--- a/gooddata-api-client/gooddata_api_client/model/declarative_workspace_hierarchy_permission.py
+++ b/gooddata-api-client/gooddata_api_client/model/declarative_workspace_hierarchy_permission.py
@@ -71,6 +71,7 @@ class DeclarativeWorkspaceHierarchyPermission(ModelNormal):
             'WRITE_KNOWLEDGE_DOCUMENTS': "WRITE_KNOWLEDGE_DOCUMENTS",
             'READ_KNOWLEDGE_DOCUMENTS': "READ_KNOWLEDGE_DOCUMENTS",
             'CREATE_FILTER_VIEW': "CREATE_FILTER_VIEW",
+            'CREATE_METRIC': "CREATE_METRIC",
             'VIEW': "VIEW",
         },
     }

--- a/gooddata-api-client/gooddata_api_client/model/json_api_workspace_out_meta.py
+++ b/gooddata-api-client/gooddata_api_client/model/json_api_workspace_out_meta.py
@@ -75,6 +75,7 @@ class JsonApiWorkspaceOutMeta(ModelNormal):
             'WRITE_KNOWLEDGE_DOCUMENTS': "WRITE_KNOWLEDGE_DOCUMENTS",
             'READ_KNOWLEDGE_DOCUMENTS': "READ_KNOWLEDGE_DOCUMENTS",
             'CREATE_FILTER_VIEW': "CREATE_FILTER_VIEW",
+            'CREATE_METRIC': "CREATE_METRIC",
             'VIEW': "VIEW",
         },
     }

--- a/gooddata-api-client/gooddata_api_client/model/user_management_workspace_permission_assignment.py
+++ b/gooddata-api-client/gooddata_api_client/model/user_management_workspace_permission_assignment.py
@@ -67,6 +67,7 @@ class UserManagementWorkspacePermissionAssignment(ModelNormal):
             'WRITE_KNOWLEDGE_DOCUMENTS': "WRITE_KNOWLEDGE_DOCUMENTS",
             'READ_KNOWLEDGE_DOCUMENTS': "READ_KNOWLEDGE_DOCUMENTS",
             'CREATE_FILTER_VIEW': "CREATE_FILTER_VIEW",
+            'CREATE_METRIC': "CREATE_METRIC",
             'VIEW': "VIEW",
         },
         ('permissions',): {
@@ -80,6 +81,7 @@ class UserManagementWorkspacePermissionAssignment(ModelNormal):
             'WRITE_KNOWLEDGE_DOCUMENTS': "WRITE_KNOWLEDGE_DOCUMENTS",
             'READ_KNOWLEDGE_DOCUMENTS': "READ_KNOWLEDGE_DOCUMENTS",
             'CREATE_FILTER_VIEW': "CREATE_FILTER_VIEW",
+            'CREATE_METRIC': "CREATE_METRIC",
             'VIEW': "VIEW",
         },
         ('access_source',): {

--- a/gooddata-api-client/gooddata_api_client/model/workspace_permission_assignment.py
+++ b/gooddata-api-client/gooddata_api_client/model/workspace_permission_assignment.py
@@ -71,6 +71,7 @@ class WorkspacePermissionAssignment(ModelNormal):
             'WRITE_KNOWLEDGE_DOCUMENTS': "WRITE_KNOWLEDGE_DOCUMENTS",
             'READ_KNOWLEDGE_DOCUMENTS': "READ_KNOWLEDGE_DOCUMENTS",
             'CREATE_FILTER_VIEW': "CREATE_FILTER_VIEW",
+            'CREATE_METRIC': "CREATE_METRIC",
             'VIEW': "VIEW",
         },
         ('permissions',): {
@@ -84,6 +85,7 @@ class WorkspacePermissionAssignment(ModelNormal):
             'WRITE_KNOWLEDGE_DOCUMENTS': "WRITE_KNOWLEDGE_DOCUMENTS",
             'READ_KNOWLEDGE_DOCUMENTS': "READ_KNOWLEDGE_DOCUMENTS",
             'CREATE_FILTER_VIEW': "CREATE_FILTER_VIEW",
+            'CREATE_METRIC': "CREATE_METRIC",
             'VIEW': "VIEW",
         },
     }

--- a/schemas/gooddata-api-client.json
+++ b/schemas/gooddata-api-client.json
@@ -8517,6 +8517,7 @@
               "WRITE_KNOWLEDGE_DOCUMENTS",
               "READ_KNOWLEDGE_DOCUMENTS",
               "CREATE_FILTER_VIEW",
+              "CREATE_METRIC",
               "VIEW"
             ],
             "type": "string"
@@ -9432,6 +9433,7 @@
               "WRITE_KNOWLEDGE_DOCUMENTS",
               "READ_KNOWLEDGE_DOCUMENTS",
               "CREATE_FILTER_VIEW",
+              "CREATE_METRIC",
               "VIEW"
             ],
             "type": "string"
@@ -31162,6 +31164,7 @@
                     "WRITE_KNOWLEDGE_DOCUMENTS",
                     "READ_KNOWLEDGE_DOCUMENTS",
                     "CREATE_FILTER_VIEW",
+                    "CREATE_METRIC",
                     "VIEW"
                   ],
                   "type": "string"
@@ -38394,6 +38397,7 @@
                 "WRITE_KNOWLEDGE_DOCUMENTS",
                 "READ_KNOWLEDGE_DOCUMENTS",
                 "CREATE_FILTER_VIEW",
+                "CREATE_METRIC",
                 "VIEW"
               ],
               "type": "string"
@@ -38420,6 +38424,7 @@
                 "WRITE_KNOWLEDGE_DOCUMENTS",
                 "READ_KNOWLEDGE_DOCUMENTS",
                 "CREATE_FILTER_VIEW",
+                "CREATE_METRIC",
                 "VIEW"
               ],
               "type": "string"
@@ -39297,6 +39302,7 @@
                 "WRITE_KNOWLEDGE_DOCUMENTS",
                 "READ_KNOWLEDGE_DOCUMENTS",
                 "CREATE_FILTER_VIEW",
+                "CREATE_METRIC",
                 "VIEW"
               ],
               "type": "string"
@@ -39316,6 +39322,7 @@
                 "WRITE_KNOWLEDGE_DOCUMENTS",
                 "READ_KNOWLEDGE_DOCUMENTS",
                 "CREATE_FILTER_VIEW",
+                "CREATE_METRIC",
                 "VIEW"
               ],
               "type": "string"
@@ -64744,9 +64751,9 @@
           "metric-controller"
         ],
         "x-gdc-security-info": {
-          "description": "Contains minimal permission level required to manage this object type.",
+          "description": "Contains minimal permission level required to create Metrics",
           "permissions": [
-            "MANAGE"
+            "CREATE_METRIC"
           ]
         }
       }

--- a/schemas/gooddata-metadata-client.json
+++ b/schemas/gooddata-metadata-client.json
@@ -5990,6 +5990,7 @@
               "WRITE_KNOWLEDGE_DOCUMENTS",
               "READ_KNOWLEDGE_DOCUMENTS",
               "CREATE_FILTER_VIEW",
+              "CREATE_METRIC",
               "VIEW"
             ],
             "type": "string"
@@ -6889,6 +6890,7 @@
               "WRITE_KNOWLEDGE_DOCUMENTS",
               "READ_KNOWLEDGE_DOCUMENTS",
               "CREATE_FILTER_VIEW",
+              "CREATE_METRIC",
               "VIEW"
             ],
             "type": "string"
@@ -26792,6 +26794,7 @@
                     "WRITE_KNOWLEDGE_DOCUMENTS",
                     "READ_KNOWLEDGE_DOCUMENTS",
                     "CREATE_FILTER_VIEW",
+                    "CREATE_METRIC",
                     "VIEW"
                   ],
                   "type": "string"
@@ -30832,6 +30835,7 @@
                 "WRITE_KNOWLEDGE_DOCUMENTS",
                 "READ_KNOWLEDGE_DOCUMENTS",
                 "CREATE_FILTER_VIEW",
+                "CREATE_METRIC",
                 "VIEW"
               ],
               "type": "string"
@@ -30858,6 +30862,7 @@
                 "WRITE_KNOWLEDGE_DOCUMENTS",
                 "READ_KNOWLEDGE_DOCUMENTS",
                 "CREATE_FILTER_VIEW",
+                "CREATE_METRIC",
                 "VIEW"
               ],
               "type": "string"
@@ -31201,6 +31206,7 @@
                 "WRITE_KNOWLEDGE_DOCUMENTS",
                 "READ_KNOWLEDGE_DOCUMENTS",
                 "CREATE_FILTER_VIEW",
+                "CREATE_METRIC",
                 "VIEW"
               ],
               "type": "string"
@@ -31220,6 +31226,7 @@
                 "WRITE_KNOWLEDGE_DOCUMENTS",
                 "READ_KNOWLEDGE_DOCUMENTS",
                 "CREATE_FILTER_VIEW",
+                "CREATE_METRIC",
                 "VIEW"
               ],
               "type": "string"
@@ -50948,9 +50955,9 @@
           "metric-controller"
         ],
         "x-gdc-security-info": {
-          "description": "Contains minimal permission level required to manage this object type.",
+          "description": "Contains minimal permission level required to create Metrics",
           "permissions": [
-            "MANAGE"
+            "CREATE_METRIC"
           ]
         }
       }


### PR DESCRIPTION
## Summary

`CREATE_METRIC` landed in the backend under F1-2785 — it was added to the permission
hierarchy and `POST /api/v1/entities/workspaces/{workspaceId}/metrics` now requires it
instead of `MANAGE`. The specs this client generates from still predate that, so assigning
the level through the SDK fails client-side validation.

- `schemas/gooddata-metadata-client.json` — adds `CREATE_METRIC` (after `CREATE_FILTER_VIEW`,
  matching the backend ordering) to all seven workspace-permission enums:
  `DeclarativeSingleWorkspacePermission`, `DeclarativeWorkspaceHierarchyPermission`,
  workspace `meta.permissions`, and the `permissions` / `hierarchyPermissions` arrays of
  `UserManagementWorkspacePermissionAssignment` and `WorkspacePermissionAssignment`. Also
  syncs the metrics `POST` `x-gdc-security-info` to `CREATE_METRIC`.
- `schemas/gooddata-api-client.json` plus five generated model files — the result of
  `make api-client-local`.

The spec edit is targeted rather than a `make api-client STAGING=1` re-download, which would
bury this change under every unrelated upstream drift accumulated since the last sync. The
merge step was verified deterministic first: re-merging the committed per-API specs
reproduced `gooddata-api-client.json` byte-for-byte, so the only spec delta is this one.

## Test Plan

- `make api-client-local` — regenerated cleanly; diff is 25 added lines, all additive enum
  entries, no model shape change, so nothing in `packages/` needs adapting.
- The five regenerated modules compile (`python -m py_compile`).
- `make test` was **not** run: `uv` here is a pyenv shim and the repo's `.python-version` pins
  3.14.0, which is not installed locally. CI is the gate for that.
- The generated client is excluded from lint / format / type-check per `AGENTS.md`.

## JIRA

https://gooddata.atlassian.net/browse/F1-2785

## Risk

low — additive enum values only. Existing values keep their meaning, and the backend already
accepts `CREATE_METRIC`; this only stops the client from rejecting it before the request is
sent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `CREATE_METRIC` permission for workspace and hierarchy permission assignments.
  - Metric creation now has a dedicated permission requirement, allowing access to be granted independently from broader management permissions.
  - Updated API schemas and metadata to recognize and document the new permission across supported workspace permission models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->